### PR TITLE
How to extract text_as_html

### DIFF
--- a/api-reference/how-to/extract-image-block-types.mdx
+++ b/api-reference/how-to/extract-image-block-types.mdx
@@ -27,3 +27,8 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_image_block_types.py.mdx';
 
 <ExtractImageBlockTypesPy />
+
+## See also 
+
+- [Extract text as HTML](/api-reference/how-to/text-as-html)
+- [Table Extraction from PDF](/examplecode/codesamples/apioss/table-extraction-from-pdf)

--- a/api-reference/how-to/text-as-html.mdx
+++ b/api-reference/how-to/text-as-html.mdx
@@ -1,0 +1,32 @@
+---
+title: Extract text as HTML
+---
+
+## Task
+
+You want to get, save, or show the contents of elements that are represented as HTML, such as tables that are embedded in a PDF document.
+
+## Approach
+
+Use the Unstructured Python SDK to extract the contents of an element's `text_as_html` JSON object, which is nested inside of its parent `metadata` object.
+
+## To run this example
+
+You will need a document that is one of the document types that can output the `text_as_html` JSON object. For the list of applicable document types, see the entries in the table at the beginning of [Partitioning](/open-source/core-functionality/partitioning) where "Table Support" is "Yes."
+
+This example uses a PDF file with an embedded table.
+
+import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
+
+<SharedAPIKeyURL />
+
+## Code
+
+import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_text_as_html.py.mdx';
+
+<ExtractImageBlockTypesPy />
+
+## See also 
+
+- [Extract image block types](/api-reference/how-to/extract-image-block-types)
+- [Table Extraction from PDF](/examplecode/codesamples/apioss/table-extraction-from-pdf)

--- a/api-reference/how-to/text-as-html.mdx
+++ b/api-reference/how-to/text-as-html.mdx
@@ -1,5 +1,5 @@
 ---
-title: Extract text as HTML
+title: Extract tables as HTML
 ---
 
 ## Task

--- a/mint.json
+++ b/mint.json
@@ -337,6 +337,7 @@
           "api-reference/how-to/output-unique-element-ids",
           "api-reference/how-to/output-bounding-box-coordinates",
           "api-reference/how-to/set-document-language-ocr",
+          "api-reference/how-to/text-as-html",
           "api-reference/how-to/extract-image-block-types",
           "api-reference/how-to/change-element-coordinate-system",
           "api-reference/how-to/powerpoint",

--- a/snippets/how-to-api/extract_text_as_html.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html.py.mdx
@@ -1,0 +1,58 @@
+```python Python SDK
+from unstructured_client import UnstructuredClient
+from unstructured_client.models import operations, shared
+
+import os, webbrowser, json
+
+if __name__ == "__main__":
+    client = UnstructuredClient(
+        api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
+        server_url=os.getenv("UNSTRUCTURED_API_URL")
+    )
+
+    # Source: https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/embedded-images-tables.pdf
+
+    # Where to get the local file, relative to this .py file.
+    local_input_filepath = "local-ingest-pdf/embedded-images-tables.pdf"
+
+    # Where to store the retrieved HTML, relative to this .py file.
+    local_html_output_path = "local-ingest-output"
+
+    with open(local_input_filepath, "rb") as f:
+        files = shared.Files(
+            content=f.read(),
+            file_name=local_input_filepath
+        )
+
+    request = operations.PartitionRequest(
+        shared.PartitionParameters(
+            files=files
+        )
+    )
+
+    try:
+        result = client.general.partition(request)
+
+        # Provide some minimal CSS for better table readability.
+        table_css = "<head><style>table, th, td { border: 1px solid; }</style></head>"
+
+        for element in result.elements:
+            if "text_as_html" in element["metadata"]:
+                # Surround the element's HTML with basic <html> and <body> tags, and add the minimal CSS.
+                html_string = f"<!DOCTYPE html><html>{table_css}<body>{element["metadata"]["text_as_html"]}</body></html>"
+
+                # Save the element's HTML to a local file.
+                save_path = f"{local_html_output_path}/{element["element_id"]}.html"
+                file = open(save_path, 'w')
+                file.write(html_string)
+                file.close()
+
+                # View the locally saved file in the local default web browser.
+                webbrowser.open_new(f"file:///{os.getcwd()}/{save_path}")
+
+        # Also print the JSON representation of all elements for
+        # inspection and validation.
+        print(json.dumps(result.elements, indent=2))
+    except Exception as e:
+        print(e)
+```


### PR DESCRIPTION
A code example I wrote that shows how to use the Unstructured Python SDK to extract, save, and show `text_as_html` elements.

See: https://unstructured-53-text-as-html-2024-07-23.mintlify.app/api-reference/how-to/text-as-html