### PR TITLE
Add missing ingest connector configuration parameter descriptions

### DIFF
--- a/snippets/ingest-configuration-shared/chunking-configuration.mdx
+++ b/snippets/ingest-configuration-shared/chunking-configuration.mdx
@@ -7,21 +7,21 @@ A common chunking configuration is a critical element in the data processing pip
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_by_api`: Default: `False`.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_combine_text_under_n_chars`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_combine_text_under_n_chars`: Combine consecutive chunks when the first does not exceed length `n` and the second will fit without exceeding the hard-maximum length. Only operative for the `by_title` chunking strategy.
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`chunk_elements`: <Icon icon="ban"/>&nbsp;&nbsp;**Deprecated!** `False` (default) to not run chunking as part of the ingest process. This option is deprecated in favor of the `chunking_strategy` option. Setting this to `True` has the same effect as `chunking_strategy=by_title`.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_include_orig_elements`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_include_orig_elements`: `True` when chunking to add the original elements consolidated to form each chunk to `.metadata.orig_elements` on that chunk.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_max_characters`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_max_characters`: Default: `500`. The hard-maximum chunk length. No chunk will exceed this length. An oversized element will be divided by text-splitting to fit this window.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_multipage_selections`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_multipage_selections`: `True` to ignore page boundaries when chunking such that elements from two different pages can appear in the same chunk. Only operative for the `by_title` chunking strategy.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_new_after_n_chars`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_new_after_n_chars`: The soft-maximum chunk length. Another element will not be added to a chunk of `n` length even when it would fit without exceeding the hard-maximum length.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_overlap`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_overlap`: Default: `0`. Prefix each chunk's text with the last overlap of `n` characters from the prior chunk. Only applies to oversized chunks divided by text-splitting. To apply overlap to non-oversized chunks, use `chunk_overlap_all`.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_overlap_all`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunk_overlap_all`: Applies overlap to chunks formed from whole elements as well as those formed by text-splitting oversized elements. The overlap length is taken from the `chunk_overlap` value.
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`chunking_endpoint`
 
@@ -33,10 +33,10 @@ A common chunking configuration is a critical element in the data processing pip
     
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`max_characters`: Default: `500`. Combine elements into chunks no larger than `n` characters. This is a hard maximum: no chunk with text longer than this value will appear in the output stream.
     
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`multipage_sections`: Default: `True`. When `False`, in addition to section boundaries, page boundaries are also respected. Only operative for the `by_title` strategy.
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`multipage_sections`: Default: `True`. When `False`, in addition to section boundaries, page boundaries are also respected. Only operative for the `by_title` chunking strategy.
     
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`new_after_n_chars`: Default: `max_characters (off)`. Cuts off new chunks once they reach a length of `n` characters. This is a soft maximum. Defaults to `max_characters` when not specified, which effectively disables any soft window. Specifying `0` for this argument causes each element to appear in a chunk by itself (although an element with text longer than `max_characters` will be still be divided into two or more chunks using text splitting).
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`overlap`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`overlap`: Default: `0`. Prefix each chunk's text with the last overlap of `n` characters from the prior chunk. Only applies to oversized chunks divided by text-splitting. To apply overlap to non-oversized chunks, use `overlap_all`.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`overlap_all`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`overlap_all`: Applies overlap to chunks formed from whole elements as well as those formed by text-splitting oversized elements. The overlap length is taken from the `overlap` value.

--- a/snippets/ingest-configuration-shared/embedding-configuration.mdx
+++ b/snippets/ingest-configuration-shared/embedding-configuration.mdx
@@ -2,26 +2,41 @@ A common embedding configuration is a critical component that allows for dynamic
 
 ## Configs
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`api_key`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`api_key`: The API key to use, if one is required to generate the embeddings through an API service, such as OpenAI.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_access_key_id`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_access_key_id`: The AWS access key ID to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_region`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_region`: The AWS Region ID to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_secret_access_key`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_secret_access_key`: The AWS secret access key to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_provider`: The Unstructured embedding provider to use while doing embedding. Available values include `langchain-openai`, `langchain-huggingface`, and `langchain-aws-bedrock`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_provider`: The embedding provider to use while doing embedding. Available values include `langchain-openai`, `langchain-huggingface`, `langchain-aws-bedrock`, `langchain-vertexai`, `langchain-voyageai`, and `octoai`.
     
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_api_key`: The API key to use, if one is required to generate the embeddings through an API service, such as OpenAI.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_access_key_id`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_access_key_id`: The AWS access key ID to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_region`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_region`: The AWS Region ID to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_secret_access_key`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_aws_secret_access_key`: The AWS secret access key to be used for AWS-based embedders, such as Amazon Bedrock.
     
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_model_name`: The specific model to use for the embedding provider, if necessary.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`model_name`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`model_name`: The specific model to use for the embedding provider, if necessary.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`provider`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`provider`: The embedding provider to use while doing embedding. Available values include `langchain-openai`, `langchain-huggingface`, `langchain-aws-bedrock`, `langchain-vertexai`, `langchain-voyageai`, and `octoai`.
+
+
+<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;The default `model_name` values unless otherwise specified are:
+
+* `langchain-openai`: `text-embedding-ada-002`
+
+* `langchain-huggingface`: `sentence-transformers/all-MiniLM-L6-v2`
+
+* `langchain-aws-bedrock`: None
+
+* `langchain-vertexai`: `textembedding-gecko@001`
+
+* `langchain-voyageai`: None
+
+* `octoai`: `thenlper/gte-large`

--- a/snippets/ingest-configuration-shared/fsspec-configuration.mdx
+++ b/snippets/ingest-configuration-shared/fsspec-configuration.mdx
@@ -14,6 +14,8 @@ Fsspec configuration is an extension of the File Storage Config:
 
 The following are configurations set on the fsspec config itself:
 
+*
+
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`access_config`: A dictionary of access keyword arguments (`kwargs`) that might be needed to provide access to the cloud provider associated with the data.
 
 The following are generated for the user after the config is initialized: 

--- a/snippets/ingest-configuration-shared/overview.mdx
+++ b/snippets/ingest-configuration-shared/overview.mdx
@@ -1,20 +1,18 @@
 
 
-The configurations listed in this section are common to all source connectors.
+The configurations listed in this section are common to all connectors.
 These configurations act as instructions for how to collect, process, and store data.
-If you're looking for parameters specific to a source connector type (such as authentication options), see the
-corresponding source connector's documentation.
 
-Configurations are available for v2 and v1 versions of source connctors, where available. 
+Some connectors implement only version 2 (v2) of the connector specification; some connectors implement only version 1 (v1); and some connectors provide both v2 and v1 implementations.
 
-*   Congigurations that apply to both v2 and v1 are prefaced by <Icon icon="v"/><Icon icon="2"/>, <Icon icon="v"/><Icon icon="1"/>.
+*   Connectors that implement both v2 and v1 are prefaced by <Icon icon="v"/><Icon icon="2"/>, <Icon icon="v"/><Icon icon="1"/>.
 
-*   v2-only configurations are prefaced by <Icon icon="v"/><Icon icon="2"/>.
+*   v2-only implementations are prefaced by <Icon icon="v"/><Icon icon="2"/>.
 
-*   v1-only configurations are prefaced by <Icon icon="v"/><Icon icon="1"/>.
+*   v1-only implementations are prefaced by <Icon icon="v"/><Icon icon="1"/>.
 
-If you're looking for parameters specific to a source connector type (such as authentication options)&mdash;or to determine whether a source connector supports v2 configurations, v1 configurations, or both&mdash;see the
-corresponding source connector's documentation:
+If you're looking for parameters specific to a connector (such as authentication options)&mdash;or to determine whether a connector provides a v2 implementation, a v1 implementation, or both&mdash;browse the
+corresponding connector's source code:
 
 - [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors)
 - [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors/fsspec)

--- a/snippets/ingest-configuration-shared/overview.mdx
+++ b/snippets/ingest-configuration-shared/overview.mdx
@@ -1,6 +1,23 @@
 
 
-The configurations listed in this section are common for all source connectors.
+The configurations listed in this section are common to all source connectors.
 These configurations act as instructions for how to collect, process, and store data.
-If you're looking for parameters specific to a source connector type (e.g. authentication options), please refer to the
+If you're looking for parameters specific to a source connector type (such as authentication options), see the
 corresponding source connector's documentation.
+
+Configurations are available for v2 and v1 versions of source connctors, where available. 
+
+*   Congigurations that apply to both v2 and v1 are prefaced by <Icon icon="v"/><Icon icon="2"/>, <Icon icon="v"/><Icon icon="1"/>.
+
+*   v2-only configurations are prefaced by <Icon icon="v"/><Icon icon="2"/>.
+
+*   v1-only configurations are prefaced by <Icon icon="v"/><Icon icon="1"/>.
+
+If you're looking for parameters specific to a source connector type (such as authentication options)&mdash;or to determine whether a source connector supports v2 configurations, v1 configurations, or both&mdash;see the
+corresponding source connector's documentation:
+
+- [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors)
+- [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors/fsspec)
+- [v1 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector)
+- [v1 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/fsspec)
+- [v1 Notion connector](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/notion)

--- a/snippets/ingest-configuration-shared/partition-configuration.mdx
+++ b/snippets/ingest-configuration-shared/partition-configuration.mdx
@@ -6,7 +6,7 @@ A standard partition configuration is a collection of parameters designed to ove
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`encoding`: The encoding method used to decode the text input. If None, utf-8 will be used.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`ocr_languages`: The languages present in the document, for use in partitioning, OCR, or both. For partitioning image or PDF documents with Tesseract, you must first install the appropriate Tesseract language pack if running with the Unstructured open source library. For other partitions, the language is detected by using a naive Bayesian filter with langdetect. Multiple languages indicate that the text could be in any of the specified languages.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`ocr_languages`: The languages present in the document, for use in partitioning, OCR, or both. Multiple languages indicate that the text could be in any of the specified languages.
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`pdf_infer_table_structure`: <Icon icon="ban"/>&nbsp;&nbsp;**Deprecated!** Use `skip_infer_table_types` to opt out of table extraction for any file type. If `False` and `strategy=hi_res`, no `Table` elements will be extracted from PDF files regardless of `skip_infer_table_types` contents.
 

--- a/snippets/ingest-configuration-shared/partition-configuration.mdx
+++ b/snippets/ingest-configuration-shared/partition-configuration.mdx
@@ -2,7 +2,7 @@ A standard partition configuration is a collection of parameters designed to ove
 
 ## Configs for Partitioning
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`additional_partition_args`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`additional_partition_args`: A JSON string representation of any values to pass through to the `partition` function.
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`encoding`: The encoding method used to decode the text input. If None, utf-8 will be used.
 
@@ -22,7 +22,7 @@ A standard partition configuration is a collection of parameters designed to ove
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`flatten_metadata`: Default: `False`. If set to `True`, the hierarchical metadata structure is flattened to have all values exist at the top level.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`hi_res_model_name`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`hi_res_model_name`: The model to use when `strategy` is set to `hi_res`. Available values are `layout_v1.0.0` (the default) and `yolox`.
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;,<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`metadata_exclude`: Values from the `metadata` field to exclude from the output.
 

--- a/snippets/ingest-configuration-shared/permissions-configuration.mdx
+++ b/snippets/ingest-configuration-shared/permissions-configuration.mdx
@@ -1,10 +1,10 @@
 
-A common permissions configuration is leveraged to extract user access data associated with the content from the source data provider. Currently supported for the Sharepoint connector.
+A common permissions configuration is leveraged to extract user access data associated with the content from the source data provider. Currently supported for only the SharePoint connector.
 
 ## Configs
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`application_id`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`application_id`: The SharePoint application client ID.
     
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`client_cred`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`client_cred`: The SharePoint application client secret.
     
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`tenant`
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`tenant`: The SharePoint tenant ID.

--- a/snippets/ingest-configuration-shared/processor-configuration.mdx
+++ b/snippets/ingest-configuration-shared/processor-configuration.mdx
@@ -4,29 +4,27 @@ A common process configuration plays a pivotal role in overseeing the entire ing
 
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`disable_parallelism`: `True` if the `INGEST_DISABLE_PARALLELISM` environment variable is set to `true` (case-insensitive), otherwise `False` (the default).
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`download_only`: Default: `False`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`download_only`: Default: `False`. If set to `True`, downloads any files that are not already present in the connector's specified download directory (`download_dir`), or `work_dir` if `download_dir` is not specified, or the default file path for `work_dir` if `work_dir` is not specified.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`max_connections`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`max_connections`: The maximum of connections allowed when running an asynchronous step in the ingest pipeline.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`max_docs`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`max_docs`: The maximum number of documents to process.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`num_processes`: Default: `2`. For every step that can use a pool of workers to increase throughput, how many workers to configure in the pool.
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`output_dir`: Where the final results will be located when the process is finished. This is regardless of whether a destination is configured. If a directory is not specified, by default a folder named `structured-output`, relative to the current working directory, is used.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`preserve_downloads`: Default: `False`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`preserve_downloads`: `False` (the default) to remove downloaded files after they are successfully processed.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`raise_on_error`: `False `(default) for any single document that fails in the process, causes the error to be logged but allows for all other documents to proceed in the process. If `True`, causes the entire process to fail and raise the error if any one document fails.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`re_download`: Default: `False`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`re_download`: `False` (the default) to not re-download files if they are already present in the download directory.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`reprocess`: Default: `False`. If set to `True`, will ignore all content that may have been cached and rerun each step.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`status`
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`tqdm`: `False` (the default) to not show a progress bar.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`tqdm`: Default `False`.
-
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`uncompress`: Default `False`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`uncompress`: `False` (the default) to not uncompress any archived ZIP or TAR files.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`verbose`: Default: `False`. If set to `True`, debug logging should be included in the output.
 

--- a/snippets/ingest-configuration-shared/processor-configuration.mdx
+++ b/snippets/ingest-configuration-shared/processor-configuration.mdx
@@ -14,17 +14,17 @@ A common process configuration plays a pivotal role in overseeing the entire ing
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`output_dir`: Where the final results will be located when the process is finished. This is regardless of whether a destination is configured. If a directory is not specified, by default a folder named `structured-output`, relative to the current working directory, is used.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`preserve_downloads`: `False` (the default) to remove downloaded files after they are successfully processed.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`preserve_downloads`: When set to `False` (the default), will remove downloaded files after they are successfully processed.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`raise_on_error`: `False `(default) for any single document that fails in the process, causes the error to be logged but allows for all other documents to proceed in the process. If `True`, causes the entire process to fail and raise the error if any one document fails.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`re_download`: `False` (the default) to not re-download files if they are already present in the download directory.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`re_download`: When set to `False` (the default), will not re-download files if they are already present in the download directory.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`reprocess`: Default: `False`. If set to `True`, will ignore all content that may have been cached and rerun each step.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`tqdm`: `False` (the default) to not show a progress bar.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`tqdm`: When set to `False` (the default), will not show a progress bar.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`uncompress`: `False` (the default) to not uncompress any archived ZIP or TAR files.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`uncompress`: When set to `False` (the default), will not uncompress any archived ZIP or TAR files.
 
 *   <Icon icon="v"/><Icon icon="2"/>,&nbsp;<Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`verbose`: Default: `False`. If set to `True`, debug logging should be included in the output.
 


### PR DESCRIPTION
See: 

- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/overview
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/processor-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/read-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/partition-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/permissions-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/retry-strategy-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/chunking-configuration (still missing `chunk_by_api`, `chunk_by_api`, and `chunking_endpoint`, but didn't want to hold up the rest of this PR for it)
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/embedding-configuration
- https://unstructured-53-docs-37-ingest-configs.mintlify.app/api-reference/ingest/ingest-configuration/fsspec-configuration

