### PR TITLE
Reduce sizes of notes in introductory content, more clarity on single/multi-file options, etc.

### DIFF
--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -3,6 +3,8 @@ title: Free Unstructured API
 description: This page describes how to obtain an API key to use with the free Unstructured API, the limitations of the free Unstructured API, and provides a quickstart example.
 ---
 
+<Info>The Free Unstructured API is different than the free 14-day trial for the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide).</Info>
+
 ## Get an API key
 
 The Free Unstructured API requires authentication via an API key. Here's how you can obtain your API key:
@@ -35,8 +37,13 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-Let's say you want to preprocess an `*.eml` file using the free Unstructured API. There are several ways
-you can do this, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-ingest-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-unstructured-api-from-the-unstructured-open-source-library).
+These examples use your local machine. They preprocess a single-file source (input) file on your local machine, and the Free Unstructured API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
+
+<Info>
+    These examples work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
+</Info> 
+
+There are several ways to use the Free Serverless API, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-ingest-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-free-unstructured-api-from-the-unstructured-open-source-library).
 
 ### POST request
 
@@ -63,17 +70,13 @@ After the command successfully runs, see the results in the specified output pat
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-<Info>`POST` requests support using only local machine paths as the source (input) for the file to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
-
-import SharedPOSTSingleFile from '/snippets/general-shared-text/post-api-single-file.mdx';
-
-<SharedPOSTSingleFile />
-
 [Learn more about how to use POST requests](/api-reference/api-services/post-requests).
 
 ### Unstructured Ingest CLI
 
