### PR TITLE
MongoDB v2 destination connector (no v2 source connector available yet)

### DIFF
--- a/api-reference/ingest/destination-connector/mongodb.mdx
+++ b/api-reference/ingest/destination-connector/mongodb.mdx
@@ -2,6 +2,29 @@
 title: MongoDB
 ---
 
-import SharedMongoDB from '/snippets/dc-shared-text/mongodb.mdx';
+import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
-<SharedMongoDB />
+<NewDocument />
+
+import SharedContentMongoDB from '/snippets/dc-shared-text/mongodb.mdx';
+import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
+
+<SharedContentMongoDB/>
+<SharedAPIKeyURL/>
+
+Now call the Unstructured Ingest CLI or the Unstructured Ingest Python library. The source connector can be any of the ones supported. This example uses the local source connector:
+
+import MongoDBAPISh from '/snippets/destination_connectors/mongodb.sh.mdx';
+import MongoDBAPIPyV2 from '/snippets/destination_connectors/mongodb.v2.py.mdx';
+import MongoDBAPIPyV1 from '/snippets/destination_connectors/mongodb.v1.py.mdx';
+
+<CodeGroup>
+
+  <MongoDBAPISh />
+
+  <MongoDBAPIPyV2 />
+
+  <MongoDBAPIPyV1 />
+
+</CodeGroup>
+

--- a/api-reference/ingest/source-connectors/mongodb.mdx
+++ b/api-reference/ingest/source-connectors/mongodb.mdx
@@ -2,60 +2,25 @@
 title: MongoDB
 ---
 
+import NewDocument from '/snippets/general-shared-text/new-document.mdx';
+
+<NewDocument />
+
 import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb.mdx';
+import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentMongoDB/>
+<SharedAPIKeyURL/>
 
-Make sure to set the `--partition-by-api` flag and pass in your API key with `--api-key`:
+Now call the Unstructured Ingest CLI or the Unstructured Ingest Python library. The destination connector can be any of the ones supported. This example uses the local destination connector:
+
+import MongoDBAPISh from '/snippets/source_connectors/mongodb.sh.mdx';
+import MongoDBAPIPyV1 from '/snippets/source_connectors/mongodb.v1.py.mdx';
 
 <CodeGroup>
-```bash Shell
-#!/usr/bin/env bash
 
-unstructured-ingest \
-  mongodb \
-  --metadata-exclude filename,file_directory,metadata.data_source.date_processed \
-  --uri "$MONGODB_URI" \
-  --database "$MONGODB_DATABASE" \
-  --collection "$MONGODB_COLLECTION" \
-  --output-dir mongodb-ingest-output \
-  --num-processes 2 \
-  --partition-by-api \
-  --api-key "$UNSTRUCTURED_API_KEY"
-```
+  <MongoDBAPISh />
 
-```python Python
-import os
-
-from unstructured.ingest.connector.mongodb import (
-    SimpleMongoDBConfig,
-)
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import MongoDBRunner
-
-if __name__ == "__main__":
-    runner = MongoDBRunner(
-        processor_config=ProcessorConfig(
-            verbose=True,
-            output_dir="mongodb-ingest-output",
-            num_processes=2,
-        ),
-        read_config=ReadConfig(),
-        partition_config=PartitionConfig(
-            metadata_exclude=["filename", "file_directory", "metadata.data_source.date_processed"],
-            partition_by_api=True,
-            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
-        ),
-        connector_config=SimpleMongoDBConfig(
-            uri=os.getenv("MONGODB_URI"),
-            database=os.getenv("MONGODB_DATABASE_NAME"),
-            collection=os.getenv("DESTINATION_MONGO_COLLECTION"),
-        ),
-    )
-    runner.run()
-```
+  <MongoDBAPIPyV1 />
 
 </CodeGroup>
-
-Additionally, if you're using Unstructured Serverless API, your locally deployed Unstructured API, or an Unstructured API
-deployed on Azure or AWS, you also need to specify the API URL via the `--partition-endpoint` argument.

--- a/open-source/ingest/destination-connectors/mongodb.mdx
+++ b/open-source/ingest/destination-connectors/mongodb.mdx
@@ -2,6 +2,30 @@
 title: MongoDB
 ---
 
+import NewDocument from '/snippets/general-shared-text/new-document.mdx';
+
+<NewDocument />
+
 import SharedMongoDB from '/snippets/dc-shared-text/mongodb.mdx';
 
 <SharedMongoDB />
