### PR TITLE
Added by_page and by_similarity chunking strategies to the docs

### DIFF
--- a/api-reference/api-services/chunking.mdx
+++ b/api-reference/api-services/chunking.mdx
@@ -1,0 +1,48 @@
+---
+title: Chunking strategies
+---
+
+Chunking functions use metadata and document elements detected with partition functions to split a document into
+appropriately-sized chunks for uses cases such as Retrieval Augmented Generation (RAG).
+
+If you are familiar with chunking methods that split long text documents into smaller chunks, you'll notice that
+Unstructured methods slightly differ, since the partitioning step already divides an entire document into its structural elements.
+
+Individual elements will only be split if they exceed the desired maximum chunk size. However, you have an option to
+combine small elements into a larger chunk without exceeding the maximum chunk size where it makes sense (based on the
+chosen chunking strategy). A chunk that is a result of combining elements will have a `CompositeElement` type. A table
+element is not combined with other elements, but if table element exceeds the maximum chunk size, it will be split into
+`TableChunk` elements.
+
+The way small elements will be combined into a larger chunk is controlled by choosing a chunking strategy.
+
+import SharedChunkingStrategies from '/snippets/concepts/chunking-strategies.mdx';
+
+<SharedChunkingStrategies/>
+
+### "by_page" chunking strategy
+
+Only available in Unstructured API and Platform.
+
+The `by_page` chunking strategy ensures the content from different pages do not end up in the same chunk.
+A single chunk will never contain text that occurred in two different pages. When a new page is detected, the
+existing chunk is completed and a new one is started, even if the next element would fit in the
+prior chunk.
+
+### "by_similarity" chunking strategy
+
+Only available in Unstructured API and Platform.
+
+The `by_similarity` chunking strategy employs embedding models to identify topically similar sequential elements and
+combine them into chunks. As with other strategies, chunks will never exceed the hard-maximum chunk size set by
+`max_characters`. For this reason, not all elements that share a topic will necessarily appear in the same chunk.
+However, with this strategy you can guarantee that two elements with low similarity will not be combined in a single chunk.
+
+Parameters specific to `by_similarity` chunking strategy:
+
+* `embedding_model`: By default, the `sentence-transformers/multi-qa-mpnet-base-dot-v1` embedding model is used to
+calculate similarity between sequential elements. At this moment, it is also the only supported embedding model for this
+chunking strategy. In the future, you will be able to specify an embedding model from the Hugging Face Hub to use here.
+
+* `similarity_threshold`: A value between 0.0 and 1.0 specifying the minimum similarity text in consecutive elements
+must have to be included in the same chunk. The default is 0.5.

--- a/mint.json
+++ b/mint.json
@@ -312,7 +312,8 @@
         "group": "Concepts",
         "pages": [
           "api-reference/api-services/document-elements",
-          "api-reference/api-services/partitioning"
+          "api-reference/api-services/partitioning",
+          "api-reference/api-services/chunking"
         ]
       },
 

--- a/open-source/core-functionality/chunking.mdx
+++ b/open-source/core-functionality/chunking.mdx
@@ -1,5 +1,5 @@
 ---
-ttile: Chunking 
+title: Chunking
 description: Chunking functions in `unstructured` use metadata and document elements detected with `partition` functions to split a document into smaller parts for uses cases such as Retrieval Augmented Generation (RAG).
 ---
 
@@ -79,31 +79,9 @@ for chunk in chunks:
 
 There are currently two chunking strategies, _basic_ and _by\_title_. The `by_title` strategy shares most behaviors with the basic strategy so we’ll describe the baseline strategy first:
 
-### “basic” chunking strategy
+import SharedChunkingStrategies from '/snippets/concepts/chunking-strategies.mdx';
 