-To work with the Free Unstructured API by using the Unstructured Ingest CLI, you will need to:
+<Info>Although this example works with only a single file at a time and only with local source and destination locations, the Unstructured Ingest CLI works with multiple files at a time and with non-local source and destination locations. [Learn more](/ingestion/overview#unstructured-ingest-cli).</Info>
+
+To work with the Free Unstructured API by using the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you will need to:
 
 - Install Python, and then install the CLI package:
 
@@ -86,14 +89,14 @@ To work with the Free Unstructured API by using the Unstructured Ingest CLI, you
 
 Now, use the CLI to call the API, replacing:
 
-- `<local/path/to/input/files>` with the path to the source (input) files on your local machine.
+- `<local/path/to/input/files>` with the path to the source (input) file on your local machine.
 - `<local/path/to/output/files>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash CLI
 unstructured-ingest \
   local \
-    --input-path <local/path/to/input/files> \
-    --output-dir <local/path/to/output/files> \
+    --input-path <local/path/to/input/file> \
+    --output-dir <local/path/to/output/file> \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
     --partition-endpoint $UNSTRUCTURED_API_URL
@@ -103,17 +106,11 @@ After the command successfully runs, see the results in the specified output pat
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-To learn more about how to use the `local` command, run the command `unstructured-ingest local --help`.
-
-To use source and destination locations outside of your local machine, see the documentation for the available [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
-
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
 To work with the Free Unstructured API in Python or JavaScript, use the
-Unstructured [Python SDK](https://github.com/Unstructured-IO/unstructured-python-client), or
-[JavaScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
-
-<Info>The JavaScript/TypeScript SDK supports using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
+[Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or the
+[Unstructured JavaScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
 
 <CodeGroup>
 ```bash Python
@@ -229,15 +226,11 @@ client.general.partition({
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-import SharedAPISingleFile from '/snippets/general-shared-text/multi-file-api-use-connectors.mdx';
-
-<SharedAPISingleFile />
-
 Learn more about how to use the ]Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
 
-### Calling the Unstructured API from the Unstructured open source library
+### Calling the Free Unstructured API from the Unstructured open source library
 
-You can call the Unstructured Serverless API directly from the Unstructured open source library. Unstructured recommends this approach only for rapid local script or code prototyping or simple proofs-of-concept, not for production scenarios:
+You can call the Free Unstructured API directly from the Unstructured open source library. Unstructured recommends this approach only for rapid local script or code prototyping or simple proofs-of-concept, not for production scenarios.
 
 You will need to: 
 
@@ -281,10 +274,6 @@ with open(output_filepath, "w") as file:
 ```
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-import SharedPartitionViaAPISingleFile from '/snippets/general-shared-text/multi-file-partition-via-api.mdx';
-
-<SharedPartitionViaAPISingleFile />
 
 [Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
 

--- a/api-reference/api-services/overview.mdx
+++ b/api-reference/api-services/overview.mdx
@@ -1,9 +1,9 @@
 ---
-title: Unstructured Serverless API Services
+title: Unstructured Serverless API services
 sidebarTitle: Overview
 ---
 
-Unstructured Serverless API Services include these offerings:
+Unstructured Serverless API services include these offerings:
 
 <CardGroup cols={2}>
     <Card title="Unstructured Serverless API" icon="computer" href="/api-reference/api-services/saas-api-development-guide">
@@ -28,21 +28,21 @@ Unstructured Serverless API Services include these offerings:
 
 <Icon icon="blog" />&nbsp;&nbsp;[Read the launch announcement](https://unstructured.io/blog/introducing-unstructured-serverless-api).
 
-## Supported File Types
+## Supported file types
 
-The Unstructured API supports the same file types as the [Unstructured open source library](/open-source/introduction/overview).
-However, the Unstructured Serverless API Services include more powerful file transformation capabilities,
+Unstructured API services support the same file types as the [Unstructured open source library](/open-source/introduction/overview).
+However, Unstructured API services include more powerful file transformation capabilities,
 such as a more accurate table extraction model.
 
-|Category  |File Types                                                    |
+|Category  |File types                                                    |
 |----------|--------------------------------------------------------------|
 |Plaintext |.eml, .html, .md, .msg, .rst, .rtf, .txt, .xml                |
 |Images    |.png, .jpg, .jpeg, .tiff, .bmp, .heic                         |
 |Documents |.csv, .doc, .docx, .epub, .odt, .pdf, .ppt, .pptx, .tsv, .xlsx|
 
-## Data Ingestion
+## Data ingestion
 
-Unstructured Serverless API Services support ingesting data from various sources. [Learn how](/api-reference/ingest/source-connectors/overview).
+Unstructured Serverless API services support ingesting data from various sources. [Learn how](/ingestion/overview).
 
 ## Billing
 
@@ -50,6 +50,6 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 <SharedPagesBilling />
 
-## Get Support
+## Get support
 
 Should you require any assistance or have any questions regarding the Unstructured API, please contact our support team at [support@unstructured.io](mailto:support%40unstructured.io).

--- a/api-reference/api-services/partition-via-api.mdx
+++ b/api-reference/api-services/partition-via-api.mdx
@@ -6,7 +6,11 @@ sidebarTitle: Open source Python library
 If you're used to working the [Unstructured open source library](https://github.com/Unstructured-IO/unstructured) but
 would like to leverage the advanced capabilities of Unstructured API services, you can do so without leaving your familiarity with the open source library. 
 Whether you're using the Free Unstructured API, the Unstructured Serverless API,
-the Unstructured API on Azure/AWS, or your local deployment of the Unstructured API, you can use the open source library to send an individual file through `partition_via_api` for processing with Unstructured API services. You'll also need:
+the Unstructured API on Azure/AWS, or your local deployment of the Unstructured API, you can use the open source library to send an individual file through `partition_via_api` for processing with Unstructured API services.
+
+<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+
+To use the open source library, you'll also need:
 
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
@@ -19,7 +23,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 ## Installation
 
 Make sure you have the Unstructured open source library installed.
-Refer to the [Unstructured Open Source library quickstart guide](/open-source/introduction/quick-start) for instructions.
+Refer to the [Unstructured open source library quickstart guide](/open-source/introduction/quick-start) for instructions.
 
 ## Basics
 
@@ -52,10 +56,6 @@ with open("example-docs/eml/fake-email-output.json", "w") as file:
 When sending a request to the Free Unstructured API, you only need to provide your individual API key.
 When sending requests to the Unstructured Serverless API, you need to supply your unique API URL in addition to your API key.
 For Unstructured API on Azure/AWS, use the API URL that you configured through those services.
-
-import SharedPartitionViaAPISingleFile from '/snippets/general-shared-text/multi-file-partition-via-api.mdx';
-
-<SharedPartitionViaAPISingleFile />
 
 ## Parameters & examples
 

--- a/api-reference/api-services/post-requests.mdx
+++ b/api-reference/api-services/post-requests.mdx
@@ -4,7 +4,11 @@ sidebarTitle: POST request
 ---
 
 Whether you're using the free Unstructured API, the Unstructured Serverless API, Unstructured API on Azure/AWS, or your local
-deployment of Unstructured API, you can work with the API by sending POST requests to it. You will need:
+deployment of Unstructured API, you can work with the API by sending single-file POST requests to it. 
+
+<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+
+To make POST requests, you will need:
 
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
@@ -30,10 +34,6 @@ your individual API Key, represented by the environment variable `UNSTRUCTURED_A
 If you are using the Unstructured Serverless API, you need to replace the URL in this example with the unique API URL that you have
 received in the same email as your API key. For Unstructured API on Azure/AWS, use the API URL that you
 configured through those services.
-
-import SharedPOSTSingleFile from '/snippets/general-shared-text/post-api-single-file.mdx';
-
-<SharedPOSTSingleFile />
 
 ## Parameters & examples
 

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -41,7 +41,11 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-The following example illustrates how to preprocess an `*.eml` file using the Unstructured Serverless API.
+These examples use your local machine. They preprocess a single-file source (input) file on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
+
+<Info>
+    These examples work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
+</Info>
 
 There are several ways to use the Unstructured Serverless API, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-ingest-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-unstructured-api-from-the-unstructured-open-source-library).
 
@@ -72,17 +76,13 @@ After the command successfully runs, see the results in the specified output pat
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-<Info>`POST` requests support using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
-
-import SharedPOSTSingleFile from '/snippets/general-shared-text/post-api-single-file.mdx';
-
-<SharedPOSTSingleFile />
-
 [Learn more about how to use POST requests](/api-reference/api-services/post-requests).
 
 ### Unstructured Ingest CLI
 
-To work with the Unstructured Serverless API by using the Unstructured Ingest CLI, you will need to:
+<Info>Although this example works with only a single file at a time and only with local source and destination locations, the Unstructured Ingest CLI works with multiple files at a time and with non-local source and destination locations. [Learn more](/ingestion/overview#unstructured-ingest-cli).</Info>
+
+To work with the Unstructured Serverless API by using the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you will need to:
 
 - Install Python, and then install the CLI package:
 
@@ -99,14 +99,14 @@ To work with the Unstructured Serverless API by using the Unstructured Ingest CL
 
 Now, use the CLI to call the API, replacing:
 
-- `<local/path/to/input/files>` with the path to the source (input) files on your local machine.
+- `<local/path/to/input/files>` with the path to the source (input) file on your local machine.
 - `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
 
 ```bash CLI
 unstructured-ingest \
   local \
-    --input-path <local/path/to/input/files> \
-    --output-dir <local/path/to/output/files> \
+    --input-path <local/path/to/input/file> \
+    --output-dir <local/path/to/output/file> \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
     --partition-endpoint $UNSTRUCTURED_API_URL
@@ -116,17 +116,11 @@ After the command successfully runs, see the results in the specified output pat
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-To learn more about how to use the `local` command, run the command `unstructured-ingest local --help`.
-
-To use source and destination locations outside of your local machine, see the documentation for the available [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
-
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
 To work with the Unstructured Serverless API in Python, JavaScript, or TypeScript, use the
-Unstructured [Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or
-[JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
-
-<Info>The JavaScript/TypeScript SDK supports using only local machine paths as the source (input) for the files to preprocess and as the destination (output) that Unstructured sends the processed data to. To specify a source or destination other than a local machine, use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
+[Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or the 
+[Unstructured JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
 
 First, install your preferred SDK:
 <CodeGroup>
@@ -249,11 +243,7 @@ After the code successfully runs, see the results in the specified output path o
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-import SharedAPISingleFile from '/snippets/general-shared-text/multi-file-api-use-connectors.mdx';
-
-<SharedAPISingleFile />
-
-[Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
+Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and the [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
 
 ### Calling the Unstructured API from the Unstructured open source library
 
@@ -301,10 +291,6 @@ with open(output_filepath, "w") as file:
 After the code successfully runs, see the results in the specified output path on your local machine.
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-import SharedPartitionViaAPISingleFile from '/snippets/general-shared-text/multi-file-partition-via-api.mdx';
-
-<SharedPartitionViaAPISingleFile />
 
 [Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
 

--- a/api-reference/api-services/sdk-jsts.mdx
+++ b/api-reference/api-services/sdk-jsts.mdx
@@ -5,7 +5,11 @@ sidebarTitle: JavaScript/TypeScript SDK
 
 The [Unstructured JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client) client allows you to send an individual file for processing by Unstructured API services. Whether you're using the
 Free Unstructured API, the Unstructured Serverless API, the Unstructured API on Azure/AWS, or your local
-deployment of the Unstructured API, you can access the API using the JavaScript/TypeScript SDK. You'll need:
+deployment of the Unstructured API, you can access the API using the JavaScript/TypeScript SDK. 
+
+<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+
+To use the JavaScript/TypeScript SDK, you'll need:
 
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 

--- a/api-reference/api-services/sdk-python.mdx
+++ b/api-reference/api-services/sdk-python.mdx
@@ -5,7 +5,11 @@ sidebarTitle: Python SDK
 
 The [Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) client allows you to send an individual file for processing by Unstructured API services. Whether you're using the
 Free Unstructured API, the Unstructured Serverless API, the Unstructured API on Azure/AWS, or your local
-deployment of the Unstructured API, you can access the API using the Python SDK. You'll need:
+deployment of the Unstructured API, you can access the API using the Python SDK. 
+
+<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+
+To use the Python SDK, you'll need:
 
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
@@ -116,10 +120,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         print(e)
     ```
     </CodeGroup>
-
-    import SharedAPISingleFile from '/snippets/general-shared-text/multi-file-api-use-connectors.mdx';
-
-    <SharedAPISingleFile />
 
 ## Page splitting
 

--- a/api-reference/ingest/python-ingest.mdx
+++ b/api-reference/ingest/python-ingest.mdx
@@ -15,7 +15,7 @@ pip install unstructured
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
-For additional installation options and dependencies, and information about v2 and v1 implementations in this library, see [Unstructed Ingest Python](/ingestion/overview#unstructured-ingest-python) in the [Ingest](/ingestion/overview) section.
+For additional installation options and dependencies, and information about v2 and v1 implementations in this library, see the [Unstructed Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) in the [Ingest](/ingestion/overview) section.
 
 ## Usage
 

--- a/ingestion/overview.mdx
+++ b/ingestion/overview.mdx
@@ -13,7 +13,7 @@ You can perform ingestion with the following tools:
 - The [Unstructured Ingest Python library](#unstructured-ingest-python-library), with unlimited pay-as-you-go and limited free options, that enable you to use Python code to get all of your data ready for RAG and model fine-tuning.
 
 <Info>
-    The [Unstructured Python SDK](/api-reference/api-services/sdk-python) and Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts) can process only one file at a time.
+    The [Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts) can process only one file at a time.
 </Info>
 
 Files are ingested from an originating *source* location. Each batch of ingested files is processed either [all by Unstructured](#ingestion-options-for-the-unstructured-service) or [all locally](#local-ingestion-options). The processed data is sent to a target *destination* location. The kinds of locations you can specify varies:

--- a/open-source/introduction/overview.mdx
+++ b/open-source/introduction/overview.mdx
@@ -3,7 +3,7 @@ title: Unstructured Open Source
 sidebarTitle: Overview
 ---
 
-<Note>The `unstructured` open source library is designed as a starting point for quick prototyping and has [limits](#limits). For production scenarios, see [Unstructured API Services](/api-reference/api-services/overview) and [Unstructured Platform](/platform/overview).</Note>
+<Note>The `unstructured` open source library is designed as a starting point for quick prototyping and has [limits](#limits). For production scenarios, see [Unstructured API services](/api-reference/api-services/overview) and [Unstructured Platform](/platform/overview).</Note>
 
 The `unstructured` [library](https://github.com/Unstructured-IO/unstructured) offers an open-source toolkit
 designed to simplify the ingestion and pre-processing of diverse data formats, including images and text-based documents
@@ -46,7 +46,7 @@ and use cases.
 
 ## Limits
 
-The open source library has the following limits as compared to [Unstructured API Services](/api-reference/api-services/overview) and the [Unstructured Platform](/platform/overview):
+The open source library has the following limits as compared to [Unstructured API services](/api-reference/api-services/overview) and the [Unstructured Platform](/platform/overview):
 
 * Not designed for production scenarios.
 * Significantly decreased performance on document and table extraction.

--- a/snippets/concepts/document-elements.mdx
+++ b/snippets/concepts/document-elements.mdx
@@ -20,7 +20,7 @@ Here's an example of what an element might look like:
   'languages': ['eng'],
   'parent_id': '56f24319ae258b735cac3ec2a271b1d9',
   'file_directory': '/content',
-  'filename': 'Unstructured API Services - Unstructured.html',
+  'filename': 'Unstructured API services - Unstructured.html',
   'filetype': 'text/html'}}
 ```
 

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -9,7 +9,7 @@ description: "Unstructured provides a platform and tools to ingest and process u
 Unstructured offers three products:
 
 <Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="computer" />&nbsp;&nbsp;[Unstructured Platform](/platform/overview) - No-code UI. Production-ready. Pay as you go.<br/><br/>
-<Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="square-terminal" />&nbsp;&nbsp;[Unstructured Serverless API Services](/api-reference/api-services/overview) - Use scripts or code. Production-ready. Pay as you go. (There is also a non-production, free edition with [limits](/api-reference/api-services/free-api#free-unstructured-api-limitations).)<br/><br/>
+<Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="square-terminal" />&nbsp;&nbsp;[Unstructured Serverless API services](/api-reference/api-services/overview) - Use scripts or code. Production-ready. Pay as you go. (There is also a non-production, free edition with [limits](/api-reference/api-services/free-api#free-unstructured-api-limitations).)<br/><br/>
 <Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="door-open" />&nbsp;&nbsp;[Unstructured open source library](/open-source/introduction/overview/) - Use scripts or code. Not production-ready. [Limited](/open-source/introduction/overview#limits).
 
 Learn more about these products:
@@ -21,9 +21,9 @@ Learn more about these products:
   [Learn more](/platform/overview).<br/><br/>
   <Icon icon="blog"/>&nbsp;&nbsp;[Read the announcement](https://unstructured.io/blog/introducing-unstructured-platform).
 </Card>
-<Card title="Unstructured Serverless API Services" icon="square-terminal" href="/api-reference/api-services/overview">
-  <br/>Use scripts or code to call the Unstructured Ingest CLI, SDKs, or REST API to get all of your data RAG-ready.<br/><br/>
-  Unstructured Serverless API Services have a [Serverless](api-reference/api-services/saas-api-development-guide) pay-as-you-go edition and a [Free](/api-reference/api-services/free-api_) [limited](/api-reference/api-services/free-api#free-unstructured-api-limitations) edition that process data on Unstructured-hosted compute resources.<br/><br/>
+<Card title="Unstructured Serverless API services" icon="square-terminal" href="/api-reference/api-services/overview">
+  <br/>Use scripts or code to call the Unstructured Ingest CLI or Ingest Python library, the Unstructured Python or JavaScript/TypeScript SDKs, or with a direct POST request to the Unstructured API, to get all of your data RAG-ready.<br/><br/>
+  Unstructured Serverless API services have a [Serverless](api-reference/api-services/saas-api-development-guide) pay-as-you-go edition and a [Free](/api-reference/api-services/free-api_) [limited](/api-reference/api-services/free-api#free-unstructured-api-limitations) edition that process data on Unstructured-hosted compute resources.<br/><br/>
   If you need to use compute resources that you host instead, there are also [Azure](/api-reference/api-services/azure) pay-as-you-go and [AWS](/api-reference/api-services/aws) pay-as-you-go editions; these editions process data by using the Unstructured API installed on compute resources hosted in your own Azure or AWS account.<br/><br/>
   [Try the quickstart](#quickstart-unstructured-api-service).<br/><br/>
   [Learn more](/api-reference/api-services/overview).<br/><br/>
@@ -40,7 +40,7 @@ Learn more about these products:
 
 ### <Icon icon="computer" />   Quickstart: Unstructured Platform
 
-<Info>If you want to use your local machine for either the source (input) or the destination (output) location, you cannot use this quickstart. You must run scripts on your local machine instead: skip to the [Quickstart: Unstructured Serverless API Services](#quickstart-unstructured-api-service) or [Quickstart: Unstructured open source library](#quickstart-unstructured-open-source-library), later in this article.</Info>
+<Info>If you want to use your local machine for either your source (input) files, or the destination (output) location for Unstructured to deliver the processed data, you cannot use this quickstart. You must run code on your local machine instead: skip to the [Quickstart: Unstructured Serverless API services](#quickstart-unstructured-api-service) or [Quickstart: Unstructured open source library](#quickstart-unstructured-open-source-library), later in this article.</Info>
 
 import SharedPlatform from '/snippets/quickstarts/platform.mdx';
 
@@ -52,9 +52,13 @@ import SharedPlatform from '/snippets/quickstarts/platform.mdx';
 
 ### <Icon icon="square-terminal" />   Quickstart: Unstructured API service
 
-This quickstart uses your local machine for the source (input) and destination (output) locations, and the [Unstructured Python SDK](/api-reference/api-services/sdk). Data is processed on Unstructured-hosted compute resources.
+This quickstart uses your local machine, with the [Unstructured Python SDK](/api-reference/api-services/sdk) installed. It preprocess a single-file source (input) file on your local machine, and it uses the Free Unstructured API to deliver the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
-<Info>The Free Unstructured API has [limits](/api-reference/api-services/free-api#free-unstructured-api-limitations). To remove these limits, sign up for the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide).</Info>
+<Info>
+    The Free Unstructured API has [limits](/api-reference/api-services/free-api#free-unstructured-api-limitations). To remove these limits, sign up for the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide).
+    
+    The Unstructured Python SDK (and the Unstructured JavaScript/TypeScript SDK) work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
+</Info>
 
 You will need:
 
@@ -126,9 +130,7 @@ You will need:
         except Exception as e:
             print(e)
         ```
-
-        <Info>The Python SDK works with only a single file. To process multiple files at a time, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
-    </Step>
+        </Step>
     <Step title="View the processed data">
         Go to your destination location to view the processed data.
     </Step>
@@ -140,9 +142,13 @@ You will need:
 
 ### <Icon icon="door-open" />   Quickstart: Unstructured open source library
 
-This quickstart uses your local machine for the source (input) and destination (output) locations and for local data processing. It does not call Unstructured Serverless API Services.
+This quickstart uses your local machine for a single-file source (input) location, and a destination (output) location for the processed data. This quickstart also uses local data processing. It does not call Unstructured Serverless API services.
 
-<Info>The open source library is [limited](/open-source/introduction/overview#limits) compared to the [Unstructured Platform](/platform/overview) and the [Unstructured Serverless API](/api-reference/api-services/overview).</Info>
+<Info>
+    The open source library is [limited](/open-source/introduction/overview#limits) compared to the [Unstructured Platform](/platform/overview) and [Unstructured Serverless API services](/api-reference/api-services/overview).
+    
+    The open source library is designed primarily to work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.    
+</Info>
 
 You will need:
 
@@ -184,8 +190,6 @@ You will need:
         with open(output_filepath, "w") as file:
             file.write(json_elements)
         ```
-
-        <Info>To process multiple files at a time, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.</Info>
     </Step>
     <Step title="View the processed data">
         Go to your destination location to view the processed data.


### PR DESCRIPTION
The sizes of notes were starting to get a bit large, especially in the introductory content. This PR seeks to reduce that a bit to make for a bit cleaner and less intimidating experience.

Also, for customers who might "parachute" directly into the single-file how-to docs, added broef notes/links to where to go find out about multi-file options. 

Docs with the most updates here:

- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/saas-api-development-guide
- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/free-api
- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/sdk-python
- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/sdk-jsts
- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/post-requests
- https://unstructured-53-naming-cleanup-2024-07-31.mintlify.app/api-reference/api-services/partition-via-api 

