### PR TITLE
Ingest CLI and Ingest Python library: migrate to pip install unstructured-ingest and import unstructured_ingest

### DIFF
--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -226,7 +226,7 @@ client.general.partition({
 
 If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-Learn more about how to use the ]Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
+Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
 
 ### Calling the Free Unstructured API from the Unstructured open source library
 

--- a/api-reference/best-practices/speed-up-large-files-batches.mdx
+++ b/api-reference/best-practices/speed-up-large-files-batches.mdx
@@ -32,7 +32,7 @@ For Unstructured Python Ingest, you can set the `ProcessorConfig` object's `num_
 
 <CodeGroup>
     ```python Python Ingest v2
-    from unstructured.ingest.v2.interfaces import ProcessorConfig
+    from unstructured_ingest.v2.interfaces import ProcessorConfig
 
     # ...
 
@@ -47,11 +47,11 @@ For Unstructured Python Ingest, you can set the `ProcessorConfig` object's `num_
     ```
 
     ```python Python Ingest v1
-    from unstructured.ingest.interfaces import (
+    from unstructured_ingest.interfaces import (
         ProcessorConfig,
         # ...
     )
-    from unstructured.ingest.runner import LocalRunner
+    from unstructured_ingest.runner import LocalRunner
 
     # ...
 

--- a/api-reference/ingest/ingest-cli.mdx
+++ b/api-reference/ingest/ingest-cli.mdx
@@ -10,12 +10,14 @@ The Unstructured Ingest CLI enables you to use command-line scripts to send file
 One approach to get started quickly with the Unstructured Ingest CLI is to install Python and then run the following command:
 
 ```bash
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
 For additional installation options and dependencies, see [Unstructed Ingest CLI](/ingestion/overview#unstructured-ingest-cli) in the [Ingest](/ingestion/overview) section.
+
+<Info>To migrate from older, deprecated versions of the Ingest CLI that used `pip install unstructured`, see the [migration guide](/ingestion/overview#migration-guide).</Info>
 
 ## Usage
 

--- a/api-reference/ingest/python-ingest.mdx
+++ b/api-reference/ingest/python-ingest.mdx
@@ -10,12 +10,14 @@ The Unstructured Ingest Python library enables you to use Python code to send fi
 One approach to get started quickly with the Unstructured Ingest Python library is to install Python and then run the following command:
 
 ```bash
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
 For additional installation options and dependencies, and information about v2 and v1 implementations in this library, see the [Unstructed Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) in the [Ingest](/ingestion/overview) section.
+
+<Info>To migrate from older, deprecated versions of the Ingest Python library that used `pip install unstructured`, see the [migration guide](/ingestion/overview#migration-guide).</Info>
 
 ## Usage
 

--- a/examplecode/codesamples/oss/multi-files-api-processing.mdx
+++ b/examplecode/codesamples/oss/multi-files-api-processing.mdx
@@ -20,7 +20,7 @@ Ensure you have Unstructured API key and access to an S3 bucket containing the t
 Install the unstructured package with S3 support.
 
 ```bash
-pip install "unstructured[s3]"
+pip install "unstructured-ingest[s3]"
 
 ```
 
@@ -30,13 +30,13 @@ pip install "unstructured[s3]"
 Import necessary libraries from the unstructured package for chunking and S3 processing.
 
 ```python
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     FsspecConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import S3Runner
+from unstructured_ingest.runner import S3Runner
 
 from unstructured.chunking.title import chunk_by_title
 from unstructured.staging.base import dict_to_elements

--- a/ingestion/overview.mdx
+++ b/ingestion/overview.mdx
@@ -93,7 +93,7 @@ The Unstructured Ingest CLI enables you to use command-line scripts to get all o
 One approach to using the CLI is installing Python and then running the following command to install the CLI:
 
 ```bash
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
@@ -133,6 +133,8 @@ To begin using the CLI, see the quickstarts for the:
 - [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide#unstructured-cli)
 - [Free Unstructured API](/api-reference/api-services/free-api#unstructured-cli)
 
+<Info>To migrate from older, deprecated versions of the Ingest CLI that used `pip install unstructured`, see the [migration guide](#migration-guide).</Info>
+
 ## Unstructured Ingest Python library
 
 The Unstructured Ingest Python library enable you to use Python code to get all of your data ready for RAG and model fine-tuning.
@@ -140,7 +142,7 @@ The Unstructured Ingest Python library enable you to use Python code to get all 
 One approach to using the Unstructured Ingest Python library is installing Python and then running the following command to install the library and the default connectors:
 
 ```bash
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
@@ -160,3 +162,13 @@ Some source and destination connectors provide newer v2 and older v1 implementat
 - [v1 Notion connector](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/notion)
 
 To begin using the Unstructured Ingest Python library, see the code examples for the [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
+
+<Info>To migrate from older, deprecated versions of the Ingest Python library that used `pip install unstructured`, see the [migration guide](#migration-guide).</Info>
+
+## Migration guide
+
+import MigrationGuideSteps from '/snippets/general-shared-text/ingest-migration.mdx';
+
+<MigrationGuideSteps/>
+
+

--- a/open-source/examples/multi-files-api-processing.mdx
+++ b/open-source/examples/multi-files-api-processing.mdx
@@ -16,7 +16,7 @@ Ensure you have Unstructured API key and access to an S3 bucket containing the t
 Install the unstructured package with S3 support.
 
 ```bash
-pip install "unstructured[s3]"
+pip install "unstructured-ingest[s3]"
 
 ```
 
@@ -26,13 +26,13 @@ pip install "unstructured[s3]"
 Import necessary libraries from the unstructured package for chunking and S3 processing.
 
 ```python
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     FsspecConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import S3Runner
+from unstructured_ingest.runner import S3Runner
 
 from unstructured.chunking.title import chunk_by_title
 from unstructured.staging.base import dict_to_elements

--- a/open-source/ingest/overview.mdx
+++ b/open-source/ingest/overview.mdx
@@ -54,14 +54,15 @@ The Unstructured Python Ingest library follows a modular architecture comprising
 
 ## Installation
 
-To install the Unstructured Python Ingest library, follow these steps:
+To install the Unstructured Ingest CLI and the Unstructured Ingest Python library, follow these steps:
 
-1.  Run `pip install unstructured` to install the latest version of the unstructured library which include the ingest code and the cli.
+1.  Run `pip install unstructured-ingest` to install the latest version of the Ingest CLI and Ingest Python library.
     
-2.  For specific connectors, run `pip install unstructured[CONNECTOR_DEPS]` where `CONNECTOR_DEPS` references the extra dependency label for a particular connector. For example, `pip install unstructured[s3]` will install the dependencies to interact with the s3 connectors. If these aren’t installed before hand, a convenient error message will be printed for you when you run the Unstructured Ingest CLI for the first time, prompting you with the correct pip command to run.
+2.  For specific connectors, run `pip install unstructured-ingest[CONNECTOR_DEPS]` where `CONNECTOR_DEPS` references the extra dependency label for a particular connector. For example, `pip install unstructured-ingest[s3]` will install the dependencies to interact with the s3 connectors. If these aren’t installed before hand, a convenient error message will be printed for you when you run the Unstructured Ingest CLI for the first time, prompting you with the correct pip command to run.
     
 3.  Once installed, you can run `unstructured-ingest --help` to get all the available commands.
     
+<Info>To migrate from older, deprecated versions of the Ingest CLI or Ingest Python library that used `pip install unstructured`, see the [migration guide](/ingestion/overview#migration-guide).</Info>
 
 ## Configuration
 

--- a/open-source/installation/full-installation.mdx
+++ b/open-source/installation/full-installation.mdx
@@ -45,7 +45,7 @@ _Available document types:_
 To use any of the data connectors, you must install the specific dependency:
 
 ```bash
-pip install "unstructured[s3]"
+pip install "unstructured-ingest[s3]"
 
 ```
 

--- a/open-source/introduction/quick-start.mdx
+++ b/open-source/introduction/quick-start.mdx
@@ -4,7 +4,7 @@ description: Using Unstructured Open Source.
 ---
 ## Installation
 
-1.  **Installing the Python SDK**: You can install the core SDK using pip:
+1.  **Installing the open source library**: You can install the core SDK using pip:
 
     `pip install unstructured`
     

--- a/snippets/dc-shared-text/azure-cognitive-search.mdx
+++ b/snippets/dc-shared-text/azure-cognitive-search.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the azure cognitive search dependencies as shown here.
 
 ```bash
-pip install "unstructured[azure-cognitive-search]"
+pip install "unstructured-ingest[azure-cognitive-search]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/chroma.mdx
+++ b/snippets/dc-shared-text/chroma.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the Chroma dependencies as shown here.
 
 ```bash
-pip install "unstructured[chroma]"
+pip install "unstructured-ingest[chroma]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/clarifai.mdx
+++ b/snippets/dc-shared-text/clarifai.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store unstructured
 First start with the installation of clarifai dependencies as shown here.
 
 ```bash
-pip install "unstructured[clarifai]"
+pip install "unstructured-ingest[clarifai]"
 ```
 
 Create a clarifai app with base workflow. Find more information in the [create clarifai app](https://docs.clarifai.com/clarifai-basics/applications/create-an-application/).

--- a/snippets/dc-shared-text/databricks-volumes.mdx
+++ b/snippets/dc-shared-text/databricks-volumes.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the Databricks Volume dependencies as shown here.
 
 ```bash
-pip install "unstructured[databricks-volumes]"
+pip install "unstructured-ingest[databricks-volumes]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/delta-table.mdx
+++ b/snippets/dc-shared-text/delta-table.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the delta table dependencies as shown here.
 
 ```bash
-pip install "unstructured[delta-table]"
+pip install "unstructured-ingest[delta-table]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/elasticsearch.mdx
+++ b/snippets/dc-shared-text/elasticsearch.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install Elasticsearch dependencies as shown here.
 
 ```bash
-pip install "unstructured[elasticsearch]"
+pip install "unstructured-ingest[elasticsearch]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/google-cloud-service.mdx
+++ b/snippets/dc-shared-text/google-cloud-service.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the GCS dependencies as shown here.
 
 ```bash 
-pip install "unstructured[gcs]"
+pip install "unstructured-ingest[gcs]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/local.mdx
+++ b/snippets/dc-shared-text/local.mdx
@@ -3,7 +3,7 @@ Batch process all your records to store structured outputs locally.
 You will need the local destination connector dependencies:
 
 ```bash CLI, Python
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 To use the local destination connector, you must set `--output-dir` (CLI) or `output_dir` (Python) to the path in the local filesystem which will contain the structured output.

--- a/snippets/dc-shared-text/opensearch.mdx
+++ b/snippets/dc-shared-text/opensearch.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install OpenSearch dependencies as shown here.
 
 ```bash
-pip install "unstructured[opensearch]"
+pip install "unstructured-ingest[opensearch]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/pinecone.mdx
+++ b/snippets/dc-shared-text/pinecone.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the Pinecone dependencies as shown here.
 
 ```bash
-pip install "unstructured[pinecone]"
+pip install "unstructured-ingest[pinecone]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/qdrant.mdx
+++ b/snippets/dc-shared-text/qdrant.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the Qdrant dependencies as shown here.
 
 ```bash
-pip install "unstructured[qdrant]"
+pip install "unstructured-ingest[qdrant]"
 ```
 
 Create a Qdrant collection with the appropriate configurations. Find more information in the [Qdrant collections guide](https://qdrant.tech/documentation/concepts/collections/).

--- a/snippets/dc-shared-text/sql.mdx
+++ b/snippets/dc-shared-text/sql.mdx
@@ -5,7 +5,7 @@ Insert query is currently limited to append.
 First you’ll need to install the sql dependencies as shown here if you are using PostgreSQL.
 
 ```bash
-pip install "unstructured[postgres]"
+pip install "unstructured-ingest[postgres]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector.

--- a/snippets/dc-shared-text/weaviate.mdx
+++ b/snippets/dc-shared-text/weaviate.mdx
@@ -3,7 +3,7 @@ Batch process all your records using `unstructured-ingest` to store structured o
 First you’ll need to install the weaviate dependencies as shown here.
 
 ```bash
-pip install "unstructured[weaviate]"
+pip install "unstructured-ingest[weaviate]"
 ```
 
 The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the upstream local connector. This will push elements into a collection schema of your choice into a weaviate instance running locally.

--- a/snippets/destination_connectors/astradb.v1.py.mdx
+++ b/snippets/destination_connectors/astradb.v1.py.mdx
@@ -1,24 +1,24 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.astradb import (
+from unstructured_ingest.connector.astradb import (
     AstraDBAccessConfig,
     AstraDBWriteConfig,
     SimpleAstraDBConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.astradb import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.astradb import (
     AstraDBWriter,
 )
-from unstructured.ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.base_writer import Writer
 
 
 def get_writer() -> Writer:

--- a/snippets/destination_connectors/astradb.v2.py.mdx
+++ b/snippets/destination_connectors/astradb.v2.py.mdx
@@ -1,23 +1,23 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.astradb import (
+from unstructured_ingest.v2.processes.connectors.astradb import (
     AstraDBConnectionConfig,
     AstraDBAccessConfig,
     AstraDBUploadStagerConfig,
     AstraDBUploaderConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalDownloaderConfig,
     LocalConnectionConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/destination_connectors/azure.v1.py.mdx
+++ b/snippets/destination_connectors/azure.v1.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.azure import (
+from unstructured_ingest.connector.fsspec.azure import (
     AzureAccessConfig,
     AzureWriteConfig,
     SimpleAzureBlobStorageConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.fsspec.azure import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.fsspec.azure import (
     AzureWriter,
 )
 

--- a/snippets/destination_connectors/azure.v2.py.mdx
+++ b/snippets/destination_connectors/azure.v2.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.azure import (
+from unstructured_ingest.v2.processes.connectors.fsspec.azure import (
     AzureConnectionConfig,
     AzureAccessConfig,
     AzureUploaderConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalDownloaderConfig,
     LocalConnectionConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/destination_connectors/azure_cognitive_search.py.mdx
+++ b/snippets/destination_connectors/azure_cognitive_search.py.mdx
@@ -1,24 +1,24 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.azure_cognitive_search import (
+from unstructured_ingest.connector.azure_cognitive_search import (
     AzureCognitiveSearchAccessConfig,
     AzureCognitiveSearchWriteConfig,
     SimpleAzureCognitiveSearchStorageConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.azure_cognitive_search import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.azure_cognitive_search import (
     AzureCognitiveSearchWriter,
 )
-from unstructured.ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.base_writer import Writer
 
 
 def get_writer() -> Writer:

--- a/snippets/destination_connectors/box.v1.py.mdx
+++ b/snippets/destination_connectors/box.v1.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.box import (
+from unstructured_ingest.connector.fsspec.box import (
     BoxAccessConfig,
     BoxWriteConfig,
     SimpleBoxConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.fsspec.box import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.fsspec.box import (
     BoxWriter,
 )
 

--- a/snippets/destination_connectors/box.v2.py.mdx
+++ b/snippets/destination_connectors/box.v2.py.mdx
@@ -1,23 +1,23 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.box import (
+from unstructured_ingest.v2.processes.connectors.fsspec.box import (
     BoxAccessConfig,
     BoxConnectionConfig,
     BoxIndexerConfig,
     BoxUploaderConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalConnectionConfig,
     LocalDownloaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/destination_connectors/chroma.py.mdx
+++ b/snippets/destination_connectors/chroma.py.mdx
@@ -1,20 +1,20 @@
 ```python Python
-from unstructured.ingest.connector.chroma import (
+from unstructured_ingest.connector.chroma import (
     ChromaAccessConfig,
     ChromaWriteConfig,
     SimpleChromaConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.chroma import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.chroma import (
     ChromaWriter,
 )
 

--- a/snippets/destination_connectors/clarifai.py.mdx
+++ b/snippets/destination_connectors/clarifai.py.mdx
@@ -1,21 +1,21 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.clarifai import (
+from unstructured_ingest.connector.clarifai import (
     ClarifaiAccessConfig,
     ClarifaiWriteConfig,
     SimpleClarifaiConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.clarifai import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.clarifai import (
     ClarifaiWriter,
 )
 

--- a/snippets/destination_connectors/databricks_volumes.py.mdx
+++ b/snippets/destination_connectors/databricks_volumes.py.mdx
@@ -1,22 +1,22 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.databricks_volumes import (
+from unstructured_ingest.connector.databricks_volumes import (
     DatabricksVolumesAccessConfig,
     DatabricksVolumesWriteConfig,
     SimpleDatabricksVolumesConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.databricks_volumes import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.databricks_volumes import (
     DatabricksVolumesWriter,
 )
 

--- a/snippets/destination_connectors/delta_table.py.mdx
+++ b/snippets/destination_connectors/delta_table.py.mdx
@@ -1,18 +1,18 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.delta_table import DeltaTableWriteConfig, SimpleDeltaTableConfig
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.delta_table import DeltaTableWriteConfig, SimpleDeltaTableConfig
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.delta_table import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.delta_table import (
     DeltaTableWriter,
 )
 

--- a/snippets/destination_connectors/dropbox.v1.py.mdx
+++ b/snippets/destination_connectors/dropbox.v1.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.connector.fsspec.dropbox import (
+from unstructured_ingest.connector.fsspec.dropbox import (
     DropboxAccessConfig,
     DropboxWriteConfig,
     SimpleDropboxConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.fsspec.dropbox import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.fsspec.dropbox import (
     DropboxWriter,
 )
 

--- a/snippets/destination_connectors/dropbox.v2.py.mdx
+++ b/snippets/destination_connectors/dropbox.v2.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.dropbox import (
+from unstructured_ingest.v2.processes.connectors.fsspec.dropbox import (
     DropboxAccessConfig,
     DropboxConnectionConfig,
     DropboxUploaderConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalConnectionConfig,
     LocalDownloaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/destination_connectors/elasticsearch.py.mdx
+++ b/snippets/destination_connectors/elasticsearch.py.mdx
@@ -1,22 +1,22 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.elasticsearch import (
+from unstructured_ingest.connector.elasticsearch import (
     ElasticsearchAccessConfig,
     ElasticsearchWriteConfig,
     SimpleElasticsearchConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.elasticsearch import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.elasticsearch import (
     ElasticsearchWriter,
 )
 

--- a/snippets/destination_connectors/gcs.py.mdx
+++ b/snippets/destination_connectors/gcs.py.mdx
@@ -1,22 +1,22 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.fsspec.gcs import (
+from unstructured_ingest.connector.fsspec.gcs import (
     GcsAccessConfig,
     GcsWriteConfig,
     SimpleGcsConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.fsspec.gcs import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.fsspec.gcs import (
     GcsWriter,
 )
 

--- a/snippets/destination_connectors/mongodb.v1.py.mdx
+++ b/snippets/destination_connectors/mongodb.v1.py.mdx
@@ -1,9 +1,9 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.mongodb import SimpleMongoDBConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.mongodb import SimpleMongoDBConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
@@ -11,9 +11,9 @@ from unstructured.ingest.interfaces import (
     ReadConfig,
     WriteConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.mongodb import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.mongodb import (
     MongodbWriter,
 )
 

--- a/snippets/destination_connectors/mongodb.v2.py.mdx
+++ b/snippets/destination_connectors/mongodb.v2.py.mdx
@@ -1,23 +1,23 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.mongodb import (
+from unstructured_ingest.v2.processes.connectors.mongodb import (
     MongoDBAccessConfig,
     MongoDBConnectionConfig,
     MongoDBUploadStagerConfig,
     MongoDBUploaderConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalConnectionConfig,
     LocalDownloaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/destination_connectors/opensearch.py.mdx
+++ b/snippets/destination_connectors/opensearch.py.mdx
@@ -1,24 +1,24 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.elasticsearch import (
+from unstructured_ingest.connector.elasticsearch import (
     ElasticsearchWriteConfig,
 )
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.opensearch import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.opensearch import (
     OpenSearchAccessConfig,
     SimpleOpenSearchConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.opensearch import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.opensearch import (
     OpenSearchWriter,
 )
 

--- a/snippets/destination_connectors/pinecone.py.mdx
+++ b/snippets/destination_connectors/pinecone.py.mdx
@@ -1,22 +1,22 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.pinecone import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.pinecone import (
     PineconeAccessConfig,
     PineconeWriteConfig,
     SimplePineconeConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.pinecone import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.pinecone import (
     PineconeWriter,
 )
 

--- a/snippets/destination_connectors/qdrant.py.mdx
+++ b/snippets/destination_connectors/qdrant.py.mdx
@@ -1,19 +1,19 @@
 ```python Python
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.qdrant import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.qdrant import (
     QdrantWriteConfig,
     SimpleQdrantConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.qdrant import QdrantWriter
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.qdrant import QdrantWriter
 
 
 def get_writer() -> Writer:

--- a/snippets/destination_connectors/s3.v1.py.mdx
+++ b/snippets/destination_connectors/s3.v1.py.mdx
@@ -1,18 +1,18 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.s3 import S3AccessConfig, S3WriteConfig, SimpleS3Config
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.s3 import S3AccessConfig, S3WriteConfig, SimpleS3Config
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.fsspec.s3 import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.fsspec.s3 import (
     S3Writer,
 )
 

--- a/snippets/destination_connectors/s3.v2.py.mdx
+++ b/snippets/destination_connectors/s3.v2.py.mdx
@@ -1,17 +1,17 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalDownloaderConfig,
     LocalConnectionConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.fsspec.s3 import (
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.fsspec.s3 import (
     S3ConnectionConfig,
     S3AccessConfig,
     S3UploaderConfig

--- a/snippets/destination_connectors/singlestore.v2.py.mdx
+++ b/snippets/destination_connectors/singlestore.v2.py.mdx
@@ -1,17 +1,17 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalDownloaderConfig,
     LocalConnectionConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.singlestore import (
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.singlestore import (
     SingleStoreConnectionConfig,
     SingleStoreAccessConfig,
     SingleStoreUploadStagerConfig,

--- a/snippets/destination_connectors/sql.py.mdx
+++ b/snippets/destination_connectors/sql.py.mdx
@@ -1,12 +1,12 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.sql import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.sql import (
     SimpleSqlConfig,
     SqlAccessConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
@@ -14,9 +14,9 @@ from unstructured.ingest.interfaces import (
     ReadConfig,
     WriteConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.sql import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.sql import (
     SqlWriter,
 )
 

--- a/snippets/destination_connectors/vectara.py.mdx
+++ b/snippets/destination_connectors/vectara.py.mdx
@@ -1,20 +1,20 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.vectara import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.vectara import (
     SimpleVectaraConfig,
     VectaraAccessConfig,
     WriteConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.vectara import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.vectara import (
     VectaraWriter,
 )
 

--- a/snippets/destination_connectors/weaviate.py.mdx
+++ b/snippets/destination_connectors/weaviate.py.mdx
@@ -1,20 +1,20 @@
 ```python Python
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.connector.weaviate import (
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.connector.weaviate import (
     SimpleWeaviateConfig,
     WeaviateAccessConfig,
     WeaviateWriteConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ChunkingConfig,
     EmbeddingConfig,
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import LocalRunner
-from unstructured.ingest.runner.writers.base_writer import Writer
-from unstructured.ingest.runner.writers.weaviate import (
+from unstructured_ingest.runner import LocalRunner
+from unstructured_ingest.runner.writers.base_writer import Writer
+from unstructured_ingest.runner.writers.weaviate import (
     WeaviateWriter,
 )
 

--- a/snippets/general-shared-text/astradb.mdx
+++ b/snippets/general-shared-text/astradb.mdx
@@ -1,7 +1,7 @@
 The Astra DB connector dependencies:
 
 ```bash CLI, Python
-pip install "unstructured[astradb]"
+pip install "unstructured-ingest[astradb]"
 ```
 
 These environment variables:

--- a/snippets/general-shared-text/azure.mdx
+++ b/snippets/general-shared-text/azure.mdx
@@ -1,7 +1,7 @@
 The Azure Storage connector dependencies:
 
 ```bash CLI, Python
-pip install "unstructured[azure]"
+pip install "unstructured-ingest[azure]"
 ```
 
 An Azure Storage account. To create one, [learn how](https://learn.microsoft.com/azure/storage/common/storage-account-create).

--- a/snippets/general-shared-text/box.mdx
+++ b/snippets/general-shared-text/box.mdx
@@ -1,7 +1,7 @@
 1. The Box connector dependencies:
 
    ```bash CLI, Python
-   pip install "unstructured[box]"
+   pip install "unstructured-ingest[box]"
    ```
 
 2. Access to the [Developer Console](https://app.box.com/developers/console) from your [Box enterprise account](https://account.box.com/signup/enterprise-plan) or [Box developer account](https://account.box.com/signup/developer).

--- a/snippets/general-shared-text/dropbox.mdx
+++ b/snippets/general-shared-text/dropbox.mdx
@@ -1,7 +1,7 @@
 1. The Dropbox connector dependencies:
 
    ```bash CLI, Python
-   pip install "unstructured[dropbox]"
+   pip install "unstructured-ingest[dropbox]"
    ```
 
 2. A Dropbox account. [Get an account](https://www.dropbox.com/try/teams).

--- a/snippets/general-shared-text/google-drive.mdx
+++ b/snippets/general-shared-text/google-drive.mdx
@@ -1,7 +1,7 @@
 The Google Drive connector dependencies:
 
   ```bash CLI, Python
-  pip install "unstructured[google-drive]"
+  pip install "unstructured-ingest[google-drive]"
   ```
 
 A Google Cloud service account and its related `credentials.json` key file or its contents in JSON format. [Learn how](https://developers.google.com/workspace/guides/create-credentials#service-account).

--- a/snippets/general-shared-text/ingest-migration.mdx
+++ b/snippets/general-shared-text/ingest-migration.mdx
@@ -1,0 +1,15 @@
+The older `unstructured` versions of the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) and [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) have been replaced and are now deprecated.
+
+To migrate to the newer [unstructured-ingest](https://pypi.org/project/unstructured-ingest/) versions of the Ingest CLI and Ingest Python library, do the following:
+
+1. If you previously ran `pip install unstructured` **only** for the purposes of using the Ingest CLI or the Ingest Python library, upgrade to the lastest versions by running the following commands:
+
+   a. `pip uninstall unstructured`<br/>
+   b. `pip install unstructured-ingest`
+
+2. If you previously installed an older version of a source or destination connector, for example `pip install "unstructured[azure]"` for the Azure Storage connector, upgrade to the latest version by running the following commands:
+
+   a. `pip uninstall "unstructured[azure]"`<br/>
+   b. `pip install "unstructured-ingest[azure]"`
+
+3. If you were running Python code against an older version of the Ingest Python library, update your `import` statements by replacing all instances of `unstructured.ingest` with `unstructured_ingest` to run against the latest version.

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,7 +1,7 @@
 The MongoDB connector dependencies:
 
 ```bash CLI, Python
-pip install "unstructured[mongodb]"
+pip install "unstructured-ingest[mongodb]"
 ```
 
 A MongoDB Atlas deployment, or a local MongoDB server:

--- a/snippets/general-shared-text/s3.mdx
+++ b/snippets/general-shared-text/s3.mdx
@@ -1,7 +1,7 @@
 The S3 connector dependencies:
 
 ```bash CLI, Python
-pip install "unstructured[s3]"
+pip install "unstructured-ingest[s3]"
 ```
 
 These environment variables:

--- a/snippets/general-shared-text/singlestore.mdx
+++ b/snippets/general-shared-text/singlestore.mdx
@@ -1,7 +1,7 @@
 The SingleStore connector dependencies:
 
 ```bash CLI, Python
-pip install "unstructured[singlestore]"
+pip install "unstructured-ingest[singlestore]"
 ```
 
 These environment variables:

--- a/snippets/how-to-api/azure-aws.mdx
+++ b/snippets/how-to-api/azure-aws.mdx
@@ -160,15 +160,15 @@
         ```python Python Ingest v2
         import os
 
-        from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-        from unstructured.ingest.v2.interfaces import ProcessorConfig
-        from unstructured.ingest.v2.processes.connectors.local import (
+        from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+        from unstructured_ingest.v2.interfaces import ProcessorConfig
+        from unstructured_ingest.v2.processes.connectors.local import (
             LocalIndexerConfig,
             LocalDownloaderConfig,
             LocalConnectionConfig,
             LocalUploaderConfig
         )
-        from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
+        from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
 
         if __name__ == "__main__":
             Pipeline.from_configs(

--- a/snippets/sc-shared-text/airtable.mdx
+++ b/snippets/sc-shared-text/airtable.mdx
@@ -5,7 +5,7 @@ store structured outputs locally on your filesystem.
 Make sure to have the Airtable dependencies installed:
 
     ```bash Shell
-    pip install "unstructured[airtable]"
+    pip install "unstructured-ingest[airtable]"
     ```
 
 Before connecting your preprocessing pipeline to Airtable, obtain a personal access token to authenticate into Airtable.

--- a/snippets/sc-shared-text/biomed.mdx
+++ b/snippets/sc-shared-text/biomed.mdx
@@ -7,7 +7,7 @@ This connector allows you to extract Biomedical documents from the supported FTP
 Make sure to have the Biomed dependencies installed:
 
     ```bash Shell
-    pip install "unstructured[biomed]"
+    pip install "unstructured-ingest[biomed]"
     ```
 
 You need to provide the path, from which the documents should be downloaded. For example, to download the documents in

--- a/snippets/sc-shared-text/confluence.mdx
+++ b/snippets/sc-shared-text/confluence.mdx
@@ -4,7 +4,7 @@ store structured outputs locally on your filesystem.
 Make sure to have the Confluence dependencies installed:
 
     ```bash Shell
-    pip install "unstructured[confluence]"
+    pip install "unstructured-ingest[confluence]"
     ```
 
 To connect to Confluence Cloud, provide the url to the Confluence Cloud instance, and your credentials:

--- a/snippets/sc-shared-text/delta-table.mdx
+++ b/snippets/sc-shared-text/delta-table.mdx
@@ -4,7 +4,7 @@ store structured outputs locally on your filesystem.
 Make sure to have the Delta Table dependencies installed:
 
     ```bash Shell
-    pip install "unstructured[delta-table]"
+    pip install "unstructured-ingest[delta-table]"
     ```
 
 AWS credentials need to be available for use with the storage options.

--- a/snippets/sc-shared-text/discord.mdx
+++ b/snippets/sc-shared-text/discord.mdx
@@ -4,7 +4,7 @@ store structured outputs locally on your filesystem.
 Make sure to have the Discord dependencies installed:
 
     ```bash Shell
-    pip install "unstructured[discord]"
+    pip install "unstructured-ingest[discord]"
     ```
 
 To ingests the contents of Discord channels, you need to supply the following information:

--- a/snippets/sc-shared-text/elastic-search.mdx
+++ b/snippets/sc-shared-text/elastic-search.mdx
@@ -3,7 +3,7 @@ Connect Elasticsearch to your preprocessing pipeline, and batch process all your
 First, install the Elasticsearch dependencies as shown here.
 
 ```bash
-pip install "unstructured[elasticsearch]"
+pip install "unstructured-ingest[elasticsearch]"
 ```
 
 Provide values for the Elasticsearch-specific parameters depending on your Elasticsearch configuration:

--- a/snippets/sc-shared-text/github.mdx
+++ b/snippets/sc-shared-text/github.mdx
@@ -3,7 +3,7 @@ Connect GitHub to your preprocessing pipeline, and batch process all your docume
 First, install the GitHub dependencies as shown here.
 
 ```bash
-pip install "unstructured[github]"
+pip install "unstructured-ingest[github]"
 ```
 
 Provide the GitHub repo URL (`url`) to fetch the files from, e.g. `"https://github.com/Unstructured-IO/unstructured"`

--- a/snippets/sc-shared-text/gitlab.mdx
+++ b/snippets/sc-shared-text/gitlab.mdx
@@ -3,7 +3,7 @@ Connect GitLab to your preprocessing pipeline, and batch process all your docume
 First, install the GitLab dependencies as shown here.
 
 ```bash
-pip install "unstructured[gitlab]"
+pip install "unstructured-ingest[gitlab]"
 ```
 
 Provide the GitLab repo URL (`url`) to fetch the files from, e.g. `"https://gitlab.com/gitlab-com/content-sites/docsy-gitlab"`,

--- a/snippets/sc-shared-text/google-cloud-storage.mdx
+++ b/snippets/sc-shared-text/google-cloud-storage.mdx
@@ -3,7 +3,7 @@ Connect Google Cloud Storage to your preprocessing pipeline, and batch process a
 First, install the Google Cloud Storage dependencies as shown here.
 
 ```bash
-pip install "unstructured[gcs]"
+pip install "unstructured-ingest[gcs]"
 ```
 
 Provide the `url` of your remote storage. You may also need to authenticate yourself with your service account key: use `token` parameter for this.

--- a/snippets/sc-shared-text/jira.mdx
+++ b/snippets/sc-shared-text/jira.mdx
@@ -4,7 +4,7 @@ First, install the Jira dependencies as shown here.
 
 
 ```bash
-pip install "unstructured[jira]"
+pip install "unstructured-ingest[jira]"
 ```
 
 To processes all the issues in projects within your Jira domain, you must specify:

--- a/snippets/sc-shared-text/local.mdx
+++ b/snippets/sc-shared-text/local.mdx
@@ -3,7 +3,7 @@ Connect local files to your preprocessing pipeline, and use the Unstructured Ing
 You will need the local source connector dependencies:
 
 ```bash CLI, Python
-pip install unstructured
+pip install unstructured-ingest
 ```
 
 To use the local source connector, you must set `--input-path` (CLI) or `input_path` (Python) to the path in the local filesystem which contains

--- a/snippets/sc-shared-text/notion.mdx
+++ b/snippets/sc-shared-text/notion.mdx
@@ -4,7 +4,7 @@ structured outputs locally on your filesystem.
 First, install the Notion dependencies as shown here:
 
 ```bash
-pip install "unstructured[notion]"
+pip install "unstructured-ingest[notion]"
 ```
 
 Make sure to provide `notion-api-key`. To get the credentials for your Notion workspace, follow the steps described

--- a/snippets/sc-shared-text/one-drive.mdx
+++ b/snippets/sc-shared-text/one-drive.mdx
@@ -4,7 +4,7 @@ store structured outputs locally on your filesystem.
 First, install the Airtable dependencies as shown here.
 
 ```bash
-pip install "unstructured[onedrive]"
+pip install "unstructured-ingest[onedrive]"
 ```
 
 When connecting to OneDrive, make sure to have your credentials ready:

--- a/snippets/sc-shared-text/opensearch.mdx
+++ b/snippets/sc-shared-text/opensearch.mdx
@@ -3,7 +3,7 @@ Connect OpenSearch to your preprocessing pipeline, and batch process all your do
 First, install the OpenSearch dependencies as shown here.
 
 ```bash
-pip install "unstructured[opensearch]"
+pip install "unstructured-ingest[opensearch]"
 ```
 
 Configure OpenSearch connection parameters:

--- a/snippets/sc-shared-text/outlook.mdx
+++ b/snippets/sc-shared-text/outlook.mdx
@@ -3,7 +3,7 @@ Connect Outlook to your preprocessing pipeline, and batch process all your docum
 First, install the Outlook dependencies as shown here.
 
 ```bash
-pip install "unstructured[outlook]"
+pip install "unstructured-ingest[outlook]"
 ```
 
 To use this source connector, you must enter a valid Azure AD app client-id, client secret, tenant-id, and email.

--- a/snippets/sc-shared-text/reddit.mdx
+++ b/snippets/sc-shared-text/reddit.mdx
@@ -3,7 +3,7 @@ Connect Reddit to your preprocessing pipeline, and batch process all your docume
 First, install the Reddit dependencies as shown here.
 
 ```bash
-pip install "unstructured[reddit]"
+pip install "unstructured-ingest[reddit]"
 ```
 
 You must provide:

--- a/snippets/sc-shared-text/salesforce.mdx
+++ b/snippets/sc-shared-text/salesforce.mdx
@@ -3,7 +3,7 @@ Connect Salesforce to your preprocessing pipeline, and batch process Salesforce 
 First, install the Salesforce dependencies as shown here.
 
 ```bash
-pip install "unstructured[salesforce]"
+pip install "unstructured-ingest[salesforce]"
 ```
 
 Salesforce source connector supports the following categories: Account, Case, Campaign, EmailMessage, Lead.

--- a/snippets/sc-shared-text/sftp.mdx
+++ b/snippets/sc-shared-text/sftp.mdx
@@ -4,7 +4,7 @@ For downloading an individual file specifically, the filename must have an exten
 First, install the SFTP dependencies as shown below .
 
 ```bash
-pip install "unstructured[sftp]"
+pip install "unstructured-ingest[sftp]"
 ```
 
 To connect to your SFTP storage, provide its `remote-url`, and authenticate yourself with `username` and `password`.

--- a/snippets/sc-shared-text/sharepoint.mdx
+++ b/snippets/sc-shared-text/sharepoint.mdx
@@ -4,7 +4,7 @@ store structured outputs locally on your filesystem.
 First, install the SharePoint dependencies as shown here.
 
 ```bash
-pip install "unstructured[sharepoint]"
+pip install "unstructured-ingest[sharepoint]"
 ```
 
 To authenticate the source connector with SharePoint, you must enter a MS Sharepoint app client-id, client secret and

--- a/snippets/sc-shared-text/slack.mdx
+++ b/snippets/sc-shared-text/slack.mdx
@@ -3,7 +3,7 @@ Connect Slack to your preprocessing pipeline, and batch process all your documen
 First, install the Slack dependencies as shown here.
 
 ```bash
-pip install "unstructured[slack]"
+pip install "unstructured-ingest[slack]"
 ```
 
 To authenticate the Slack source connector provide the following:

--- a/snippets/sc-shared-text/wikipedia.mdx
+++ b/snippets/sc-shared-text/wikipedia.mdx
@@ -3,7 +3,7 @@ Connect Wikipedia to your preprocessing pipeline, and batch process all your doc
 First, install the Wikipedia dependencies as shown here.
 
 ```bash
-pip install "unstructured[wikipedia]"
+pip install "unstructured-ingest[wikipedia]"
 ```
 
 Provide the `page-title` to ingest the text from.

--- a/snippets/source_connectors/airtable.py.mdx
+++ b/snippets/source_connectors/airtable.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.airtable import AirtableAccessConfig, SimpleAirtableConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.airtable import AirtableAccessConfig, SimpleAirtableConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import AirtableRunner
+from unstructured_ingest.runner import AirtableRunner
 
 if __name__ == "__main__":
     runner = AirtableRunner(

--- a/snippets/source_connectors/airtable_api.py.mdx
+++ b/snippets/source_connectors/airtable_api.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.airtable import AirtableAccessConfig, SimpleAirtableConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.airtable import AirtableAccessConfig, SimpleAirtableConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import AirtableRunner
+from unstructured_ingest.runner import AirtableRunner
 
 if __name__ == "__main__":
     runner = AirtableRunner(

--- a/snippets/source_connectors/astradb.v1.py.mdx
+++ b/snippets/source_connectors/astradb.v1.py.mdx
@@ -1,12 +1,12 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.runner import AstraDBRunner
-from unstructured.ingest.connector.astradb import (
+from unstructured_ingest.runner import AstraDBRunner
+from unstructured_ingest.connector.astradb import (
     SimpleAstraDBConfig,
     AstraDBAccessConfig
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     ProcessorConfig,
     ReadConfig,
     PartitionConfig

--- a/snippets/source_connectors/azure.v1.py.mdx
+++ b/snippets/source_connectors/azure.v1.py.mdx
@@ -1,16 +1,16 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.azure import (
+from unstructured_ingest.connector.fsspec.azure import (
     AzureAccessConfig,
     SimpleAzureBlobStorageConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import AzureRunner
+from unstructured_ingest.runner import AzureRunner
 
 if __name__ == "__main__":
     runner = AzureRunner(

--- a/snippets/source_connectors/azure.v2.py.mdx
+++ b/snippets/source_connectors/azure.v2.py.mdx
@@ -1,19 +1,19 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.azure import (
+from unstructured_ingest.v2.processes.connectors.fsspec.azure import (
     AzureIndexerConfig,
     AzureDownloaderConfig,
     AzureConnectionConfig,
     AzureAccessConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.local import LocalUploaderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.local import LocalUploaderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/biomed.py.mdx
+++ b/snippets/source_connectors/biomed.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
-from unstructured.ingest.connector.biomed import (
+from unstructured_ingest.connector.biomed import (
     SimpleBiomedConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import BiomedRunner
+from unstructured_ingest.runner import BiomedRunner
 
 if __name__ == "__main__":
     runner = BiomedRunner(

--- a/snippets/source_connectors/biomed_api.py.mdx
+++ b/snippets/source_connectors/biomed_api.py.mdx
@@ -1,15 +1,15 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.biomed import (
+from unstructured_ingest.connector.biomed import (
     SimpleBiomedConfig,
 )
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import BiomedRunner
+from unstructured_ingest.runner import BiomedRunner
 
 if __name__ == "__main__":
     runner = BiomedRunner(

--- a/snippets/source_connectors/box.v1.py.mdx
+++ b/snippets/source_connectors/box.v1.py.mdx
@@ -1,13 +1,13 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.box import BoxAccessConfig, SimpleBoxConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.box import BoxAccessConfig, SimpleBoxConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import BoxRunner
+from unstructured_ingest.runner import BoxRunner
 
 if __name__ == "__main__":
     runner = BoxRunner(

--- a/snippets/source_connectors/box.v2.py.mdx
+++ b/snippets/source_connectors/box.v2.py.mdx
@@ -1,20 +1,20 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.box import (
+from unstructured_ingest.v2.processes.connectors.fsspec.box import (
     BoxAccessConfig,
     BoxConnectionConfig,
     BoxIndexerConfig,
     BoxDownloaderConfig
 )
 
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.local import LocalUploaderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.local import LocalUploaderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/box_api.py.mdx
+++ b/snippets/source_connectors/box_api.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.fsspec.box import BoxAccessConfig, SimpleBoxConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.box import BoxAccessConfig, SimpleBoxConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import BoxRunner
+from unstructured_ingest.runner import BoxRunner
 
 if __name__ == "__main__":
     runner = BoxRunner(

--- a/snippets/source_connectors/confluence.py.mdx
+++ b/snippets/source_connectors/confluence.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.confluence import ConfluenceAccessConfig, SimpleConfluenceConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import ConfluenceRunner
+from unstructured_ingest.connector.confluence import ConfluenceAccessConfig, SimpleConfluenceConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import ConfluenceRunner
 
 if __name__ == "__main__":
     runner = ConfluenceRunner(

--- a/snippets/source_connectors/confluence_api.py.mdx
+++ b/snippets/source_connectors/confluence_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.confluence import ConfluenceAccessConfig, SimpleConfluenceConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import ConfluenceRunner
+from unstructured_ingest.connector.confluence import ConfluenceAccessConfig, SimpleConfluenceConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import ConfluenceRunner
 
 if __name__ == "__main__":
     runner = ConfluenceRunner(

--- a/snippets/source_connectors/delta_table.py.mdx
+++ b/snippets/source_connectors/delta_table.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.delta_table import SimpleDeltaTableConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import DeltaTableRunner
+from unstructured_ingest.connector.delta_table import SimpleDeltaTableConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import DeltaTableRunner
 
 if __name__ == "__main__":
     runner = DeltaTableRunner(

--- a/snippets/source_connectors/delta_table_api.py.mdx
+++ b/snippets/source_connectors/delta_table_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.delta_table import SimpleDeltaTableConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import DeltaTableRunner
+from unstructured_ingest.connector.delta_table import SimpleDeltaTableConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import DeltaTableRunner
 
 if __name__ == "__main__":
     runner = DeltaTableRunner(

--- a/snippets/source_connectors/discord.py.mdx
+++ b/snippets/source_connectors/discord.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.discord import DiscordAccessConfig, SimpleDiscordConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import DiscordRunner
+from unstructured_ingest.connector.discord import DiscordAccessConfig, SimpleDiscordConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import DiscordRunner
 
 if __name__ == "__main__":
     runner = DiscordRunner(

--- a/snippets/source_connectors/discord_api.py.mdx
+++ b/snippets/source_connectors/discord_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.discord import DiscordAccessConfig, SimpleDiscordConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import DiscordRunner
+from unstructured_ingest.connector.discord import DiscordAccessConfig, SimpleDiscordConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import DiscordRunner
 
 if __name__ == "__main__":
     runner = DiscordRunner(

--- a/snippets/source_connectors/dropbox.v1.py.mdx
+++ b/snippets/source_connectors/dropbox.v1.py.mdx
@@ -1,13 +1,13 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.dropbox import DropboxAccessConfig, SimpleDropboxConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.dropbox import DropboxAccessConfig, SimpleDropboxConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import DropboxRunner
+from unstructured_ingest.runner import DropboxRunner
 
 if __name__ == "__main__":
     runner = DropboxRunner(

--- a/snippets/source_connectors/dropbox.v2.py.mdx
+++ b/snippets/source_connectors/dropbox.v2.py.mdx
@@ -1,22 +1,22 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured.ingest.v2.processes.connectors.fsspec.dropbox import (
+from unstructured_ingest.v2.processes.connectors.fsspec.dropbox import (
     DropboxIndexerConfig,
     DropboxDownloaderConfig,
     DropboxAccessConfig,
     DropboxConnectionConfig
 )
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalConnectionConfig,
     LocalUploaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/elasticsearch.py.mdx
+++ b/snippets/source_connectors/elasticsearch.py.mdx
@@ -1,10 +1,10 @@
 ```python Python
-from unstructured.ingest.connector.elasticsearch import (
+from unstructured_ingest.connector.elasticsearch import (
     ElasticsearchAccessConfig,
     SimpleElasticsearchConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import ElasticSearchRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import ElasticSearchRunner
 
 if __name__ == "__main__":
     runner = ElasticSearchRunner(

--- a/snippets/source_connectors/elasticsearch_api.py.mdx
+++ b/snippets/source_connectors/elasticsearch_api.py.mdx
@@ -1,12 +1,12 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.elasticsearch import (
+from unstructured_ingest.connector.elasticsearch import (
     ElasticsearchAccessConfig,
     SimpleElasticsearchConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import ElasticSearchRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import ElasticSearchRunner
 
 if __name__ == "__main__":
     runner = ElasticSearchRunner(

--- a/snippets/source_connectors/gcs.py.mdx
+++ b/snippets/source_connectors/gcs.py.mdx
@@ -1,11 +1,11 @@
 ```python Python
-from unstructured.ingest.connector.fsspec.gcs import GcsAccessConfig, SimpleGcsConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.gcs import GcsAccessConfig, SimpleGcsConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import GCSRunner
+from unstructured_ingest.runner import GCSRunner
 
 if __name__ == "__main__":
     runner = GCSRunner(

--- a/snippets/source_connectors/gcs_api.py.mdx
+++ b/snippets/source_connectors/gcs_api.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.fsspec.gcs import GcsAccessConfig, SimpleGcsConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.gcs import GcsAccessConfig, SimpleGcsConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import GCSRunner
+from unstructured_ingest.runner import GCSRunner
 
 if __name__ == "__main__":
     runner = GCSRunner(

--- a/snippets/source_connectors/github.py.mdx
+++ b/snippets/source_connectors/github.py.mdx
@@ -1,8 +1,8 @@
 ```python Python
-from unstructured.ingest.connector.git import GitAccessConfig
-from unstructured.ingest.connector.github import SimpleGitHubConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import GithubRunner
+from unstructured_ingest.connector.git import GitAccessConfig
+from unstructured_ingest.connector.github import SimpleGitHubConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import GithubRunner
 
 if __name__ == "__main__":
     runner = GithubRunner(

--- a/snippets/source_connectors/github_api.py.mdx
+++ b/snippets/source_connectors/github_api.py.mdx
@@ -1,10 +1,10 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.git import GitAccessConfig
-from unstructured.ingest.connector.github import SimpleGitHubConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import GithubRunner
+from unstructured_ingest.connector.git import GitAccessConfig
+from unstructured_ingest.connector.github import SimpleGitHubConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import GithubRunner
 
 if __name__ == "__main__":
     runner = GithubRunner(

--- a/snippets/source_connectors/gitlab.py.mdx
+++ b/snippets/source_connectors/gitlab.py.mdx
@@ -1,8 +1,8 @@
 ```python Python
-from unstructured.ingest.connector.git import GitAccessConfig
-from unstructured.ingest.connector.gitlab import SimpleGitlabConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import GitlabRunner
+from unstructured_ingest.connector.git import GitAccessConfig
+from unstructured_ingest.connector.gitlab import SimpleGitlabConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import GitlabRunner
 
 if __name__ == "__main__":
     runner = GitlabRunner(

--- a/snippets/source_connectors/gitlab_api.py.mdx
+++ b/snippets/source_connectors/gitlab_api.py.mdx
@@ -1,10 +1,10 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.git import GitAccessConfig
-from unstructured.ingest.connector.gitlab import SimpleGitlabConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import GitlabRunner
+from unstructured_ingest.connector.git import GitAccessConfig
+from unstructured_ingest.connector.gitlab import SimpleGitlabConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import GitlabRunner
 
 if __name__ == "__main__":
     runner = GitlabRunner(

--- a/snippets/source_connectors/google_drive.v1.py.mdx
+++ b/snippets/source_connectors/google_drive.v1.py.mdx
@@ -1,12 +1,12 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.google_drive import (
+from unstructured_ingest.connector.google_drive import (
     GoogleDriveAccessConfig,
     SimpleGoogleDriveConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import GoogleDriveRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import GoogleDriveRunner
 
 if __name__ == "__main__":
     runner = GoogleDriveRunner(

--- a/snippets/source_connectors/google_drive.v2.py.mdx
+++ b/snippets/source_connectors/google_drive.v2.py.mdx
@@ -1,18 +1,18 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
-from unstructured.ingest.v2.processes.connectors.google_drive import (
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.google_drive import (
     GoogleDriveConnectionConfig,
     GoogleDriveAccessConfig,
     GoogleDriveIndexerConfig,
     GoogleDriveDownloaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.local import LocalUploaderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.local import LocalUploaderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/jira.py.mdx
+++ b/snippets/source_connectors/jira.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.jira import JiraAccessConfig, SimpleJiraConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import JiraRunner
+from unstructured_ingest.connector.jira import JiraAccessConfig, SimpleJiraConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import JiraRunner
 
 if __name__ == "__main__":
     runner = JiraRunner(

--- a/snippets/source_connectors/jira_api.py.mdx
+++ b/snippets/source_connectors/jira_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.jira import JiraAccessConfig, SimpleJiraConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import JiraRunner
+from unstructured_ingest.connector.jira import JiraAccessConfig, SimpleJiraConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import JiraRunner
 
 if __name__ == "__main__":
     runner = JiraRunner(

--- a/snippets/source_connectors/local.v1.py.mdx
+++ b/snippets/source_connectors/local.v1.py.mdx
@@ -1,9 +1,9 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.local import SimpleLocalConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import LocalRunner
+from unstructured_ingest.connector.local import SimpleLocalConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import LocalRunner
 
 if __name__ == "__main__":
     runner = LocalRunner(

--- a/snippets/source_connectors/local.v2.py.mdx
+++ b/snippets/source_connectors/local.v2.py.mdx
@@ -1,17 +1,17 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
-from unstructured.ingest.v2.processes.connectors.local import (
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.local import (
     LocalIndexerConfig,
     LocalDownloaderConfig,
     LocalConnectionConfig,
     LocalUploaderConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/mongodb.v1.py.mdx
+++ b/snippets/source_connectors/mongodb.v1.py.mdx
@@ -1,11 +1,11 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.mongodb import (
+from unstructured_ingest.connector.mongodb import (
     SimpleMongoDBConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import MongoDBRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import MongoDBRunner
 
 if __name__ == "__main__":
     runner = MongoDBRunner(

--- a/snippets/source_connectors/notion.py.mdx
+++ b/snippets/source_connectors/notion.py.mdx
@@ -1,7 +1,7 @@
 ```python Python
-from unstructured.ingest.connector.notion.connector import NotionAccessConfig, SimpleNotionConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import NotionRunner
+from unstructured_ingest.connector.notion.connector import NotionAccessConfig, SimpleNotionConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import NotionRunner
 
 if __name__ == "__main__":
     runner = NotionRunner(

--- a/snippets/source_connectors/notion_api.py.mdx
+++ b/snippets/source_connectors/notion_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.notion.connector import NotionAccessConfig, SimpleNotionConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import NotionRunner
+from unstructured_ingest.connector.notion.connector import NotionAccessConfig, SimpleNotionConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import NotionRunner
 
 if __name__ == "__main__":
     runner = NotionRunner(

--- a/snippets/source_connectors/onedrive.py.mdx
+++ b/snippets/source_connectors/onedrive.py.mdx
@@ -1,7 +1,7 @@
 ```python Python
-from unstructured.ingest.connector.onedrive import OneDriveAccessConfig, SimpleOneDriveConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OneDriveRunner
+from unstructured_ingest.connector.onedrive import OneDriveAccessConfig, SimpleOneDriveConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OneDriveRunner
 
 if __name__ == "__main__":
     runner = OneDriveRunner(

--- a/snippets/source_connectors/onedrive_api.py.mdx
+++ b/snippets/source_connectors/onedrive_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.onedrive import OneDriveAccessConfig, SimpleOneDriveConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OneDriveRunner
+from unstructured_ingest.connector.onedrive import OneDriveAccessConfig, SimpleOneDriveConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OneDriveRunner
 
 if __name__ == "__main__":
     runner = OneDriveRunner(

--- a/snippets/source_connectors/opensearch.py.mdx
+++ b/snippets/source_connectors/opensearch.py.mdx
@@ -1,10 +1,10 @@
 ```python Python
-from unstructured.ingest.connector.opensearch import (
+from unstructured_ingest.connector.opensearch import (
     OpenSearchAccessConfig,
     SimpleOpenSearchConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OpenSearchRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OpenSearchRunner
 
 if __name__ == "__main__":
     runner = OpenSearchRunner(

--- a/snippets/source_connectors/opensearch_api.py.mdx
+++ b/snippets/source_connectors/opensearch_api.py.mdx
@@ -1,12 +1,12 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.opensearch import (
+from unstructured_ingest.connector.opensearch import (
     OpenSearchAccessConfig,
     SimpleOpenSearchConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OpenSearchRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OpenSearchRunner
 
 if __name__ == "__main__":
     runner = OpenSearchRunner(

--- a/snippets/source_connectors/outlook.py.mdx
+++ b/snippets/source_connectors/outlook.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.outlook import OutlookAccessConfig, SimpleOutlookConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OutlookRunner
+from unstructured_ingest.connector.outlook import OutlookAccessConfig, SimpleOutlookConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OutlookRunner
 
 if __name__ == "__main__":
     runner = OutlookRunner(

--- a/snippets/source_connectors/outlook_api.py.mdx
+++ b/snippets/source_connectors/outlook_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.outlook import OutlookAccessConfig, SimpleOutlookConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import OutlookRunner
+from unstructured_ingest.connector.outlook import OutlookAccessConfig, SimpleOutlookConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import OutlookRunner
 
 if __name__ == "__main__":
     runner = OutlookRunner(

--- a/snippets/source_connectors/reddit.py.mdx
+++ b/snippets/source_connectors/reddit.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.reddit import RedditAccessConfig, SimpleRedditConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import RedditRunner
+from unstructured_ingest.connector.reddit import RedditAccessConfig, SimpleRedditConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import RedditRunner
 
 if __name__ == "__main__":
     runner = RedditRunner(

--- a/snippets/source_connectors/reddit_api.py.mdx
+++ b/snippets/source_connectors/reddit_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.reddit import RedditAccessConfig, SimpleRedditConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import RedditRunner
+from unstructured_ingest.connector.reddit import RedditAccessConfig, SimpleRedditConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import RedditRunner
 
 if __name__ == "__main__":
     runner = RedditRunner(

--- a/snippets/source_connectors/s3.v1.py.mdx
+++ b/snippets/source_connectors/s3.v1.py.mdx
@@ -1,13 +1,13 @@
 ```python Python Ingest v1
 import os
 
-from unstructured.ingest.connector.fsspec.s3 import S3AccessConfig, SimpleS3Config
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.s3 import S3AccessConfig, SimpleS3Config
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import S3Runner
+from unstructured_ingest.runner import S3Runner
 
 if __name__ == "__main__":
     runner = S3Runner(

--- a/snippets/source_connectors/s3.v2.py.mdx
+++ b/snippets/source_connectors/s3.v2.py.mdx
@@ -1,18 +1,18 @@
 ```python Python Ingest v2
 import os
 
-from unstructured.ingest.v2.pipeline.pipeline import Pipeline
-from unstructured.ingest.v2.interfaces import ProcessorConfig
-from unstructured.ingest.v2.processes.connectors.fsspec.s3 import (
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.fsspec.s3 import (
     S3IndexerConfig,
     S3DownloaderConfig,
     S3ConnectionConfig,
     S3AccessConfig
 )
-from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
-from unstructured.ingest.v2.processes.chunker import ChunkerConfig
-from unstructured.ingest.v2.processes.embedder import EmbedderConfig
-from unstructured.ingest.v2.processes.connectors.local import LocalUploaderConfig
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+from unstructured_ingest.v2.processes.chunker import ChunkerConfig
+from unstructured_ingest.v2.processes.embedder import EmbedderConfig
+from unstructured_ingest.v2.processes.connectors.local import LocalUploaderConfig
 
 if __name__ == "__main__":
     Pipeline.from_configs(

--- a/snippets/source_connectors/salesforce.py.mdx
+++ b/snippets/source_connectors/salesforce.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.salesforce import SalesforceAccessConfig, SimpleSalesforceConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SalesforceRunner
+from unstructured_ingest.connector.salesforce import SalesforceAccessConfig, SimpleSalesforceConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SalesforceRunner
 
 if __name__ == "__main__":
     runner = SalesforceRunner(

--- a/snippets/source_connectors/salesforce_api.py.mdx
+++ b/snippets/source_connectors/salesforce_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.salesforce import SalesforceAccessConfig, SimpleSalesforceConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SalesforceRunner
+from unstructured_ingest.connector.salesforce import SalesforceAccessConfig, SimpleSalesforceConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SalesforceRunner
 
 if __name__ == "__main__":
     runner = SalesforceRunner(

--- a/snippets/source_connectors/sftp.py.mdx
+++ b/snippets/source_connectors/sftp.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.fsspec.sftp import SftpAccessConfig, SimpleSftpConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.sftp import SftpAccessConfig, SimpleSftpConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import SftpRunner
+from unstructured_ingest.runner import SftpRunner
 
 if __name__ == "__main__":
     runner = SftpRunner(

--- a/snippets/source_connectors/sftp_api.py.mdx
+++ b/snippets/source_connectors/sftp_api.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.fsspec.sftp import SftpAccessConfig, SimpleSftpConfig
-from unstructured.ingest.interfaces import (
+from unstructured_ingest.connector.fsspec.sftp import SftpAccessConfig, SimpleSftpConfig
+from unstructured_ingest.interfaces import (
     PartitionConfig,
     ProcessorConfig,
     ReadConfig,
 )
-from unstructured.ingest.runner import SftpRunner
+from unstructured_ingest.runner import SftpRunner
 
 if __name__ == "__main__":
     runner = SftpRunner(

--- a/snippets/source_connectors/sharepoint.py.mdx
+++ b/snippets/source_connectors/sharepoint.py.mdx
@@ -1,11 +1,11 @@
 ```python Python
-from unstructured.ingest.connector.sharepoint import (
+from unstructured_ingest.connector.sharepoint import (
     SharepointAccessConfig,
     SharepointPermissionsConfig,
     SimpleSharepointConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SharePointRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SharePointRunner
 
 if __name__ == "__main__":
     runner = SharePointRunner(

--- a/snippets/source_connectors/sharepoint_api.py.mdx
+++ b/snippets/source_connectors/sharepoint_api.py.mdx
@@ -1,13 +1,13 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.sharepoint import (
+from unstructured_ingest.connector.sharepoint import (
     SharepointAccessConfig,
     SharepointPermissionsConfig,
     SimpleSharepointConfig,
 )
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SharePointRunner
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SharePointRunner
 
 if __name__ == "__main__":
     runner = SharePointRunner(

--- a/snippets/source_connectors/slack.py.mdx
+++ b/snippets/source_connectors/slack.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.slack import SimpleSlackConfig, SlackAccessConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SlackRunner
+from unstructured_ingest.connector.slack import SimpleSlackConfig, SlackAccessConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SlackRunner
 
 if __name__ == "__main__":
     runner = SlackRunner(

--- a/snippets/source_connectors/slack_api.py.mdx
+++ b/snippets/source_connectors/slack_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.slack import SimpleSlackConfig, SlackAccessConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import SlackRunner
+from unstructured_ingest.connector.slack import SimpleSlackConfig, SlackAccessConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import SlackRunner
 
 if __name__ == "__main__":
     runner = SlackRunner(

--- a/snippets/source_connectors/wikipedia.py.mdx
+++ b/snippets/source_connectors/wikipedia.py.mdx
@@ -1,7 +1,7 @@
 ```python Python
-from unstructured.ingest.connector.wikipedia import SimpleWikipediaConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import WikipediaRunner
+from unstructured_ingest.connector.wikipedia import SimpleWikipediaConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import WikipediaRunner
 
 if __name__ == "__main__":
     runner = WikipediaRunner(

--- a/snippets/source_connectors/wikipedia_api.py.mdx
+++ b/snippets/source_connectors/wikipedia_api.py.mdx
@@ -1,9 +1,9 @@
 ```python Python
 import os
 
-from unstructured.ingest.connector.wikipedia import SimpleWikipediaConfig
-from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
-from unstructured.ingest.runner import WikipediaRunner
+from unstructured_ingest.connector.wikipedia import SimpleWikipediaConfig
+from unstructured_ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+from unstructured_ingest.runner import WikipediaRunner
 
 if __name__ == "__main__":
     runner = WikipediaRunner(


### PR DESCRIPTION
Includes:

- New installation commands for the Unstructured Ingest CLI and Unstructured Ingest Python library.
- New imports for the Ingest Python library.
- Migration guide for getting from old to new.
- Updated all impacted `pip install unstructured` and `import unstructured.ingest` mentions across the docs. 

See for example:

- https://unstructured-53-docs-45-ingest-upgrade.mintlify.app/api-reference/ingest/ingest-cli#installation
- https://unstructured-53-docs-45-ingest-upgrade.mintlify.app/api-reference/ingest/python-ingest#installation
- https://unstructured-53-docs-45-ingest-upgrade.mintlify.app/ingestion/overview#migration-guide