+
+Now call the Unstructured Ingest CLI or Unstructured Ingest Python.  The source connector can be any of the ones supported. This example uses the local source connector:
+
+import MongoDBAPISh from '/snippets/destination_connectors/mongodb.sh.mdx';
+import MongoDBAPIPyV2 from '/snippets/destination_connectors/mongodb.v2.py.mdx';
+import MongoDBAPIPyV1 from '/snippets/destination_connectors/mongodb.v1.py.mdx';
+
+<CodeGroup>
+
+  <MongoDBAPISh />
+
+  <MongoDBAPIPyV2 />
+
+  <MongoDBAPIPyV1 />
+
+</CodeGroup>
+
+import SharedPartitionByAPIOSS from '/snippets/ingest-configuration-shared/partition-by-api-oss.mdx';
+
+<SharedPartitionByAPIOSS/>

--- a/open-source/ingest/source-connectors/mongodb.mdx
+++ b/open-source/ingest/source-connectors/mongodb.mdx
@@ -10,17 +10,20 @@ import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb.mdx';
 
 <SharedContentMongoDB/>
 
-The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.
+Now call the Unstructured Ingest CLI or the Unstructured Ingest Python library.  The destination connector can be any of the ones supported. This example uses the local destination connector:
 
 import MongoDBSh from '/snippets/source_connectors/mongodb.sh.mdx';
-import MongoDBPy from '/snippets/source_connectors/mongodb.py.mdx';
+import MongoDBPyV1 from '/snippets/source_connectors/mongodb.v1.py.mdx';
 
 <CodeGroup>
 
   <MongoDBSh />
 
-  <MongoDBPy />
+  <MongoDBPyV1 />
 
 </CodeGroup>
 
-For a full list of the options the Unstructured Ingest CLI accepts check `unstructured-ingest <upstream connector> mongodb --help`.
+import SharedPartitionByAPIOSS from '/snippets/ingest-configuration-shared/partition-by-api-oss.mdx';
+
+<SharedPartitionByAPIOSS/>
+

--- a/snippets/dc-shared-text/mongodb.mdx
+++ b/snippets/dc-shared-text/mongodb.mdx
@@ -1,25 +1,7 @@
-Batch process all your records using `unstructured-ingest` to store structured outputs locally on your filesystem and upload those local files to an MongoDB collection.
+Batch process all your records to store structured outputs in MongoDB.
 
-First you’ll need to install the MongoDB dependencies as shown here.
+You will need:
 
-```bash
-pip install "unstructured[mongodb]"
-```
+import SharedAzure from '/snippets/general-shared-text/mongodb.mdx';
 
-The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.
-
-import MongoDBSh from '/snippets/destination_connectors/mongodb.sh.mdx';
-import MongoDBPy from '/snippets/destination_connectors/mongodb.py.mdx';
-
-<CodeGroup>
-
-  <MongoDBSh />
-
-  <MongoDBPy />
-
-</CodeGroup>
-
-
-For a full list of the options the Unstructured Ingest CLI accepts check `unstructured-ingest <upstream connector> mongodb --help`.
-
-NOTE: Keep in mind that you will need to have all the appropriate extras and dependencies for the file types of the documents contained in your data storage platform if you’re running this locally. You can find more information about this in the [installation guide](/open-source/installation/overview).
+<SharedAzure />

--- a/snippets/destination_connectors/mongodb.sh.mdx
+++ b/snippets/destination_connectors/mongodb.sh.mdx
@@ -1,19 +1,22 @@
-```bash Shell
+```bash CLI
 #!/usr/bin/env bash
 
 EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-"langchain-huggingface"}
 
 unstructured-ingest \
   local \
-  --input-path example-docs/book-war-and-peace-1225p.txt \
-  --output-dir local-output-to-mongodb \
-  --strategy fast \
-  --chunk-elements \
-  --embedding-provider "$EMBEDDING_PROVIDER" \
-  --num-processes 2 \
-  --verbose \
+    --input-path example-docs/book-war-and-peace-1225p.txt \
+    --output-dir local-output-to-mongodb \
+    --strategy fast \
+    --chunk-elements \
+    --embedding-provider "$EMBEDDING_PROVIDER" \
+    --num-processes 2 \
+    --verbose \
+    --partition-by-api \
+    --api-key $UNSTRUCTURED_API_KEY \
+    --partition-endpoint $UNSTRUCTURED_API_URL \
   mongodb \
