### PR TITLE
Update overview.mdx with correct embedding section url

### DIFF
--- a/open-source/introduction/overview.mdx
+++ b/open-source/introduction/overview.mdx
@@ -43,7 +43,7 @@ and use cases.
         
     *   [Chunking](/open-source/core-functionality/chunking): The chunking process in Unstructured is distinct from conventional methods. Instead of relying solely on text-based features to form chunks, Unstructured uses a deep understanding of document formats to partition documents into semantic units (document elements).
         
-    *   [Embedding](/open-source/core-functionality/chunking): The embedding encoder classes in Unstructured leverage document elements detected through partitioning or grouped via chunking to obtain embeddings for each element. This is particularly useful for applications like Retrieval Augmented Generation (RAG), where precise and contextually relevant embeddings are crucial.
+    *   [Embedding](/open-source/core-functionality/embedding): The embedding encoder classes in Unstructured leverage document elements detected through partitioning or grouped via chunking to obtain embeddings for each element. This is particularly useful for applications like Retrieval Augmented Generation (RAG), where precise and contextually relevant embeddings are crucial.
         
 *   **High-performant Connectors**: The platform includes optimized connectors for efficient data ingestion and output. These comprise [Source Connectors](/ingest/destination-connectors/overview) for data input and [Destination Connectors](/ingest/destination-connectors/overview) for data export.
     


### PR DESCRIPTION
updating a URL but seems like an earlier change wasn't merged and this is re-adding at the bottom:
* Traditional ETL