-*   The basic strategy combines sequential elements to maximally fill each chunk while respecting both the specified `max_characters` (hard-max) and `new_after_n_chars` (soft-max) option values.
-    
-*   A single element that by itself exceeds the hard-max is isolated (never combined with another element) and then divided into two or more chunks using text-splitting.
-    
-*   A `Table` element is always isolated and never combined with another element. A `Table` can be oversized, like any other text element, and in that case is divided into two or more `TableChunk` elements using text-splitting.
-    
-*   If specified, `overlap` is applied between split-chunks and is also applied between normal chunks when `overlap_all` is `True`.
-    
-
-### “by\_title” chunking strategy
-
-The `by_title` chunking strategy preserves section boundaries and optionally page boundaries as well. “Preserving” here means that a single chunk will never contain text that occurred in two different sections. When a new section starts, the existing chunk is closed and a new one started, even if the next element would fit in the prior chunk.
-
-In addition to the behaviors of the `basic` strategy above, the `by_title` strategy has the following behaviors:
-
-*   **Detect section headings.** A `Title` element is considered to start a new section. When a `Title` element is encountered, the prior chunk is closed and a new chunk started, even if the `Title` element would fit in the prior chunk. This implements the first aspect of the “preserve section boundaries” contract.
-    
-*   **Detect metadata.section change.** An element with a new value in `element.metadata.section` is considered to start a new section. When a change in this value is encountered a new chunk is started. This implements the second aspect of preserving section boundaries. This metadata is not present in all document formats so is not used alone. An element having `None` for this metadata field is considered to be part of the prior section; a section break is only detected on an explicit change in value.
-    
-*   **Respect page boundaries.** Page boundaries can optionally also be respected using the `multipage_sections` argument. This defaults to `True` meaning that a page break does _not_ start a new chunk. Setting this to `False` will separate elements that occur on different pages into distinct chunks.
-    
-*   **Combine small sections.** In certain documents, partitioning may identify a list-item or other short paragraph as a `Title` element even though it does not serve as a section heading. This can produce chunks substantially smaller than desired. This behavior can be mitigated using the `combine_text_under_n_chars` argument. This defaults to the same value as `max_characters` such that sequential small sections are combined to maximally fill the chunking window. Setting this to `0` will disable section combining.
-    
+<SharedChunkingStrategies/>
 
 ## Recovering Chunk Elements
 

--- a/snippets/concepts/chunking-strategies.mdx
+++ b/snippets/concepts/chunking-strategies.mdx
@@ -1,0 +1,25 @@
+### "basic" chunking strategy
+
+*   The basic strategy combines sequential elements to maximally fill each chunk while respecting both the specified `max_characters` (hard-max) and `new_after_n_chars` (soft-max) option values.
+
+*   A single element that by itself exceeds the hard-max is isolated (never combined with another element) and then divided into two or more chunks using text-splitting.
+
+*   A `Table` element is always isolated and never combined with another element. A `Table` can be oversized, like any other text element, and in that case is divided into two or more `TableChunk` elements using text-splitting.
+
+*   If specified, `overlap` is applied between split-chunks and is also applied between normal chunks when `overlap_all` is `True`.
+
+
+### "by_title" chunking strategy
+
+The `by_title` chunking strategy preserves section boundaries and optionally page boundaries as well. “Preserving” here means that a single chunk will never contain text that occurred in two different sections. When a new section starts, the existing chunk is closed and a new one started, even if the next element would fit in the prior chunk.
+
+In addition to the behaviors of the `basic` strategy above, the `by_title` strategy has the following behaviors:
+
+*   **Detect section headings.** A `Title` element is considered to start a new section. When a `Title` element is encountered, the prior chunk is closed and a new chunk started, even if the `Title` element would fit in the prior chunk. This implements the first aspect of the “preserve section boundaries” contract.
+
+*   **Detect metadata.section change.** An element with a new value in `element.metadata.section` is considered to start a new section. When a change in this value is encountered a new chunk is started. This implements the second aspect of preserving section boundaries. This metadata is not present in all document formats so is not used alone. An element having `None` for this metadata field is considered to be part of the prior section; a section break is only detected on an explicit change in value.
+
+*   **Respect page boundaries.** Page boundaries can optionally also be respected using the `multipage_sections` argument. This defaults to `True` meaning that a page break does _not_ start a new chunk. Setting this to `False` will separate elements that occur on different pages into distinct chunks.
+
+*   **Combine small sections.** In certain documents, partitioning may identify a list-item or other short paragraph as a `Title` element even though it does not serve as a section heading. This can produce chunks substantially smaller than desired. This behavior can be mitigated using the `combine_text_under_n_chars` argument. This defaults to the same value as `max_characters` such that sequential small sections are combined to maximally fill the chunking window. Setting this to `0` will disable section combining.
+


### PR DESCRIPTION
The description of the API-specific chunking strategies has been missing in the docs. The PR fixes this. 