### PR TITLE
Must specify API URL when using POST, Free, Azure, and AWS calling patterns

### DIFF
--- a/api-reference/api-services/examples.mdx
+++ b/api-reference/api-services/examples.mdx
@@ -9,6 +9,10 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAPIKeyURL />
 
+import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
+
+<NoURLForServerlessAPI/>
+
 ### Changing partition strategy for a PDF
 
 Here's how you can modify partition strategy for a pdf file, and select an alternative model to use with Unstructured API.

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -12,7 +12,7 @@ The Free Unstructured API requires authentication via an API key. Here's how you
 3.  Check the **I agree** box if you consent to Unstructured contacting you about our products and services.
 4.  Click the **Terms and Conditions** link, read it, and check the related box to agree.
 5.  Click **Submit**. You will receive a Free Unstructured API key at the **Email** you provided. Store your API key in a secure location. Do not share it with others.
-6.  For the Free Unstructured API, you must also provide an API URL only when you make [POST requests](#post-request), and the API URL for POST requests is always `https://api.unstructured.io/general/v0/general`. In all other cases, the API URL is an empty string.
+6.  For the Free Unstructured API, the API URL is `https://api.unstructured.io/general/v0/general`
 
 import FreeKeyNoServerlessURL from '/snippets/general-shared-text/free-api-key-no-serverless-access.mdx';
 
@@ -38,16 +38,12 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 Let's say you want to preprocess an `*.eml` file using the free Unstructured API. There are several ways
 you can do this, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-unstructured-api-from-the-unstructured-open-source-library).
 
-<Info>When using the Free Unstructured API, use `https://api.unstructured.io/general/v0/general` as the URL for `POST` requests, or a blank string as the URL when using the CLI, SDKs, or open source library. Note that the Free API URL has a slightly different domain name than the Serverless API which is `api.unstructuredapp.io`.</Info>
-
 ### POST request
 
 To work with the Unstructured Serverless API by calling the Unstructured REST API POST with `curl`, first do the following:
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
-- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which for POST requests is always `https://api.unstructured.io/general/v0/general`.
-
-<Info>Setting the `UNSTRUCTURED_API_URL` environment variable makes your code forward-compatible if you later upgrade to the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide), which requires a different API URL.</Info>
+- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
 Now, use `curl` to call the API, specifying where the source (input) file is to preprocess and the destination (output) where Unstructured will deliver the processed data:
 
@@ -59,12 +55,13 @@ curl -X POST $UNSTRUCTURED_API_URL \
      -F 'files=@<local/path/to/input/file>' \
      -o '<local/path/to/output/file>'
 ```
+
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 The result will look something like this:
 ![Sample Output](/img/api/sample_output.png)
 
-<Info>`POST` requests support using only local machine paths as the source (input) for the file to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the Python SDK, or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead.</Info>
+<Info>`POST` requests support using only local machine paths as the source (input) for the file to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the [Python SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead.</Info>
 
 import SharedPOSTSingleFile from '/snippets/general-shared-text/post-api-single-file.mdx';
 
@@ -83,6 +80,7 @@ To work with the Free Unstructured API by using the Unstructured CLI, you will n
   ```
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
+- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
 Now, use the CLI to call the API, specifying where the files are to preprocess and where Unstructured will output the processed data.
 
@@ -92,7 +90,8 @@ unstructured-ingest \
     --input-path <local/path/to/input/files> \
     --output-dir <local/path/to/output/files> \
     --partition-by-api \
-    --api-key $UNSTRUCTURED_API_KEY
+    --api-key $UNSTRUCTURED_API_KEY \
+    --partition-endpoint $UNSTRUCTURED_API_URL
 ```
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
@@ -109,12 +108,12 @@ To work with the Unstructured Serverless API in Python, JavaScript, or TypeScrip
 Unstructured [Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or
 [JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
 
-<Info>The JavaScript/TypeScript SDK supports using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the Python SDK, or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead..</Info>
+<Info>The JavaScript/TypeScript SDK supports using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the Python SDK, or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead.</Info>
 
-First, install your preferred SDK:
+Install your preferred SDK:
+
 <CodeGroup>
-
-```bash
+```bash Python
 pip install unstructured-client
 ```
 
