### PR TITLE
docs: remove chipper oss reference

### DIFF
--- a/open-source/concepts/models.mdx
+++ b/open-source/concepts/models.mdx
@@ -1,5 +1,5 @@
 ---
-title: Models 
+title: Models
 description: Depending on your need, `Unstructured` provides OCR-based and Transformer-based models to detect elements in the documents. The models are useful to detect the complex layout in the documents and predict the element types.
 ---
 
@@ -15,22 +15,20 @@ elements = partition(filename=filename,
 <Note>
 
 *   To use any model with the partition, set the `strategy` to `hi_res` as shown above.
-    
+
 *   To maintain the consistency between the `unstructured` and `unstructured-api` libraries, we are deprecating the `model_name` parameter. Please use `hi_res_model_name` parameter when specifing a model.
-</Note> 
+</Note>
 
 
-  
+
 **List of Available Models in the Partitions:**
 
 *   `detectron2_onnx` is a Computer Vision model by Facebook AI that provides object detection and segmentation algorithms with ONNX Runtime. It is the fastest model with the `hi_res` strategy.
-    
+
 *   `yolox` is a single-stage real-time object detector that modifies YOLOv3 with a DarkNet53 backbone.
-    
+
 *   `yolox_quantized`: runs faster than YoloX and its speed is closer to Detectron2.
-    
-*   `chipper` (beta version): the Chipper model is Unstructured’s in-house image-to-text model based on transformer-based Visual Document Understanding (VDU) models.
-    
+
 
 ## Using a Non-Default Model
 
@@ -39,7 +37,7 @@ elements = partition(filename=filename,
 There are three ways you can use the non-default model as follows:
 
 1.  Store the model name in the environment variable
-    
+
 
 ```python
 import os
@@ -53,7 +51,7 @@ out_yolox = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy=
 
 
 2.  Pass the model name in the `partition` function.
-    
+
 
 ```python
 filename = "example-docs/layout-parser-paper-fast.pdf"
@@ -66,7 +64,7 @@ elements = partition(filename=filename,
 
 
 3.  Use [unstructured-inference](https://github.com/Unstructured-IO/unstructured-inference) library.
-    
+
 
 ```python
 from unstructured_inference.models.base import get_model
@@ -93,8 +91,8 @@ To seamlessly integrate your custom detection and extraction models into `unstru
 Ensure your `UnstructuredObjectDetectionModel` subclass incorporates two vital methods:
 
 1.  The `predict` method, which should be designed to accept a `PIL.Image.Image` type and return a list of `LayoutElements`, facilitating the communication of your model’s results.
-    
+
 2.  The `initialize` method is essential for loading and prepping your model for inference, guaranteeing its readiness for any incoming tasks.
-    
+
 
 It’s important that your model’s outputs, specifically from the predict method, integrate smoothly with the DocumentLayout class for optimal performance.


### PR DESCRIPTION
### Summary

Updates the docs to remove the Chipper reference from the OSS section since Chipper is only supported in the API and Platform.