### PR TITLE
Add links to blogs, best practices TOCs

### DIFF
--- a/api-reference/api-services/chunking.mdx
+++ b/api-reference/api-services/chunking.mdx
@@ -49,4 +49,4 @@ must have to be included in the same chunk. The default is 0.5.
 
 ## Learn more
 
-- <Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)
+<Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/api-reference/api-services/chunking.mdx
+++ b/api-reference/api-services/chunking.mdx
@@ -49,4 +49,4 @@ must have to be included in the same chunk. The default is 0.5.
 
 ## Learn more
 
-<Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)
+<Icon icon="blog" />&nbsp;&nbsp;[Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/api-reference/api-services/chunking.mdx
+++ b/api-reference/api-services/chunking.mdx
@@ -46,3 +46,7 @@ guarantee that two elements with low similarity will not be combined in a single
 You can control the level of topic similarity you require for elements to have by setting the `similarity_threshold` parameter.
 `similarity_threshold` expects a value between 0.0 and 1.0 specifying the minimum similarity text in consecutive elements
 must have to be included in the same chunk. The default is 0.5.
+
+## Learn more
+
+- <Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/api-reference/api-services/overview.mdx
+++ b/api-reference/api-services/overview.mdx
@@ -26,6 +26,8 @@ Unstructured Serverless API Services include these offerings:
     </Card>
 </CardGroup>
 
+<Icon icon="blog" />&nbsp;&nbsp;[Read the launch announcement](https://unstructured.io/blog/introducing-unstructured-serverless-api).
+
 ## Supported File Types
 
 The Unstructured API supports the same file types as the [Unstructured open source library](/open-source/introduction/overview).

--- a/api-reference/best-practices/chunking.mdx
+++ b/api-reference/best-practices/chunking.mdx
@@ -1,0 +1,5 @@
+---
+title: "Chunking"
+url: "https://unstructured.io/blog/chunking-for-rag-best-practices"
+icon: "blog"
+---

--- a/mint.json
+++ b/mint.json
@@ -196,6 +196,12 @@
         ]
       },
       {
+        "group": "Best Practices",
+        "pages": [
+          "open-source/best-practices/chunking"
+        ]
+      },
+      {
         "group": "Concepts",
         "pages": [
           "open-source/concepts/document-elements",
@@ -318,6 +324,12 @@
       { "group": "How To",
         "pages": [
           "api-reference/how-to/extract-image-block-types"
+        ]
+      },
+      { 
+        "group": "Best Practices",
+        "pages": [
+          "api-reference/best-practices/chunking"
         ]
       },
       {

--- a/open-source/best-practices/chunking.mdx
+++ b/open-source/best-practices/chunking.mdx
@@ -1,0 +1,5 @@
+---
+title: "Chunking"
+url: "https://unstructured.io/blog/chunking-for-rag-best-practices"
+icon: "blog"
+---

--- a/open-source/core-functionality/chunking.mdx
+++ b/open-source/core-functionality/chunking.mdx
@@ -179,4 +179,4 @@ for element in elements:
 
 ## Learn more
 
-- <Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)
+<Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/open-source/core-functionality/chunking.mdx
+++ b/open-source/core-functionality/chunking.mdx
@@ -176,3 +176,7 @@ for element in elements:
 #     ListItem: Roses are red
 #     ListItem: Violets are blue
 ```
+
+## Learn more
+
+- <Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/open-source/core-functionality/chunking.mdx
+++ b/open-source/core-functionality/chunking.mdx
@@ -179,4 +179,4 @@ for element in elements:
 
 ## Learn more
 
-<Icon icon="blog" />&nbsp;&nbsp;> [Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)
+<Icon icon="blog" />&nbsp;&nbsp;[Chunking for RAG: best practices](https://unstructured.io/blog/chunking-for-rag-best-practices)

--- a/platform/overview.mdx
+++ b/platform/overview.mdx
@@ -8,7 +8,8 @@ Platform is currently in private beta. [Click here](https://unstructured.io/plat
 </Warning>
 
 ### What We Do
-The ```Unstructured Platform``` is a **no-code platform** for **transforming unstructured data** to **RAG-ready data**. 
+The ```Unstructured Platform``` is a **no-code platform** for **transforming unstructured data** to **RAG-ready data**. [Read the announcement](https://unstructured.io/blog/introducing-unstructured-platform)&nbsp;&nbsp;<Icon icon="blog"/>.
+
 
 To **get your data RAG-ready** our platform moves it through the following process:
 

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -18,14 +18,16 @@ Learn more about these products:
   <br/>No-code user interface, pay-as-you-go platform to get all of your data RAG-ready.<br/><br/>
   Data is processed on Unstructured-hosted compute resources.<br/><br/>
   [Try the quickstart](#quickstart-unstructured-platform).<br/><br/>
-  [Learn more](/platform/overview).
+  [Learn more](/platform/overview).<br/><br/>
+  <Icon icon="blog"/>&nbsp;&nbsp;[Read the announcement](https://unstructured.io/blog/introducing-unstructured-platform).
 </Card>
 <Card title="Unstructured Serverless API Services" icon="square-terminal" href="/api-reference/api-services/overview">
   <br/>Use scripts or code to call the Unstructured CLI, SDKs, or REST API to get all of your data RAG-ready.<br/><br/>
   Unstructured Serverless API Services have a [Serverless](api-reference/api-services/saas-api-development-guide) pay-as-you-go edition and a [Free](/api-reference/api-services/free-api_) [limited](/api-reference/api-services/free-api#free-unstructured-api-limitations) edition that process data on Unstructured-hosted compute resources.<br/><br/>
   If you need to use compute resources that you host instead, there are also [Azure](/api-reference/api-services/azure) pay-as-you-go and [AWS](/api-reference/api-services/aws) pay-as-you-go editions; these editions process data by using the Unstructured API installed on compute resources hosted in your own Azure or AWS account.<br/><br/>
   [Try the quickstart](#quickstart-unstructured-api-service).<br/><br/>
-  [Learn more](/api-reference/api-services/overview).
+  [Learn more](/api-reference/api-services/overview).<br/><br/>
+  <Icon icon="blog"/>&nbsp;&nbsp;[Read the launch announcement](https://unstructured.io/blog/introducing-unstructured-serverless-api).
 </Card>
 <Card title="Unstructured open source library" icon="door-open" href="/open-source/introduction/overview/">
   <br/>Recommended only for rapid local script or code prototyping or simple proofs-of-concept. It is not designed for production scenarios.<br/><br/>


### PR DESCRIPTION
A few spots where this shows up:

- API TOC sidebar (may need to scroll down, look for "Best Practices"): https://unstructured-53-best-practices-2024-07-19.mintlify.app/api-reference/api-services/overview
- OSS TOC sidebar (may need to scroll down, look for "Best Practices"): https://unstructured-53-best-practices-2024-07-19.mintlify.app/open-source/introduction/overview
- "Learn more" in these spots:
  - https://unstructured-53-best-practices-2024-07-19.mintlify.app/api-reference/api-services/chunking#learn-more
  - https://unstructured-53-best-practices-2024-07-19.mintlify.app/open-source/core-functionality/chunking#learn-more

Feel free to suggest other spots to link to these. 😄 