@@ -123,7 +122,9 @@ npm install unstructured-client
 ```
 </CodeGroup>
 
-Next, set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
+Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
+
+Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
 Now call the API. 
 
@@ -136,7 +137,8 @@ import unstructured_client
 from unstructured_client.models import operations, shared
 
 client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
+    api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+    server_url=os.getenv("UNSTRUCTURED_API_URL")
 )
 
 filename = "sample-docs/layout-parser-paper.pdf"
@@ -165,11 +167,13 @@ import { PartitionResponse } from "unstructured-client/dist/sdk/models/operation
 import * as fs from "fs";
 
 const key = process.env.UNSTRUCTURED_API_KEY;
+const url = process.env.UNSTRUCTURED_API_URL;
 
 const client = new UnstructuredClient({
     security: {
         apiKeyAuth: key,
     },
+    serverUrl: url
 });
 
 const filename = "PATH_TO_FILE";
@@ -211,7 +215,8 @@ You will need to:
   pip install unstructured
   ```
 
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your API key.
+- Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
+- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
 Now, use the open source library to call the API, specifying the file to preprocess:
 
@@ -224,7 +229,8 @@ filename = "PATH_TO_FILE"
 
 elements = partition_via_api(
   filename=filename,
-  api_key=os.getenv("UNSTRUCTURED_API_KEY")
+  api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+  parition_endpoint=os.getenv("UNSTRUCTURED_API_URL")
 )
 ```
 

--- a/api-reference/api-services/partition-via-api.mdx
+++ b/api-reference/api-services/partition-via-api.mdx
@@ -12,6 +12,10 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAPIKeyURL />
 
+import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
+
+<NoURLForServerlessAPI/>
+
 ## Installation
 
 Make sure you have the Unstructured Open Source library installed.
@@ -32,7 +36,7 @@ elements = partition_via_api(
     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
     api_url=os.getenv("UNSTRUCTURED_API_URL"),
     content_type="message/rfc822"
-    )
+)
 ```
 
 When sending a request to the free Unstructured API, you only need to provide your individual API key.

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -71,7 +71,7 @@ The result will look something like this:
 
 ![Sample Output](/img/api/sample_output.png)
 
