### PR TITLE
Default to user's color mode

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -10,9 +10,6 @@
       "light": "#09C6DE",
       "dark": "#09C6DE"
     },
-    "modeToggle": {
-      "default": "dark"
-    },
     "topbarCtaButton": {
       "type": "github",
       "url": "https://github.com/Unstructured-IO/unstructured"


### PR DESCRIPTION
As a light mode user, it's jarring to get a screen full of black every time I open an Unstructured page.

Removed the `modeToggle` setting so Mintlify respects the end user's default color mode preference.

* [The Dark Side of Dark Mode](https://tidbits.com/2019/05/31/the-dark-side-of-dark-mode/)
* [Dark mode isn't as good for your eyes as you believe](https://www.wired.com/story/dark-mode-chrome-android-ios-science/)
* [Positive display polarity is advantageous for both younger and older adults](https://pubmed.ncbi.nlm.nih.gov/23654206/)

> Set if you always want to show light or dark mode for new users. When not set, we default to the same mode as the user’s operating system.
