### PR TITLE
Quickstarts and overviews: show how to print and write data

### DIFF
--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -49,7 +49,10 @@ To work with the Unstructured Serverless API by calling the Unstructured REST AP
 
 <Info>Setting the `UNSTRUCTURED_API_URL` environment variable makes your code forward-compatible if you later upgrade to the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide), which requires a different API URL.</Info>
 
-Now, use `curl` to call the API, specifying where the source (input) file is to preprocess and the destination (output) where Unstructured will deliver the processed data:
+Now, use `curl` to call the API, replacing:
+
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash
 curl -X POST $UNSTRUCTURED_API_URL \
@@ -59,10 +62,10 @@ curl -X POST $UNSTRUCTURED_API_URL \
      -F 'files=@<local/path/to/input/file>' \
      -o '<local/path/to/output/file>'
 ```
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-The result will look something like this:
-![Sample Output](/img/api/sample_output.png)
+After the command successfully runs, see the results in the specified output path on your local machine.
+
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 <Info>`POST` requests support using only local machine paths as the source (input) for the file to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the Python SDK, or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead.</Info>
 
@@ -84,7 +87,10 @@ To work with the Free Unstructured API by using the Unstructured CLI, you will n
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
 
-Now, use the CLI to call the API, specifying where the files are to preprocess and where Unstructured will output the processed data.
+Now, use the CLI to call the API, replacing:
+
+- `<local/path/to/input/files>` with the path to the source (input) files on your local machine.
+- `<local/path/to/output/files>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash CLI
 unstructured-ingest \
@@ -95,19 +101,19 @@ unstructured-ingest \
     --api-key $UNSTRUCTURED_API_KEY
 ```
 
+After the command successfully runs, see the results in the specified output path on your local machine.
+
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 To learn more about how to use the `local` command, run the command `unstructured-ingest local --help`.
 
+To use source and destination locations outside of your local machine, see the documentation for the available [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
+
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
-To work with the free Unstructured API in Python or JavaScript, use the
+To work with the Free Unstructured API in Python or JavaScript, use the
 Unstructured [Python SDK](https://github.com/Unstructured-IO/unstructured-python-client), or
 [JavaScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
-
-To work with the Unstructured Serverless API in Python, JavaScript, or TypeScript, use the
-Unstructured [Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or
-[JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
 
 <Info>The JavaScript/TypeScript SDK supports using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [CLI](#unstructured-cli), the Python SDK, or the [open source library](#calling-the-unstructured-api-from-the-unstructured-open-source-library) instead..</Info>
 
@@ -125,68 +131,95 @@ npm install unstructured-client
 
 Next, set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
 
-Now call the API. 
+Now, call the API, replacing:
+
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data.
 
 <CodeGroup>
 
 ```python Python
-import os
+import json, os
 
-import unstructured_client
+from unstructured_client import UnstructuredClient
 from unstructured_client.models import operations, shared
 