-<Info>`POST` requests support using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the CLI, the Python SDK, or the open source library instead.</Info>
+<Info>`POST` requests support using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the [Python SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead.</Info>
 
 import SharedPOSTSingleFile from '/snippets/general-shared-text/post-api-single-file.mdx';
 
@@ -90,6 +90,10 @@ To work with the Unstructured Serverless API by using the Unstructured CLI, you 
   ```
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your API key. Make sure to also set the `UNSTRUCTURED_API_URL` environment variable to your API URL. [Get your API key and API URL](#get-started).
+
+import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
+
+<NoURLForServerlessAPI/>
 
 Now, use the CLI to call the API, specifying where the source (input) files are to preprocess and the destination (output) where Unstructured will deliver the processed data:
 
@@ -128,6 +132,8 @@ npm install unstructured-client
 </CodeGroup>
 
 Next, use it to call the API. Be sure to set the `UNSTRUCTURED_API_URL` environment variable to your API URL Also set the `UNSTRUCTURED_API_KEY` environment variable to your API key. [Get your API key and API URL](#get-started). 
+
+<NoURLForServerlessAPI/>
 
 <CodeGroup>
 
@@ -230,6 +236,8 @@ You will need to:
   ```
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your API key. Make sure to set the `UNSTRUCTURED_API_URL` environment variable to your API URL. [Get your API key and API URL](#get-started). 
+
+<NoURLForServerlessAPI/>
 
 Now, use the open source library to call the API, specifying the file to preprocess:
 

--- a/api-reference/api-services/sdk.mdx
+++ b/api-reference/api-services/sdk.mdx
@@ -13,6 +13,10 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAPIKeyURL />
 
+import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
+
+<NoURLForServerlessAPI/>
+
 ## Installation
 
     Before using the SDK to interact with your Unstructured API, install the library:
@@ -48,12 +52,6 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
         could break in future releases. Users should migrate to the new `shared.PartitionRequest` object 
         to ensure compatibility with future updates.
     </Warning>
-
-    <Note>
-    By default, the SDKs send requests to the free API. In order to access the paid API, you'll need
-    to include the argument for the server URL. If you receive authentication errors, and you've
-    checked that your key is correct, be sure that you are accessing the correct endpoint.
-    </Note>
 
     <CodeGroup>
     ```python Python
@@ -208,32 +206,6 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
     import SharedAPISingleFile from '/snippets/general-shared-text/multi-file-api-use-connectors.mdx';
 
     <SharedAPISingleFile />
-
-## Unstructured Serverless API
-
-    If you want to use the Unstructured Serverless API, all you need to do is initialize the SDK client with
-    the unique API URL that you received in the same email as your API key. For Unstructured API on
-    Azure/AWS, use the API URL that you configured through those services.
-
-    <CodeGroup>
-    ```python Python
-    import os
-
-    client = unstructured_client.UnstructuredClient(
-        api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-        server_url=os.getenv("UNSTRUCTURED_API_URL"),
-    )
-    ```
-    ```typescript TypeScript
-    const key = process.env.UNSTRUCTURED_API_KEY;
-    const url = process.env.UNSTRUCTURED_API_URL;    
-
-    const client = new UnstructuredClient({
-        security: { apiKeyAuth: key },
-        serverURL: url,
-    });
-    ```
-    </CodeGroup>
 
 ## Page Splitting
 

--- a/snippets/general-shared-text/api-key-url.mdx
+++ b/snippets/general-shared-text/api-key-url.mdx
@@ -2,5 +2,3 @@ These environment variables:
 
 - `UNSTRUCTURED_API_KEY` - Your Unstructured API key value.
 - `UNSTRUCTURED_API_URL` - Your Unstructured API URL.
-
-[Get your API key and API URL](/api-reference/api-services/saas-api-development-guide#get-started).

--- a/snippets/general-shared-text/no-url-for-serverless-api.mdx
+++ b/snippets/general-shared-text/no-url-for-serverless-api.mdx
@@ -1,0 +1,5 @@
+<Info>
+    If you do not specify the API URL, your [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) pay-as-you-go account will be used by default. You must always specify your Serverless API key.<br/><br/>
+    To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io/general/v0/general`<br/><br/>
+    To use the pay-as-you-go Unstructured API on Azure or AWS with the SDKs, you must always specify the corresponding API URL. See the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) instructions.
+</Info>

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -67,13 +67,11 @@ You will need:
     </Step>
     <Step title="Get your API key and API URL">
         1. Get your Unstructured API key from the welcome email that Unstructured sends you. Store your API key in a secure location. Do not share it with others.
-        2. For this quickstart, your Unstructured API URL is an empty string.
+        2. For the Free edition, the API URL is `https://api.unstructured.io/general/v0/general`
     </Step>
     <Step title="Set enviromnent variables">
         1. Set an environment variable named `UNSTRUCTURED_API_KEY` to the value of your Unstructured API key.
-        2. Set another environment variable named `UNSTRUCTURED_API_URL` to an empty string.
-        <Info>Setting the environment variable named `UNSTRUCTURED_API_URL` to an empty string makes your code forward-compatible if you later upgrade to the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide), which requires an API URL instead of an empty string.</Info>
-        To learn how to set environment variables, see your operating system's documentation.
+        2. Set another environment variable named `UNSTRUCTURED_API_URL` to the Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
     </Step>
     <Step title="Install the API library">
         Run the following command:


### PR DESCRIPTION
New behavior, per @awalker4 @amanda103. 

You do not need to specify API URL when using Serverless API (the default). You must in all other cases.