### PR TITLE
elements_from_json tip for the source connectors docs

### DIFF
--- a/open-source/ingest/source-connectors/overview.mdx
+++ b/open-source/ingest/source-connectors/overview.mdx
@@ -1,4 +1,15 @@
 ---
 title: Source Connectors
-description: Connect to your favorite data storage platforms for effortless batch processing of your files. We are constantly adding new data connectors and if you don’table see your favorite platform let us know in our community Slack.
+description: Connect to your favorite data storage platforms for effortless batch processing of your files. We are constantly adding new data connectors and if you don’t see your favorite platform let us know in our community Slack.
 ---
+
+When ingesting data from a storage via a source connector, you typically store the resulting `*.json` files in a
+specified output directory.
+
+To "rehydrate" elements in JSON form into in-memory objects to further use in your application, use `elements_from_json`:
+
+```python
+from unstructured.staging.base import elements_from_json
+
+elements = elements_from_json(filename=path_to_json_file)
+```

--- a/open-source/ingest/source-connectors/wikipedia.mdx
+++ b/open-source/ingest/source-connectors/wikipedia.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wikipedia
-description: Connect Airtable to your preprocessing pipeline, and batch process all your documents using `unstructured-ingest` to store structured outputs locally on your filesystem.
+description: Connect Wikipedia to your preprocessing pipeline, and batch process all your documents using `unstructured-ingest` to store structured outputs locally on your filesystem.
 ---
 
 First you’ll need to install the Wikipedia dependencies as shown here.


### PR DESCRIPTION
The PR adds a mention on how to proceed with the *.json files generated as a result of ingesting data from a source connector. 
Also, fixes a typo. 