### PR TITLE
Bump default split page concurrency level in SDKs

### DIFF
--- a/api-reference/api-services/sdk.mdx
+++ b/api-reference/api-services/sdk.mdx
@@ -226,7 +226,7 @@ deployment of Unstructured API, you can access the API using the Python or TypeS
     filetypes are ignored.
 
     The number of parallel requests is controlled by `splitPdfConcurrencyLevel`[*](#parameter-names). 
-    The default is 5 and the max is set to 15 to avoid high resource usage and costs.
+    The default is 8 and the max is set to 15 to avoid high resource usage and costs.
 
     If at least one request is successful, the responses are combined into a single response object. An
     error is returned only if all requests failed or there was an error during splitting.


### PR DESCRIPTION
Default is being updated:
https://github.com/Unstructured-IO/unstructured-python-client/pull/122
https://github.com/Unstructured-IO/unstructured-js-client/pull/87