### PR TITLE
Fixed the Community link leading to Slack

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -32,7 +32,7 @@
       {
         "name": "Community",
         "icon": "slack",
-        "url": "https://unstructuredw-kbe4326.slack.com/signup#/domain-signup"
+        "url": "https://unstructuredw-kbe4326.slack.com/join/shared_invite/zt-205vplvw5-417vkrwKPtqI5wSDPbu5vQ#/shared-invite/email"
       },
       {
         "name": "Product",

--- a/mint.json
+++ b/mint.json
@@ -32,7 +32,7 @@
       {
         "name": "Community",
         "icon": "slack",
-        "url": "https://short.unstructured.io/pzw05l7."
+        "url": "https://short.unstructured.io/pzw05l7"
       },
       {
         "name": "Product",

--- a/mint.json
+++ b/mint.json
@@ -32,7 +32,7 @@
       {
         "name": "Community",
         "icon": "slack",
-        "url": "https://unstructuredw-kbe4326.slack.com/join/shared_invite/zt-205vplvw5-417vkrwKPtqI5wSDPbu5vQ#/shared-invite/email"
+        "url": "https://short.unstructured.io/pzw05l7."
       },
       {
         "name": "Product",


### PR DESCRIPTION
The link was requiring @unstructured.io email. Replaced with the Slack link from the website 