### PR TITLE
Fixed some api titling and welcome page confusion

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -49,7 +49,7 @@
     },
     "tabs": [
       {
-        "name": "Serverless API",
+        "name": "API",
         "url": "api-reference"
       },
       {

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -6,7 +6,7 @@ description: "**Unstructured** provides tools to ingest and preprocess unstructu
 
 ### We Offer 3 Products
 
-1. [Unstructured Serverless API](/api-reference/api-services/overview "API") - The quickest way to get started for document transformation.
+1. [Unstructured API](/api-reference/api-services/overview "API") - The quickest way to get started for document transformation. We offer [Serverless](api-reference/api-services/saas-api-development-guide), [Azure Marketplace](/api-reference/api-services/azure), [AWS Marketplace](/api-reference/api-services/aws) and [Free](/api-reference/api-services/free-api_) versions of our API.
 2. [Platform](/platform/overview "Platform") - Entirely no code enterprise platform to get **all** your data RAG-ready.
 3. [Open Source](/open-source/introduction/overview/ "OSS") - Best for prototyping.
 


### PR DESCRIPTION
I'd changed the top level API in the nav to Serverless API and it was confusing. I've also better explained this situation on the welcome page.