### PR TITLE
chore/more sdk docs enhancements

### DIFF
--- a/api-reference/api-services/api-parameters.mdx
+++ b/api-reference/api-services/api-parameters.mdx
@@ -42,9 +42,9 @@ The following parameters only apply when a `chunking_strategy` is specified. Oth
 
 The following parameters are specific to the Python and Javascript clients and are not sent to the server.
 
-| Python & direct call                  | JavaScript                 | Description                                                                                                                    |
-|---------------------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `split_pdf_page` (_bool_)             | `splitPdfPage` (_boolean_) | Should the pdf file be split at client. See [page splitting](/api-reference/api-services/sdk#page-splitting) for more details. |
-| `split_pdf_concurrency_level` (_int_) | _Not supported yet_        | Number of split files to be sent concurrently. Default: 5, maximum: 15                                                         |
+| Python & direct call                  | JavaScript                            | Description                                                                                                                    |
+|---------------------------------------|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `split_pdf_page` (_bool_)             | `splitPdfPage` (_boolean_)            | Should the pdf file be split at client. See [page splitting](/api-reference/api-services/sdk#page-splitting) for more details. |
+| `split_pdf_concurrency_level` (_int_) | `splitPdfConcurrencyLevel` (_number_) | Number of split files to be sent concurrently. Default: 5, maximum: 15                                                         |
 
 Need help getting started? Check out the [Examples page](/api-reference/api-services/examples) for some inspiration.

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -86,40 +86,45 @@ from unstructured_client.models import operations, shared
 
 client = unstructured_client.UnstructuredClient(
     api_key_auth="YOUR_API_KEY",
-    # you may need to provide your unique API URL
     # server_url="YOUR_API_URL",
 )
 
-filename = "sample-docs/layout-parser-paper.pdf"
-file = open(filename, "rb")
+filename = "PATH_TO_FILE"
+with open(filename, "rb") as f:
+    data = f.read()
 
-res = client.general.partition(request=operations.PartitionRequest(
+req = operations.PartitionRequest(
     partition_parameters=shared.PartitionParameters(
-        # Note that this currently only supports a single file
         files=shared.Files(
-            content=file.read(),
+            content=data,
             file_name=filename,
         ),
-        # Other parameters
-        strategy=shared.Strategy.HI_RES,
-        chunking_strategy=shared.ChunkingStrategy.BY_PAGE,
+        # --- Other partition parameters ---
+        # Note: Defining `strategy`, `chunking_strategy`, and `output_format`
+        # parameters as strings is accepted, but will not pass strict type checking. It is
+        # advised to use the defined enum classes as shown below.
+        strategy=shared.Strategy.AUTO,  
+        languages=['eng'],
     ),
-))
+)
+
+res = client.general.partition(request=req)
 
 if res.elements is not None:
-    # handle response
+    # Handle the response
     pass
 ```
 
 ```javascript JavaScript
 import { UnstructuredClient } from "unstructured-client";
-import { PartitionResponse } from "unstructured-client/dist/sdk/models/operations";
+import { PartitionResponse } from "unstructured-client/sdk/models/operations";
+import { Strategy } from "unstructured-client/sdk/models/shared";
 import * as fs from "fs";
 
-const key = "YOUR-API-KEY";
+const key = "YOUR_API_KEY";
 
 const client = new UnstructuredClient({
-    serverURL: "YOUR_API_URL",
+    // serverURL: "YOUR_API_URL",
     security: {
         apiKeyAuth: key,
     },
@@ -129,17 +134,25 @@ const filename = "PATH_TO_FILE";
 const data = fs.readFileSync(filename);
 
 client.general.partition({
-    files: {
-        content: data,
-        fileName: filename,
-    },
+    partitionParameters: {
+        files: {
+            content: data,
+            fileName: filename,
+        },
+        strategy: Strategy.Auto,
+        languages: ['eng'],
+    }
 }).then((res: PartitionResponse) => {
     if (res.statusCode == 200) {
         console.log(res.elements);
     }
 }).catch((e) => {
-    console.log(e.statusCode);
-    console.log(e.body);
+    if (e.statusCode) {
+        console.log(e.statusCode);
+        console.log(e.body);
+    } else {
+        console.log(e);
+    }
 });
 ```
 </CodeGroup>

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -100,9 +100,6 @@ req = operations.PartitionRequest(
             file_name=filename,
         ),
         # --- Other partition parameters ---
-        # Note: Defining `strategy`, `chunking_strategy`, and `output_format`
-        # parameters as strings is accepted, but will not pass strict type checking. It is
-        # advised to use the defined enum classes as shown below.
         strategy=shared.Strategy.AUTO,  
         languages=['eng'],
     ),

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -108,11 +108,11 @@ req = operations.PartitionRequest(
     ),
 )
 
-res = client.general.partition(request=req)
-
-if res.elements is not None:
-    # Handle the response
-    pass
+try:
+    res = client.general.partition(request=req)
+    print(res.elements[0])
+except Exception as e:
+    print(e)
 ```
 
 ```javascript JavaScript

--- a/api-reference/api-services/sdk.mdx
+++ b/api-reference/api-services/sdk.mdx
@@ -80,11 +80,11 @@ deployment of Unstructured API, you can access the API using the Python or TypeS
         ),
     )
 
-    res = client.general.partition(request=req)
-
-    if res.elements is not None:
-        # Handle the response
-        pass
+    try:
+        res = client.general.partition(request=req)
+        print(res.elements[0])
+    except Exception as e:
+        print(e)
     ```
     ```javascript TypeScript
     import { UnstructuredClient } from "unstructured-client";

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -31,9 +31,10 @@ npm install unstructured-client
 <CodeGroup>
 
 ```python Python
+import json
+
 from unstructured_client import UnstructuredClient
-from unstructured_client.models import shared
-from unstructured_client.models.errors import SDKError
+from unstructured_client.models import operations, shared
 
 # Update here with your api key and server url
 client = UnstructuredClient(
@@ -42,27 +43,30 @@ client = UnstructuredClient(
 )
 
 # Update here with your filename
-filename = "sample-docs/YOUR_FILE_NAME.pdf"
+filename = "YOUR_FILE_NAME.pdf"
 
 with open(filename, "rb") as f:
-    files=shared.Files(
+    files = shared.Files(
         content=f.read(),
         file_name=filename,
     )
 
-# You can choose fast, hi_res or ocr_only for strategy, learn more in the docs at step 4
-req = shared.PartitionParameters(files=files, strategy="auto")
+# You can choose FAST, HI_RES or OCR_ONLY for strategy, learn more in the docs at step 4
+req = operations.PartitionRequest(
+    shared.PartitionParameters(files=files, strategy=shared.Strategy.AUTO)
+)
 
 try:
     resp = client.general.partition(req)
-    pprint(json.dumps(resp.elements, indent=2))
-except SDKError as e:
+    print(json.dumps(resp.elements, indent=2))
+except Exception as e:
     print(e)
 ```
 
-```javascript JavaScript
+```javascript TypeScript
 import { UnstructuredClient } from "unstructured-client";
-import { PartitionResponse } from "unstructured-client/dist/sdk/models/operations";
+import { PartitionResponse } from "unstructured-client/sdk/models/operations";
+import { Strategy } from "unstructured-client/sdk/models/shared";
 import * as fs from "fs";
 
 // Update here with your api 
@@ -77,21 +81,28 @@ const client = new UnstructuredClient({
 });
 
 // Update here with your filename
-filename = "sample-docs/YOUR_FILE_NAME.pdf"
+filename = "YOUR_FILE_NAME.pdf"
 const data = fs.readFileSync(filename);
 
 client.general.partition({
-    files: {
-        content: data,
-        fileName: filename,
-    },
+    partitionParameters: {
+        files: {
+            content: data,
+            fileName: filename,
+        },
+        strategy: Strategy.Auto,
+   }
 }).then((res: PartitionResponse) => {
     if (res.statusCode == 200) {
         console.log(res.elements);
     }
 }).catch((e) => {
-    console.log(e.statusCode);
-    console.log(e.body);
+    if (e.statusCode) {
+        console.log(e.statusCode);
+        console.log(e.body);
+    } else {
+        console.log(e);
+    }
 });
 ```
 </CodeGroup>


### PR DESCRIPTION
# Changes
* Add `split_pdf_concurrency_level` to the param table for the js client
* Copy the code samples from the sdks page over to the SaaS quick start and main getting started page to make sure all are on the new syntax
* Ensure that the python snippet uses a try catch. Let's catch the base Exception - right now we throw a few different errors and we should revisit these before getting more specific