### PR TITLE
fix: correct use of clean_ordered_bullets function cleaning.mdx

### DIFF
--- a/open-source/core-functionality/cleaning.mdx
+++ b/open-source/core-functionality/cleaning.mdx
@@ -171,10 +171,10 @@ Examples:
 from unstructured.cleaners.core import clean_ordered_bullets
 
 # Returns "This is a very important point"
-clean_bullets("1.1 This is a very important point")
+clean_ordered_bullets("1.1 This is a very important point")
 
 # Returns "This is a very important point ●"
-clean_bullets("a.b This is a very important point ●")
+clean_ordered_bullets("a.b This is a very important point ●")
 
 ```
 


### PR DESCRIPTION
Hi, We need to fix the example code for clean_ordered_bullets

If you look at this link
https://docs.unstructured.io/open-source/core-functionality/cleaning#clean-ordered-bullets

`
from unstructured.cleaners.core import clean_ordered_bullets 

clean_bullets("1.1 This is a very important point")

clean_bullets("a.b This is a very important point ●")
`

Correction:
`
from unstructured.cleaners.core import clean_ordered_bullets

**clean_ordered_bullets**("1.1 This is a very important point")

**clean_ordered_bullets**("a.b This is a very important point ●")
`