-client = unstructured_client.UnstructuredClient(
+input_filepath = "<local/path/to/input/file>"
+output_filepath = "<local/path/to/output/file>"
+
+client = UnstructuredClient(
     api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
 )
 
-filename = "sample-docs/layout-parser-paper.pdf"
-file = open(filename, "rb")
+with open(input_filepath, "rb") as f:
+    files = shared.Files(
+        content=f.read(),
+        file_name=input_filepath
+    )
 
-res = client.general.partition(request=operations.PartitionRequest(
-    partition_parameters=shared.PartitionParameters(
-        files=shared.Files(
-            content=file.read(),
-            file_name=filename,
-        ),
-        # Other parameters.
-        strategy=shared.Strategy.HI_RES,
-        chunking_strategy=shared.ChunkingStrategy.BY_PAGE,
-    ),
-))
+req = operations.PartitionRequest(
+    shared.PartitionParameters(
+        files=files,
+        strategy=shared.Strategy.AUTO
+    )
+)
 
-if res.elements is not None:
-    # handle response
-    pass
+try:
+    res = client.general.partition(request=req)
+    element_dicts = [element for element in res.elements]
+    json_elements = json.dumps(element_dicts, indent=2)
+    
+    # Print the processed data.
+    print(json_elements)
+
+    # Write the processed data to a local file.
+    with open(output_filepath, "w") as file:
+      file.write(json_elements)
+except Exception as e:
+    print(e)
 ```
 
 ```typescript TypeScript
 import { UnstructuredClient } from "unstructured-client";
-import { PartitionResponse } from "unstructured-client/dist/sdk/models/operations";
+import { Strategy } from "unstructured-client/sdk/models/shared/index.js";
 import * as fs from "fs";
 
-const key = process.env.UNSTRUCTURED_API_KEY;
+const inputFilepath = "<local/path/to/input/file>" || '';
+const outputFilepath = "<local/path/to/output/file>" || ''
+
+const key = process.env.UNSTRUCTURED_API_KEY || '';
 
 const client = new UnstructuredClient({
-    security: {
-        apiKeyAuth: key,
-    },
+    security: { apiKeyAuth: key }
 });
 
-const filename = "PATH_TO_FILE";
-const data = fs.readFileSync(filename);
+const data = fs.readFileSync(inputFilepath);
 
 client.general.partition({
-    files: {
-        content: data,
-        fileName: filename,
-    },
-}).then((res: PartitionResponse) => {
+    partitionParameters: {
+        files: {
+            content: data,
+            fileName: inputFilepath
+        },
+        strategy: Strategy.Auto
+    }
+}).then((res) => {
     if (res.statusCode == 200) {
-        console.log(res.elements);
+       const jsonElements = JSON.stringify(res.elements, null, 2)
+       
+       // Print the processed data.
+       console.log(jsonElements);
+
+       // Write the processed data to a local file.
+       fs.writeFileSync(outputFilepath, jsonElements)
     }
 }).catch((e) => {
-    console.log(e.statusCode);
-    console.log(e.body);
+    if (e.statusCode) {
+        console.log(e.statusCode);
+        console.log(e.body);
+    } else {
+        console.log(e);
+    }
 });
 ```
 </CodeGroup>
@@ -213,19 +246,33 @@ You will need to:
 
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your API key.
 
-Now, use the open source library to call the API, specifying the file to preprocess:
+Now, call the API, replacing:
+
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```python
-import os
+import os, json
 
 from unstructured.partition.api import partition_via_api
 
-filename = "PATH_TO_FILE"
+input_filepath = "<local/path/to/input/file>"
+output_filepath = "<local/path/to/output/file>"
 
 elements = partition_via_api(
-  filename=filename,
+  filename=input_filepath,
   api_key=os.getenv("UNSTRUCTURED_API_KEY")
 )
+
+element_dicts = [element.to_dict() for element in elements]
+json_elements = json.dumps(element_dicts, indent=2)
+
+# Print the processed data to a local file.
+print(json_elements)
+
+# Write the processed data to a local file.
+with open(output_filepath, "w") as file:
+    file.write(json_elements)
 ```
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.

--- a/api-reference/api-services/partition-via-api.mdx
+++ b/api-reference/api-services/partition-via-api.mdx
@@ -23,7 +23,7 @@ Here's a basic example in which you send an email file to partition via Unstruct
 in the Unstructured Open Source library:
 
 ```python
-import os
+import os, json
 
 from unstructured.partition.api import partition_via_api
 
@@ -33,6 +33,16 @@ elements = partition_via_api(
     api_url=os.getenv("UNSTRUCTURED_API_URL"),
     content_type="message/rfc822"
     )
+
+element_dicts = [element.to_dict() for element in elements]
+json_elements = json.dumps(element_dicts, indent=2)
+
+# Print the processed data.
+print(json_elements)
+
+# Write the processed data to a local file.
+with open("example-docs/eml/fake-email-output.json", "w") as file:
+    file.write(json_elements)
 ```
 
 When sending a request to the free Unstructured API, you only need to provide your individual API key.

--- a/api-reference/api-services/post-requests.mdx
+++ b/api-reference/api-services/post-requests.mdx
@@ -20,7 +20,8 @@ Let's start with a simple example in which you send an email file (`*.eml`) to p
   -H 'accept: application/json' \
   -H 'Content-Type: multipart/form-data' \
   -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
-  -F 'files=@sample-docs/family-day.eml'
+  -F 'files=@sample-docs/family-day.eml' \
+  -o 'sample-docs/family-day-output.json'
 ```
 
 In the example above we're sending the request to the Free Unstructured API, in which case the API URL is the same for all

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -54,7 +54,10 @@ To work with the Unstructured Serverless API by calling the Unstructured REST AP
 
 [Get your API key and API URL](#get-started).
 
-Now, use `curl` to call the API, specifying where the source (input) file is to preprocess and the destination (output) where Unstructured will deliver the processed data. 
+Now, use `curl` to call the API, replacing:
+
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash
 curl -X POST $UNSTRUCTURED_API_URL \
@@ -65,11 +68,9 @@ curl -X POST $UNSTRUCTURED_API_URL \
      -o '<local/path/to/output/file>'
 ```
 
+After the command successfully runs, see the results in the specified output path on your local machine.
+
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-The result will look something like this:
-
-![Sample Output](/img/api/sample_output.png)
 
 <Info>`POST` requests support using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the CLI, the Python SDK, or the open source library instead.</Info>
 
@@ -89,9 +90,17 @@ To work with the Unstructured Serverless API by using the Unstructured CLI, you 
   pip install unstructured
   ```
 
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your API key. Make sure to also set the `UNSTRUCTURED_API_URL` environment variable to your API URL. [Get your API key and API URL](#get-started).
+- Set the following environment variables:
 
-Now, use the CLI to call the API, specifying where the source (input) files are to preprocess and the destination (output) where Unstructured will deliver the processed data:
+  - Set `UNSTRUCTURED_API_KEY` to your API key.
+  - Set `UNSTRUCTURED_API_URL` to your API URL.
+  
+  [Get your API key and API URL](#get-started).
+
+Now, use the CLI to call the API, replacing:
+
+- `<local/path/to/input/files>` with the path to the source (input) files on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash CLI
 unstructured-ingest \
@@ -103,9 +112,13 @@ unstructured-ingest \
     --partition-endpoint $UNSTRUCTURED_API_URL
 ```
 
+After the command successfully runs, see the results in the specified output path on your local machine.
+
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 To learn more about how to use the `local` command, run the command `unstructured-ingest local --help`.
+
+To use source and destination locations outside of your local machine, see the documentation for the available [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
 
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
@@ -127,76 +140,97 @@ npm install unstructured-client
 ```
 </CodeGroup>
 
-Next, use it to call the API. Be sure to set the `UNSTRUCTURED_API_URL` environment variable to your API URL Also set the `UNSTRUCTURED_API_KEY` environment variable to your API key. [Get your API key and API URL](#get-started). 
+Next, set the following environment variables:
+
+- Set `UNSTRUCTURED_API_URL` environment variable to your API URL.
+- Set the `UNSTRUCTURED_API_KEY` environment variable to your API key.
+
+[Get your API key and API URL](#get-started). 
+
+Now, call the API, replacing:
+
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data.
 
 <CodeGroup>
 
 ```python Python
-import os
+import json, os
 
-import unstructured_client
+from unstructured_client import UnstructuredClient
 from unstructured_client.models import operations, shared
 
-client = unstructured_client.UnstructuredClient(
+input_filepath = "<local/path/to/input/file>"
+output_filepath = "<local/path/to/output/file>"
+
+client = UnstructuredClient(
     api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
     server_url=os.getenv("UNSTRUCTURED_API_URL"),
 )
 
-filename = "PATH_TO_FILE"
-with open(filename, "rb") as f:
-    data = f.read()
+with open(input_filepath, "rb") as f:
+    files = shared.Files(
+        content=f.read(),
+        file_name=input_filepath
+    )
 
 req = operations.PartitionRequest(
-    partition_parameters=shared.PartitionParameters(
-        files=shared.Files(
-            content=data,
-            file_name=filename,
-        ),
-        # --- Other partition parameters. ---
-        strategy=shared.Strategy.AUTO,
-        languages=['eng'],
-    ),
+    shared.PartitionParameters(
+        files=files,
+        strategy=shared.Strategy.AUTO
+    )
 )
 
 try:
     res = client.general.partition(request=req)
-    print(res.elements[0])
+    element_dicts = [element for element in res.elements]
+    json_elements = json.dumps(element_dicts, indent=2)
+    
+    # Print the processed data.
+    print(json_elements)
+
+    # Write the processed data to a local file.
+    with open(output_filepath, "w") as file:
+      file.write(json_elements)
 except Exception as e:
     print(e)
 ```
 
 ```typescript TypeScript
 import { UnstructuredClient } from "unstructured-client";
-import { PartitionResponse } from "unstructured-client/sdk/models/operations";
-import { Strategy } from "unstructured-client/sdk/models/shared";
+import { Strategy } from "unstructured-client/sdk/models/shared/index.js";
 import * as fs from "fs";
 
-const key = process.env.UNSTRUCTURED_API_KEY;
-const url = process.env.UNSTRUCTURED_API_URL;
+const inputFilepath = "<local/path/to/input/file>" || '';
+const outputFilepath = "<local/path/to/output/file>" || ''
+
+const key = process.env.UNSTRUCTURED_API_KEY || '';
+const url = process.env.UNSTRUCTURED_API_URL || '';
 
 const client = new UnstructuredClient({
-    serverURL: url,
-    security: {
-        apiKeyAuth: key,
-    },
+    security: { apiKeyAuth: key },
+    serverURL: url
 });
 
-const filename = "PATH_TO_FILE";
-const data = fs.readFileSync(filename);
+const data = fs.readFileSync(inputFilepath);
 
 client.general.partition({
     partitionParameters: {
         files: {
             content: data,
-            fileName: filename,
+            fileName: inputFilepath
         },
-        // --- Other partition parameters. ---
-        strategy: Strategy.Auto,
-        languages: ['eng'],
+        strategy: Strategy.Auto
     }
-}).then((res: PartitionResponse) => {
+}).then((res) => {
     if (res.statusCode == 200) {
-        console.log(res.elements);
+       const jsonElements = JSON.stringify(res.elements, null, 2)
+       
+       // Print the processed data.
+       console.log(jsonElements);
+
+       // Write the processed data to a local file.
+       fs.writeFileSync(outputFilepath, jsonElements)
     }
 }).catch((e) => {
     if (e.statusCode) {
@@ -208,6 +242,8 @@ client.general.partition({
 });
 ```
 </CodeGroup>
+
+After the code successfully runs, see the results in the specified output path on your local machine.
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
@@ -223,29 +259,44 @@ You can call the Unstructured Serverless API directly from the Unstructured open
 
 You will need to: 
 
-- Install Python, and then install the open source library:
+- Set the following environment variables:
 
-  ```bash
-  pip install unstructured
-  ```
+  - Set `UNSTRUCTURED_API_KEY` to your API key.
+  - Set `UNSTRUCTURED_API_URL` to your API URL.
+  
+  [Get your API key and API URL](#get-started).
 
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your API key. Make sure to set the `UNSTRUCTURED_API_URL` environment variable to your API URL. [Get your API key and API URL](#get-started). 
+Now, call the API, replacing:
 
-Now, use the open source library to call the API, specifying the file to preprocess:
+- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
+- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```python
-import os 
+import os, json
 
 from unstructured.partition.api import partition_via_api
 
-filename = "PATH_TO_FILE"
+input_filepath = "<local/path/to/input/file>"
+output_filepath = "<local/path/to/output/file>"
 
 elements = partition_via_api(
-  filename=filename,
+  filename=input_filepath,
   api_key=os.getenv("UNSTRUCTURED_API_KEY"),
   api_url=os.getenv("UNSTRUCTURED_API_URL")
 )
+
+element_dicts = [element.to_dict() for element in elements]
+json_elements = json.dumps(element_dicts, indent=2)
+
+# Print the processed data.
+print(json_elements)
+
+# Write the processed data to a local file.
+with open(output_filepath, "w") as file:
+    file.write(json_elements)
 ```
+
+After the code successfully runs, see the results in the specified output path on your local machine.
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 

--- a/api-reference/api-services/sdk.mdx
+++ b/api-reference/api-services/sdk.mdx
@@ -57,7 +57,7 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
     <CodeGroup>
     ```python Python
-    import os
+    import os, json
 
     import unstructured_client
     from unstructured_client.models import operations, shared
@@ -67,7 +67,7 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
         server_url=os.getenv("UNSTRUCTURED_API_URL"),
     )
 
-    filename = "PATH_TO_FILE"
+    filename = "PATH_TO_INPUT_FILE"
     with open(filename, "rb") as f:
         data = f.read()
 
@@ -88,7 +88,15 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
     try:
         res = client.general.partition(request=req)
-        print(res.elements[0])
+        element_dicts = [element for element in res.elements]
+        json_elements = json.dumps(element_dicts, indent=2)
+    
+        # Print the processed data.
+        print(json_elements)
+
+        # Write the processed data to a local file.
+        with open("PATH_TO_OUTPUT_FILE", "w") as file:
+            file.write(json_elements)
     except Exception as e:
         print(e)
     ```
@@ -108,7 +116,7 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
         },
     });
 
-    const filename = "PATH_TO_FILE";
+    const filename = "PATH_TO_INPUT_FILE";
     const data = fs.readFileSync(filename);
 
     client.general.partition({
@@ -122,7 +130,13 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
         }
     }).then((res: PartitionResponse) => {
         if (res.statusCode == 200) {
-            console.log(res.elements);
+            const jsonElements = JSON.stringify(res.elements, null, 2)
+       
+            // Print the processed data.
+            console.log(jsonElements);
+
+            // Write the processed data to a local file.
+            fs.writeFileSync("PATH_TO_OUTPUT_FILE", jsonElements)
         }
     }).catch((e) => {
         if (e.statusCode) {


### PR DESCRIPTION
Until this PR, our main quickstarts and overviews for the CLI, SDKs, and open source library didn't show how to print or write the processed data that is returned. This would result in running code and nothing appearing to happen, or at best perhaps only the first element is printed to the terminal. This PR now prints all of the results and also saves the results locally for these quickstarts and overviews, enabling customers to get a better understanding of the shape of their processed data. 

See: 

- https://unstructured-53-quickstart-updates-2024-07-29.mintlify.app/api-reference/api-services/saas-api-development-guide
- https://unstructured-53-quickstart-updates-2024-07-29.mintlify.app/api-reference/api-services/free-api
- https://unstructured-53-quickstart-updates-2024-07-29.mintlify.app/api-reference/api-services/post-requests
- https://unstructured-53-quickstart-updates-2024-07-29.mintlify.app/api-reference/api-services/sdk (latest SDK releases only)
- https://unstructured-53-quickstart-updates-2024-07-29.mintlify.app/api-reference/api-services/partition-via-api