-  --uri "$MONGODB_URI" \
-  --database "$MONGODB_DATABASE_NAME" \
-  --collection "$DESTINATION_MONGO_COLLECTION"
+    --uri "$MONGODB_URI" \
+    --database "$MONGODB_DATABASE" \
+    --collection "$MONGODB_COLLECTION"
 ```

--- a/snippets/destination_connectors/mongodb.v1.py.mdx
+++ b/snippets/destination_connectors/mongodb.v1.py.mdx
@@ -1,4 +1,4 @@
-```python Python
+```python Python Ingest v1
 import os
 
 from unstructured.ingest.connector.local import SimpleLocalConfig
@@ -22,8 +22,8 @@ def get_writer() -> Writer:
     return MongodbWriter(
         connector_config=SimpleMongoDBConfig(
             uri=os.getenv("MONGODB_URI"),
-            database=os.getenv("MONGODB_DATABASE_NAME"),
-            collection=os.getenv("DESTINATION_MONGO_COLLECTION"),
+            database=os.getenv("MONGODB_DATABASE"),
+            collection=os.getenv("MONGODB_COLLECTION"),
         ),
         write_config=WriteConfig(),
     )
@@ -41,7 +41,11 @@ if __name__ == "__main__":
             input_path="example-docs/book-war-and-peace-1225p.txt",
         ),
         read_config=ReadConfig(),
-        partition_config=PartitionConfig(),
+        partition_config=PartitionConfig(
+            partition_by_api=True,
+            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+            partition_endpoint=os.getenv("UNSTRUCTURED_API_URL")
+        ),
         chunking_config=ChunkingConfig(chunk_elements=True),
         embedding_config=EmbeddingConfig(
             provider="langchain-huggingface",

--- a/snippets/destination_connectors/mongodb.v2.py.mdx
+++ b/snippets/destination_connectors/mongodb.v2.py.mdx
@@ -1,0 +1,45 @@
+```python Python Ingest v2
+import os
+
+from unstructured.ingest.v2.pipeline.pipeline import Pipeline
+from unstructured.ingest.v2.interfaces import ProcessorConfig
+
+from unstructured.ingest.v2.processes.connectors.mongodb import (
+    MongoDBAccessConfig,
+    MongoDBConnectionConfig,
+    MongoDBUploadStagerConfig,
+    MongoDBUploaderConfig
+)
+from unstructured.ingest.v2.processes.connectors.local import (
+    LocalIndexerConfig,
+    LocalConnectionConfig,
+    LocalDownloaderConfig
+)
+from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured.ingest.v2.processes.chunker import ChunkerConfig
+from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+
+if __name__ == "__main__":
+    Pipeline.from_configs(
+        context=ProcessorConfig(),
+        indexer_config=LocalIndexerConfig(input_path="local-ingest-source"),
+        downloader_config=LocalDownloaderConfig(),
+        source_connection_config=LocalConnectionConfig(),
+        partitioner_config=PartitionerConfig(
+            partition_by_api=True,
+            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+            partition_endpoint=os.getenv("UNSTRUCTURED_API_URL")
+        ),
+        chunker_config=ChunkerConfig(chunking_strategy="by_title"),
+        embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
+        destination_connection_config=MongoDBConnectionConfig(
+            access_config=MongoDBAccessConfig(
+                uri=os.getenv("MONGODB_URI")
+            ),
+            database=os.getenv("MONGODB_DATABASE"),
+            collection=os.getenv("MONGODB_COLLECTION")
+        ),
+        stager_config=MongoDBUploadStagerConfig(),
+        uploader_config=MongoDBUploaderConfig(batch_size=100)
+    ).run()
+```

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,0 +1,37 @@
+The MongoDB connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured[mongodb]"
+```
+
+A MongoDB Atlas deployment, or a local MongoDB server:
+
+For a MongoDB Atlas deployment:
+
+- A MongoDB Atlas account. [Create an account](https://www.mongodb.com/cloud/atlas/register).
+
+- A MongoDB Atlas cluster. [Create a cluster](https://www.mongodb.com/docs/atlas/tutorial/deploy-free-tier-cluster).
+
+- The cluster must be reachable from your application environment. [Learn how](https://www.mongodb.com/docs/atlas/setup-cluster-security/#network-and-firewall-requirements). 
+
+- The cluster must be configured to use your IP address. [Learn how](https://www.mongodb.com/docs/atlas/setup-cluster-security/#ip-access-list).
+
+- The cluster must have at least one database, the name of which is specified with `--database` (CLI) or `database` (Python) and represented in the following examples by the environment variable `MONGODB_DATABASE`.[Create a database](https://www.mongodb.com/docs/compass/current/databases/#create-a-database).
+
+- The database must have at least one user, and that user must have sufficient access to the database. [Create a database user](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users). [Give the user database access](https://www.mongodb.com/docs/manual/core/authorization/).
+
+- The database must have at least one collection, the name of which is specified with `--collection` (CLI) or `collection` (Python) and represented in the following examples by the environment variable `MONGODB_COLLECTION`. [Create a collection](https://www.mongodb.com/docs/compass/current/collections/#create-a-collection).
+
+- The URI for the cluster, specified with `--uri` (CLI) or `uri` (Python) and is represented in the following examples by the environment variable `MONGODB_URI`. This URI must include the protocol, username, password, and host. [Learn how to get this value](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).
+
+For a local MongoDB server:
+
+- Installation of a local MongoDB server. [Learn how](https://www.mongodb.com/docs/manual/installation/).
+
+- The host and port for the local MongoDB server (instead of `--uri` (CLI) or `uri` (Python)), as follows:
+
+  - The host is specified with `--host` (CLI) or `host` (Python), represented by the environment variable `MONGODB_HOST`.
+
+  - The port is specified with `--port` (CLI) or `port` (Python), represented by the environment variable `MONGODB_PORT`.
+
+    [Learn how to get these values](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).

--- a/snippets/sc-shared-text/mongodb.mdx
+++ b/snippets/sc-shared-text/mongodb.mdx
@@ -1,16 +1,7 @@
-Batch process all your records using `unstructured-ingest` to store structured outputs locally on your filesystem and upload those local files to an MongoDB collection.
+Connect MongoDB to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-First, install the MongoDB dependencies as shown here:
+You will need: 
 
-```bash
-pip install "unstructured[mongodb]"
-```
+import SharedMongoDB from '/snippets/general-shared-text/mongodb.mdx';
 
-Specify the following parameters to configure your MongoDB source connector:
-
-* `uri`: URI to user when connecting.
-* `host`: Hostname, IP address, or Unix domain socket path where mongodb database is served.
-* `port`: Port where mongodb database is served.
-* `database`: Database name to connect to.
-* `collection`: Collection name to ingest data from.
-* `batch-size`: How many records to read at a time per process.
+<SharedMongoDB />

--- a/snippets/source_connectors/mongodb.sh.mdx
+++ b/snippets/source_connectors/mongodb.sh.mdx
@@ -1,12 +1,15 @@
-```bash Shell
+```bash CLI
 #!/usr/bin/env bash
 
 unstructured-ingest \
   mongodb \
-  --metadata-exclude filename,file_directory,metadata.data_source.date_processed \
-  --uri "$MONGODB_URI" \
-  --database "$MONGODB_DATABASE" \
-  --collection "$MONGODB_COLLECTION" \
-  --output-dir mongodb-ingest-output \
-  --num-processes 2
+    --metadata-exclude filename,file_directory,metadata.data_source.date_processed \
+    --uri "$MONGODB_URI" \
+    --database "$MONGODB_DATABASE" \
+    --collection "$MONGODB_COLLECTION" \
+    --output-dir mongodb-ingest-output \
+    --num-processes 2 \
+    --partition-by-api \
+    --api-key $UNSTRUCTURED_API_KEY \
+    --partition-endpoint $UNSTRUCTURED_API_URL
 ```

--- a/snippets/source_connectors/mongodb.v1.py.mdx
+++ b/snippets/source_connectors/mongodb.v1.py.mdx
@@ -1,4 +1,4 @@
-```python Python
+```python Python Ingest v1
 import os
 
 from unstructured.ingest.connector.mongodb import (
@@ -17,11 +17,14 @@ if __name__ == "__main__":
         read_config=ReadConfig(),
         partition_config=PartitionConfig(
             metadata_exclude=["filename", "file_directory", "metadata.data_source.date_processed"],
+            partition_by_api=True,
+            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+            partition_endpoint=os.getenv("UNSTRUCTURED_API_URL"),
         ),
         connector_config=SimpleMongoDBConfig(
             uri=os.getenv("MONGODB_URI"),
-            database=os.getenv("MONGODB_DATABASE_NAME"),
-            collection=os.getenv("DESTINATION_MONGO_COLLECTION"),
+            database=os.getenv("MONGODB_DATABASE"),
+            collection=os.getenv("MONGODB_COLLECTION"),
         ),
     )
     runner.run()


### PR DESCRIPTION
See:

- API: https://unstructured-53-docs-36-mongodb.mintlify.app/api-reference/ingest/destination-connector/mongodb
- Open source: https://unstructured-53-docs-36-mongodb.mintlify.app/open-source/ingest/destination-connectors/mongodb

For comparison, here are the source connector docs:

- API: https://unstructured-53-docs-36-mongodb.mintlify.app/api-reference/ingest/source-connectors/mongodb
- Open source: https://unstructured-53-docs-36-mongodb.mintlify.app/open-source/ingest/source-connectors/mongodb