### PR TITLE
Replaced file path in quick start API guides with a placeholder PATH_TO_FILE

### DIFF
--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -36,15 +36,14 @@ you can do this, which all lead to the same result, so pick your preferred metho
 
 ### POST request
 
-Supply your API key, and the file to preprocess:
+Supply your API key, and the file to preprocess, the URL is the same for all free Unstructured API users:
 
 ```bash
-# The URL is the same for all free Unstructured API users
 curl -X 'POST' 'https://api.unstructured.io/general/v0/general' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -H 'unstructured-api-key: YOUR_API_KEY' \
-     -F 'files=@sample-docs/family-day.eml'
+     -F 'files=PATH_TO_FILE'
 ```
 
 The result will look something like this:
@@ -78,7 +77,7 @@ from unstructured_client.models import shared
 from unstructured_client.models.errors import SDKError
 
 client = UnstructuredClient(api_key_auth="YOUR_API_KEY")
-filename = "sample-docs/family-day.eml"
+filename = "PATH_TO_FILE"
 
 with open(filename, "rb") as f:
     files=shared.Files(
@@ -107,7 +106,7 @@ const client = new UnstructuredClient({
     },
 });
 
-const filename = "sample-docs/family-day.eml";
+const filename = "PATH_TO_FILE";
 const data = fs.readFileSync(filename);
 
 client.general.partition({
@@ -133,7 +132,7 @@ Finally, you can call the Unstructured API directly from the Unstructured open s
 ```python
 from unstructured.partition.api import partition_via_api
 
-filename = "sample-docs/family-day.eml"
+filename = "PATH_TO_FILE"
 
 elements = partition_via_api(
   filename=filename,

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -43,7 +43,7 @@ curl -X 'POST' 'https://api.unstructured.io/general/v0/general' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -H 'unstructured-api-key: YOUR_API_KEY' \
-     -F 'files=PATH_TO_FILE'
+     -F 'files=@PATH_TO_FILE'
 ```
 
 The result will look something like this:

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -45,13 +45,11 @@ Supply your API key, and the file to preprocess. Make sure to copy the complete 
 your email, i.e. this URL should include the specific path `/general/v0/general`:
 
 ```bash
-# Make sure to replace the placeholders with the actual URL and API key from your email
-# Include the path `/general/v0/general` in the URL.
 curl -X 'POST' 'https://YOUR_API_URL' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -H 'unstructured-api-key: YOUR_API_KEY' \
-     -F 'files=@sample-docs/family-day.eml'
+     -F 'files=PATH_TO_FILE'
 ```
 
 The result will look something like this:
@@ -92,7 +90,7 @@ client = UnstructuredClient(
     server_url="YOUR_API_URL",
 )
 
-filename = "sample-docs/family-day.eml"
+filename = "PATH_TO_FILE"
 
 with open(filename, "rb") as f:
     files=shared.Files(
@@ -122,7 +120,7 @@ const client = new UnstructuredClient({
     },
 });
 
-const filename = "sample-docs/family-day.eml";
+const filename = "PATH_TO_FILE";
 const data = fs.readFileSync(filename);
 
 client.general.partition({
@@ -149,7 +147,7 @@ Finally, you can call the SaaS Unstructured API directly from the Unstructured o
 ```python
 from unstructured.partition.api import partition_via_api
 
-filename = "sample-docs/family-day.eml"
+filename = "PATH_TO_FILE"
 
 elements = partition_via_api(
   filename=filename,

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -49,7 +49,7 @@ curl -X 'POST' 'https://YOUR_API_URL' \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -H 'unstructured-api-key: YOUR_API_KEY' \
-     -F 'files=PATH_TO_FILE'
+     -F 'files=@PATH_TO_FILE'
 ```
 
 The result will look something like this:


### PR DESCRIPTION
To avoid confusion, the file path in the examples is now a placeholder - PATH_TO_FILE