### PR TITLE
Source/destination connector content refactoring to accommodate Platform

### DIFF
--- a/api-reference/ingest/destination-connector/astradb.mdx
+++ b/api-reference/ingest/destination-connector/astradb.mdx
@@ -2,7 +2,7 @@
 title: Astra DB
 ---
 
-import SharedAstraDB from '/snippets/dc-shared-text/astradb.mdx';
+import SharedAstraDB from '/snippets/dc-shared-text/astradb-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAstraDB />

--- a/api-reference/ingest/destination-connector/azure.mdx
+++ b/api-reference/ingest/destination-connector/azure.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentAzure from '/snippets/dc-shared-text/azure.mdx';
+import SharedContentAzure from '/snippets/dc-shared-text/azure-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentAzure/>

--- a/api-reference/ingest/destination-connector/box.mdx
+++ b/api-reference/ingest/destination-connector/box.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentBox from '/snippets/dc-shared-text/box.mdx';
+import SharedContentBox from '/snippets/dc-shared-text/box-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentBox/>

--- a/api-reference/ingest/destination-connector/dropbox.mdx
+++ b/api-reference/ingest/destination-connector/dropbox.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentDropbox from '/snippets/dc-shared-text/dropbox.mdx';
+import SharedContentDropbox from '/snippets/dc-shared-text/dropbox-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentDropbox/>

--- a/api-reference/ingest/destination-connector/mongodb.mdx
+++ b/api-reference/ingest/destination-connector/mongodb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentMongoDB from '/snippets/dc-shared-text/mongodb.mdx';
+import SharedContentMongoDB from '/snippets/dc-shared-text/mongodb-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentMongoDB/>

--- a/api-reference/ingest/destination-connector/s3.mdx
+++ b/api-reference/ingest/destination-connector/s3.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentS3 from '/snippets/dc-shared-text/s3.mdx';
+import SharedContentS3 from '/snippets/dc-shared-text/s3-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentS3/>

--- a/api-reference/ingest/destination-connector/singlestore.mdx
+++ b/api-reference/ingest/destination-connector/singlestore.mdx
@@ -6,10 +6,12 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedSingleStore from '/snippets/dc-shared-text/singlestore.mdx';
+import SharedSingleStore from '/snippets/dc-shared-text/singlestore-cli-api.mdx';
+import SharedSingleStoreCLIAPI from '/snippets/general-shared-text/singlestore-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedSingleStore />
+<SharedSingleStoreCLIAPI />
 <SharedAPIKeyURL/>
 
 Now call the Unstructured Ingest CLI or the Unstructured Ingest Python library. The source connector can be any of the ones supported. This example uses the local source connector:

--- a/api-reference/ingest/source-connectors/astradb.mdx
+++ b/api-reference/ingest/source-connectors/astradb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentAstraDB from '/snippets/sc-shared-text/astradb.mdx';
+import SharedContentAstraDB from '/snippets/sc-shared-text/astradb-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentAstraDB/>

--- a/api-reference/ingest/source-connectors/azure.mdx
+++ b/api-reference/ingest/source-connectors/azure.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentAzure from '/snippets/sc-shared-text/azure.mdx';
+import SharedContentAzure from '/snippets/sc-shared-text/azure-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentAzure/>

--- a/api-reference/ingest/source-connectors/box.mdx
+++ b/api-reference/ingest/source-connectors/box.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentBox from '/snippets/sc-shared-text/box.mdx';
+import SharedContentBox from '/snippets/sc-shared-text/box-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentBox/>

--- a/api-reference/ingest/source-connectors/dropbox.mdx
+++ b/api-reference/ingest/source-connectors/dropbox.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentDropbox from '/snippets/sc-shared-text/dropbox.mdx';
+import SharedContentDropbox from '/snippets/sc-shared-text/dropbox-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentDropbox/>

--- a/api-reference/ingest/source-connectors/google-drive.mdx
+++ b/api-reference/ingest/source-connectors/google-drive.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentGoogleDrive from '/snippets/sc-shared-text/google-drive.mdx';
+import SharedContentGoogleDrive from '/snippets/sc-shared-text/google-drive-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentGoogleDrive/>

--- a/api-reference/ingest/source-connectors/mongodb.mdx
+++ b/api-reference/ingest/source-connectors/mongodb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb.mdx';
+import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentMongoDB/>

--- a/api-reference/ingest/source-connectors/s3.mdx
+++ b/api-reference/ingest/source-connectors/s3.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentS3 from '/snippets/sc-shared-text/s3.mdx';
+import SharedContentS3 from '/snippets/sc-shared-text/s3-cli-api.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedContentS3/>

--- a/open-source/ingest/destination-connectors/astradb.mdx
+++ b/open-source/ingest/destination-connectors/astradb.mdx
@@ -2,7 +2,11 @@
 title: Astra DB
 ---
 
-import SharedAstraDB from '/snippets/dc-shared-text/astradb.mdx';
+import NewDocument from '/snippets/general-shared-text/new-document.mdx';
+
+<NewDocument />
+
+import SharedAstraDB from '/snippets/dc-shared-text/astradb-cli-api.mdx';
 
 <SharedAstraDB />
 

--- a/open-source/ingest/destination-connectors/azure.mdx
+++ b/open-source/ingest/destination-connectors/azure.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedAzure from '/snippets/dc-shared-text/azure.mdx';
+import SharedAzure from '/snippets/dc-shared-text/azure-cli-api.mdx';
 
 <SharedAzure />
 

--- a/open-source/ingest/destination-connectors/box.mdx
+++ b/open-source/ingest/destination-connectors/box.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedBox from '/snippets/dc-shared-text/box.mdx';
+import SharedBox from '/snippets/dc-shared-text/box-cli-api.mdx';
 
 <SharedBox />
 

--- a/open-source/ingest/destination-connectors/dropbox.mdx
+++ b/open-source/ingest/destination-connectors/dropbox.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedDropbox from '/snippets/dc-shared-text/dropbox.mdx';
+import SharedDropbox from '/snippets/dc-shared-text/dropbox-cli-api.mdx';
 
 <SharedDropbox />
 

--- a/open-source/ingest/destination-connectors/mongodb.mdx
+++ b/open-source/ingest/destination-connectors/mongodb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedMongoDB from '/snippets/dc-shared-text/mongodb.mdx';
+import SharedMongoDB from '/snippets/dc-shared-text/mongodb-cli-api.mdx';
 
 <SharedMongoDB />
 

--- a/open-source/ingest/destination-connectors/s3.mdx
+++ b/open-source/ingest/destination-connectors/s3.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedS3 from '/snippets/dc-shared-text/s3.mdx';
+import SharedS3 from '/snippets/dc-shared-text/s3-cli-api.mdx';
 
 <SharedS3 />
 

--- a/open-source/ingest/destination-connectors/singlestore.mdx
+++ b/open-source/ingest/destination-connectors/singlestore.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedSingleStore from '/snippets/dc-shared-text/singlestore.mdx';
+import SharedSingleStore from '/snippets/dc-shared-text/singlestore-cli-api.mdx';
 
 <SharedSingleStore />
 
@@ -28,6 +28,8 @@ import SingleStoreAPIPyV2 from '/snippets/destination_connectors/singlestore.v2.
 import SharedSingleStoreSchema from '/snippets/general-shared-text/singlestore-schema.mdx';
 
 <SharedSingleStoreSchema/>
+
+## Calling Unstuctured API services
 
 import SharedPartitionByAPIOSS from '/snippets/ingest-configuration-shared/partition-by-api-oss.mdx';
 

--- a/open-source/ingest/source-connectors/astradb.mdx
+++ b/open-source/ingest/source-connectors/astradb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentAstraDB from '/snippets/sc-shared-text/astradb.mdx';
+import SharedContentAstraDB from '/snippets/sc-shared-text/astradb-cli-api.mdx';
 
 <SharedContentAstraDB/>
 

--- a/open-source/ingest/source-connectors/azure.mdx
+++ b/open-source/ingest/source-connectors/azure.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentAzure from '/snippets/sc-shared-text/azure.mdx';
+import SharedContentAzure from '/snippets/sc-shared-text/azure-cli-api.mdx';
 
 <SharedContentAzure/>
 

--- a/open-source/ingest/source-connectors/box.mdx
+++ b/open-source/ingest/source-connectors/box.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentBox from '/snippets/sc-shared-text/box.mdx';
+import SharedContentBox from '/snippets/sc-shared-text/box-cli-api.mdx';
 
 <SharedContentBox/>
 

--- a/open-source/ingest/source-connectors/dropbox.mdx
+++ b/open-source/ingest/source-connectors/dropbox.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentDropbox from '/snippets/sc-shared-text/dropbox.mdx';
+import SharedContentDropbox from '/snippets/sc-shared-text/dropbox-cli-api.mdx';
 
 <SharedContentDropbox/>
 

--- a/open-source/ingest/source-connectors/google-drive.mdx
+++ b/open-source/ingest/source-connectors/google-drive.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentGoogleDrive from '/snippets/sc-shared-text/google-drive.mdx';
+import SharedContentGoogleDrive from '/snippets/sc-shared-text/google-drive-cli-api.mdx';
 
 <SharedContentGoogleDrive/>
 

--- a/open-source/ingest/source-connectors/mongodb.mdx
+++ b/open-source/ingest/source-connectors/mongodb.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb.mdx';
+import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb-cli-api.mdx';
 
 <SharedContentMongoDB/>
 

--- a/open-source/ingest/source-connectors/s3.mdx
+++ b/open-source/ingest/source-connectors/s3.mdx
@@ -6,7 +6,7 @@ import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
 <NewDocument />
 
-import SharedContentS3 from '/snippets/sc-shared-text/s3.mdx';
+import SharedContentS3 from '/snippets/sc-shared-text/s3-cli-api.mdx';
 
 <SharedContentS3/>
 

--- a/snippets/dc-shared-text/astradb-cli-api.mdx
+++ b/snippets/dc-shared-text/astradb-cli-api.mdx
@@ -4,6 +4,9 @@ Batch process all your records to store structured outputs in an Astra DB accoun
 You will need:
 
 import AstraDBShared from '/snippets/general-shared-text/astradb.mdx';
+import AstraDBSharedCLIAPI from '/snippets/general-shared-text/astradb-cli-api.mdx';
 
 <AstraDBShared />
+<AstraDBSharedCLIAPI />
+
 

--- a/snippets/dc-shared-text/azure-cli-api.mdx
+++ b/snippets/dc-shared-text/azure-cli-api.mdx
@@ -3,5 +3,7 @@ Batch process all your records to store structured outputs in an Azure Storage a
 You will need:
 
 import SharedAzure from '/snippets/general-shared-text/azure.mdx';
+import SharedAzureCLIAPI from '/snippets/general-shared-text/azure-cli-api.mdx';
 
 <SharedAzure />
+<SharedAzureCLIAPI />

--- a/snippets/dc-shared-text/box-cli-api.mdx
+++ b/snippets/dc-shared-text/box-cli-api.mdx
@@ -3,3 +3,7 @@ Batch process all your records to store structured outputs in a Box account.
 You will need:
 
 import SharedBox from '/snippets/general-shared-text/box.mdx';
+import SharedBoxCLIAPI from '/snippets/general-shared-text/box-cli-api.mdx';
+
+<SharedBox />
+<SharedBoxCLIAPI />

--- a/snippets/dc-shared-text/dropbox-cli-api.mdx
+++ b/snippets/dc-shared-text/dropbox-cli-api.mdx
@@ -3,5 +3,7 @@ Batch process all your records to store structured outputs in a Dropbox account.
 You will need:
 
 import SharedDropbox from '/snippets/general-shared-text/dropbox.mdx';
+import SharedDropboxCLIAPI from '/snippets/general-shared-text/dropbox-cli-api.mdx';
 
 <SharedDropbox />
+<SharedDropboxCLIAPI />

--- a/snippets/dc-shared-text/mongodb-cli-api.mdx
+++ b/snippets/dc-shared-text/mongodb-cli-api.mdx
@@ -1,0 +1,9 @@
+Batch process all your records to store structured outputs in MongoDB.
+
+You will need:
+
+import SharedMongoDB from '/snippets/general-shared-text/mongodb.mdx';
+import SharedMongoDBCLIAPI from '/snippets/general-shared-text/mongodb-cli-api.mdx';
+
+<SharedMongoDB />
+<SharedMongoDBCLIAPI />

--- a/snippets/dc-shared-text/mongodb.mdx
+++ b/snippets/dc-shared-text/mongodb.mdx
@@ -1,7 +1,0 @@
-Batch process all your records to store structured outputs in MongoDB.
-
-You will need:
-
-import SharedAzure from '/snippets/general-shared-text/mongodb.mdx';
-
-<SharedAzure />

--- a/snippets/dc-shared-text/s3-cli-api.mdx
+++ b/snippets/dc-shared-text/s3-cli-api.mdx
@@ -1,0 +1,9 @@
+Batch process all your records to store structured outputs in an S3 bucket.
+
+You will need:
+
+import SharedS3 from '/snippets/general-shared-text/s3-cli-api.mdx';
+import SharedS3CLIAPI from '/snippets/general-shared-text/s3-cli-api.mdx';
+
+<SharedS3 />
+<SharedS3CLIAPI />

--- a/snippets/dc-shared-text/s3.mdx
+++ b/snippets/dc-shared-text/s3.mdx
@@ -1,7 +1,0 @@
-Batch process all your records to store structured outputs in an S3 bucket.
-
-You will need:
-
-import SharedS3 from '/snippets/general-shared-text/s3.mdx';
-
-<SharedS3 />

--- a/snippets/dc-shared-text/singlestore-cli-api.mdx
+++ b/snippets/dc-shared-text/singlestore-cli-api.mdx
@@ -3,5 +3,7 @@ Batch process all your records to store structured outputs in a SingleStore acco
 You will need:
 
 import SingleStoreShared from '/snippets/general-shared-text/singlestore.mdx';
+import SingleStoreSharedCLIAPI from '/snippets/general-shared-text/singlestore-cli-api.mdx';
 
 <SingleStoreShared />
+<SingleStoreSharedCLIAPI />

--- a/snippets/general-shared-text/astradb-cli-api.mdx
+++ b/snippets/general-shared-text/astradb-cli-api.mdx
@@ -1,0 +1,13 @@
+The Astra DB connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[astradb]"
+```
+
+These environment variables:
+
+- `ASTRA_DB_API_ENDPOINT` - The API endpoint for the Astra DB database, represented by `--api-endpoint` (CLI) or `api_endpoint` (Python). To get the endpoint, see the **Database Details > API Endpoint** value on your database's **Overview** tab.
+- `ASTRA_DB_APPLICATION_TOKEN` - The database application token value for the database, represented by `--token` (CLI) or `token` (Python). To get the token, see the **Database Details > Application Tokens** box on your database's **Overview** tab.
+- `ASTRA_DB_NAMESPACE` - The name of the namespace for the database, represented by `--namespace` (CLI) or `namespace` (Python).
+- `ASTRA_DB_COLLECTION` - The name of the collection for the namespace, represented by `--collection-name` (CLI) or `collection_name` (Python). 
+- `ASTRA_DB_EMBEDDING_DIMENSIONS` - The number of dimensions in the collection, represented by `--embedding-dimension` (CLI) or `embedding_dimension` (Python).

--- a/snippets/general-shared-text/astradb.mdx
+++ b/snippets/general-shared-text/astradb.mdx
@@ -1,21 +1,7 @@
-The Astra DB connector dependencies:
+The Astra DB connector prerequisites:
 
-```bash CLI, Python
-pip install "unstructured-ingest[astradb]"
-```
-
-These environment variables:
-
-- `ASTRA_DB_API_ENDPOINT` - The API endpoint for the Astra DB database. To get the endpoint, see the **Database Details > API Endpoint** value on your database's **Overview** tab.
-- `ASTRA_DB_APPLICATION_TOKEN` - The database application token value for the database. To get the token, see the **Database Details > Application Tokens** box on your database's **Overview** tab.
-- `ASTRA_DB_NAMESPACE` - The name of the namespace for the database.
-- `ASTRA_DB_COLLECTION` - The name of the collection for the namespace. 
-- `ASTRA_DB_EMBEDDING_DIMENSIONS` - The number of dimensions in the collection.
-
-Learn how to:
-
-- [Create or sign in to an Astra account](https://astra.datastax.com/).
-- [Create a database in an account](https://docs.datastax.com/en/astra-db-classic/databases/manage-create.html).
-- [Create a database application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html).
-- [Create a namespace in a database](https://docs.datastax.com/en/astra-db-serverless/databases/manage-namespaces.html#create-namespace).
-- [Create a collection in a namespace](https://docs.datastax.com/en/astra-db-serverless/databases/manage-collections.html#create-collection).
+- An Astra account. [Create or sign in to an Astra account](https://astra.datastax.com/).
+- A database in the Astra account. [Create a database in an account](https://docs.datastax.com/en/astra-db-classic/databases/manage-create.html).
+- An application token for the database. [Create a database application token](https://docs.datastax.com/en/astra-db-serverless/administration/manage-application-tokens.html).
+- A namespace in the database. [Create a namespace in a database](https://docs.datastax.com/en/astra-db-serverless/databases/manage-namespaces.html#create-namespace).
+- A collection in the namespace. [Create a collection in a namespace](https://docs.datastax.com/en/astra-db-serverless/databases/manage-collections.html#create-collection).

--- a/snippets/general-shared-text/azure-cli-api.mdx
+++ b/snippets/general-shared-text/azure-cli-api.mdx
@@ -1,0 +1,11 @@
+The Azure Storage account connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[azure]"
+```
+
+These environment variables:
+
+- `AZURE_STORAGE_ACCOUNT_URL` - The remote Azure Storage remote URL, represented by `--remote-url` (CLI) or `remote_url` (Python).
+- `AZURE_STORAGE_ACCOUNT_NAME` - The name of the Azure Storage account, represented by `--account-name` (CLI) or `account_name` (Python).
+- `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_STORAGE_CONNECTION_STRING`, or `AZURE_STORAGE_SAS_TOKEN` - The name of the key, connection string, or SAS token for the Azure Storage account, depending on your security configuration, represented by `--account-key` (CLI) or `account_key` (Python), `--connection-string` (CLI) or `connection_string` (Python), and `--sas_token` (CLI) or `sas_token` (Python), respectively.

--- a/snippets/general-shared-text/azure.mdx
+++ b/snippets/general-shared-text/azure.mdx
@@ -1,13 +1,5 @@
-The Azure Storage connector dependencies:
+The Azure Storage account prerequisites:
 
-```bash CLI, Python
-pip install "unstructured-ingest[azure]"
-```
-
-An Azure Storage account. To create one, [learn how](https://learn.microsoft.com/azure/storage/common/storage-account-create).
-
-These environment variables:
-
-- `AZURE_STORAGE_ACCOUNT_URL` - The remote Azure Storage remote URL, using the format `abfs://<container-name>@<storage-account-name>.blob.core.windows.net/<path/to/file/or/folder/in/container/as/needed>`
-- `AZURE_STORAGE_ACCOUNT_NAME` - The name of the Azure Storage account.
-- `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_STORAGE_CONNECTION_STRING`, or `AZURE_STORAGE_SAS_TOKEN` - The name of the key, connection string, or SAS token for the Azure Storage account, depending on your security configuration. [Get an account key](https://learn.microsoft.com/azure/storage/common/storage-account-keys-manage#view-account-access-keys). [Configure a connection string](https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account). [Create an SAS token](https://learn.microsoft.com/azure/ai-services/translator/document-translation/how-to-guides/create-sas-tokens).
+- An Azure Storage account. To create one, [learn how](https://learn.microsoft.com/azure/storage/common/storage-account-create).
+- The remote Azure Storage remote URL, using the format `abfs://<container-name>@<storage-account-name>.blob.core.windows.net/<path/to/file/or/folder/in/container/as/needed>`
+- A key, connection string, or SAS token for the Azure Storage account, depending on your security configuration. [Get an account key](https://learn.microsoft.com/azure/storage/common/storage-account-keys-manage#view-account-access-keys). [Configure a connection string](https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account). [Create an SAS token](https://learn.microsoft.com/azure/ai-services/translator/document-translation/how-to-guides/create-sas-tokens).

--- a/snippets/general-shared-text/box-cli-api.mdx
+++ b/snippets/general-shared-text/box-cli-api.mdx
@@ -1,0 +1,10 @@
+The Box connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[box]"
+```
+
+The following environment variables:
+
+- `BOX_APP_CONFIG_PATH` - The local path to the downloaded private key configuration JSON file for the Box Custom App, represented by `--box-app-config` (CLI) or `box_app_config` (Python).
+- `BOX_REMOTE_URL` - The remote URL to the target folder, represented by `--remote-url` (CLI) or `remote_url` (Python).

--- a/snippets/general-shared-text/box.mdx
+++ b/snippets/general-shared-text/box.mdx
@@ -1,28 +1,21 @@
-1. The Box connector dependencies:
+The Box prerequisites:
 
-   ```bash CLI, Python
-   pip install "unstructured-ingest[box]"
-   ```
+1. Access to the [Developer Console](https://app.box.com/developers/console) from your [Box enterprise account](https://account.box.com/signup/enterprise-plan) or [Box developer account](https://account.box.com/signup/developer).
 
-2. Access to the [Developer Console](https://app.box.com/developers/console) from your [Box enterprise account](https://account.box.com/signup/enterprise-plan) or [Box developer account](https://account.box.com/signup/developer).
+2. A Box Custom App in your Box account, set up to use **Server Authentication (with JWT)**. See [Setup with JWT](https://developer.box.com/guides/authentication/jwt/jwt-setup/).
 
-3. A Box Custom App in your Box account, set up to use **Server Authentication (with JWT)**. See [Setup with JWT](https://developer.box.com/guides/authentication/jwt/jwt-setup/).
-
-4. The appropriate application scopes and advanced features set up for the Box Custom App, as follows:
+3. The appropriate application scopes and advanced features set up for the Box Custom App, as follows:
 
    - In the Box Custom App, on the **Configuration** tab, under **Application Scopes**, check the box titled **Write all files and folders stored in Box**.
    - In the Box Custom App, on the **Configuration** tab, under **Advanced Features**, check the box titled **Make API calls using the as-user header**.
    - Click **Save Changes** before continuing.
 
-5. Authorization by a Box Admin in your Box account for the Box Custom App. See [App Authorization](https://developer.box.com/guides/authentication/jwt/jwt-setup/#app-authorization).
+4. Authorization by a Box Admin in your Box account for the Box Custom App. See [App Authorization](https://developer.box.com/guides/authentication/jwt/jwt-setup/#app-authorization).
 
-6. Access by your Box account's source or target [folder](https://app.box.com/folder/0) to your Box Custom App, as follows:
+5. Access by your Box account's source or target [folder](https://app.box.com/folder/0) to your Box Custom App, as follows:
 
    - In the Box Custom App, on the **General Settings** tab, copy the **Service Account ID** (which takes the form `AutomationUser_<your-app-service-id>_<a-random-string@boxdevedition.com`).
    - **Share** your Box account's target folder with the copied service account's email address as a **Co-owner** or **Editor**. 
+   - Note the remote URL to the target folder, which takes the format `box://<path/to/folder/in/account>`.
 
-7. The private key configuration JSON file for the Box Custom App. To download this file, in the Box Custom App, on the **Configuration** tab, under **Add and Manage Public Keys**, click **Generate a Public/Private Keypair**. Store the downloaded private key configuration JSON file in a secure location. Do not share it with others.
-
-8. In your code, set `--box-app-config` (CLI) or `box_app_config` (Python) to the local path to the downloaded private key configuration JSON file for the Box Custom App, represented in the following example by the environment variable `BOX_APP_CONFIG_PATH`.
-
-9. In your code, set `--remote-url` (CLI) or `remote_url` (Python) to the remote URL to the target folder, which takes the format `box://<path/to/folder/in/account>`, represented in the following example by the environment variable `BOX_REMOTE_URL`.
+6. The private key configuration JSON file for the Box Custom App. To download this file, in the Box Custom App, on the **Configuration** tab, under **Add and Manage Public Keys**, click **Generate a Public/Private Keypair**. Store the downloaded private key configuration JSON file in a secure location. Do not share it with others.

--- a/snippets/general-shared-text/dropbox-cli-api.mdx
+++ b/snippets/general-shared-text/dropbox-cli-api.mdx
@@ -1,0 +1,10 @@
+The Dropbox connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[dropbox]"
+```
+
+The following environment variables:
+
+- `DROPBOX_ACCESS_TOKEN` - The value of your access token, represented by `--token` (CLI) or `token` (Python).
+- `DROPBOX_REMOTE_URL` - The remote URL to the target folder, represented by `--remote-url` (CLI) or `remote_url` (Python).

--- a/snippets/general-shared-text/dropbox.mdx
+++ b/snippets/general-shared-text/dropbox.mdx
@@ -1,23 +1,17 @@
-1. The Dropbox connector dependencies:
+The Dropbox prerequisites:
 
-   ```bash CLI, Python
-   pip install "unstructured-ingest[dropbox]"
-   ```
+1. A Dropbox account. [Get an account](https://www.dropbox.com/try/teams).
 
-2. A Dropbox account. [Get an account](https://www.dropbox.com/try/teams).
+2. A target source or destination folder in your Dropbox account. [Create a folder](https://help.dropbox.com/create-upload/creating-using-folders-on-dropbox).
 
-3. A target source or destination folder in your Dropbox account. [Create a folder](https://help.dropbox.com/create-upload/creating-using-folders-on-dropbox).
+3. A Dropbox app for your Dropbox account. To learn how to create an app, click the **App Console** tab on the [Getting Started](https://www.dropbox.com/developers/reference/getting-started) page.
 
-4. A Dropbox app for your Dropbox account. To learn how to create an app, click the **App Console** tab on the [Getting Started](https://www.dropbox.com/developers/reference/getting-started) page.
-
-5. Permission for your Dropbox app to read from, and write to, the target folder in your Dropbox account as needed. To do this:
+4. Permission for your Dropbox app to read from, and write to, the target folder in your Dropbox account as needed. To do this:
 
    - On the **Permissions** tab of your Dropbox app, check the boxes **files.content.read** or **files.content.write** or both. [Learn more](https://developers.dropbox.com/oauth-guide).
 
    - On the **Settings** tab of your Dropbox app, for **App folder name**, set the name of the target folder in your Dropbox account for your Dropbox app to have access to.
 
-6. An access token for your Dropbox account. [Get a token](https://dropbox.tech/developers/generate-an-access-token-for-your-own-account). Save this token in a secure location. Do not share it with others.
+   - Note the remote URL to the target folder, which takes the format `dropbox://<path/to/folder/in/account>`.
 
-7. In your code, set `--token` (CLI) or `token` (Python) to the value of your access token, represented in the following example by the environment variable `DROPBOX_ACCESS_TOKEN`.
-
-8. In your code, set `--remote-url` (CLI) or `remote_url` (Python) to the remote URL to the target folder, which takes the format `dropbox://<path/to/folder/in/account>`, represented in the following example by the environment variable `DROPBOX_REMOTE_URL`.
+5. An access token for your Dropbox account. [Get a token](https://dropbox.tech/developers/generate-an-access-token-for-your-own-account). Save this token in a secure location. Do not share it with others.

--- a/snippets/general-shared-text/google-drive-cli-api.mdx
+++ b/snippets/general-shared-text/google-drive-cli-api.mdx
@@ -1,0 +1,10 @@
+The Google Drive connector dependencies:
+
+  ```bash CLI, Python
+  pip install "unstructured-ingest[google-drive]"
+  ```
+
+The following environment variables:
+
+- `GOOGLE_DRIVE_FOLDER_ID` - The folder ID, represented by `--drive-id` (CLI) or `drive_id` (Python).
+- `GCP_SERVICE_ACCOUNT_KEY` - The path to the `credentials.json` key file or its contents in JSON format, represented by `--service-account-key` (CLI) or `service_account_key` (Python).

--- a/snippets/general-shared-text/google-drive.mdx
+++ b/snippets/general-shared-text/google-drive.mdx
@@ -1,14 +1,9 @@
-The Google Drive connector dependencies:
+The Google Drive prerequisites:
 
-  ```bash CLI, Python
-  pip install "unstructured-ingest[google-drive]"
-  ```
+1. A Google Cloud service account and its related `credentials.json` key file or its contents in JSON format. [Learn how](https://developers.google.com/workspace/guides/create-credentials#service-account).
 
-A Google Cloud service account and its related `credentials.json` key file or its contents in JSON format. [Learn how](https://developers.google.com/workspace/guides/create-credentials#service-account).
+2. Note the path to the `credentials.json` key file or its contents in JSON format.
 
-Give the service account's email address access to the Google Drive folder.
+3. Give the service account's email address access to the Google Drive folder.
 
-These environment variables:
-
-- `GOOGLE_DRIVE_FOLDER_ID` - The folder ID. This is a part of the URL for your Google Drive folder represented in the following URL as `{folder_id}`: `https://drive.google.com/drive/folders/{folder-id}`.
-- `GCP_SERVICE_ACCOUNT_KEY` - The path to the `credentials.json` key file or its contents in JSON format.
+4. Note the folder ID. This is a part of the URL for your Google Drive folder represented in the following URL as `{folder_id}`: `https://drive.google.com/drive/folders/{folder-id}`.

--- a/snippets/general-shared-text/mongodb-cli-api.mdx
+++ b/snippets/general-shared-text/mongodb-cli-api.mdx
@@ -1,0 +1,20 @@
+The MongoDB connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[mongodb]"
+```
+
+For a MongoDB Atlas deployment, the following environment variables:
+
+- `MONGODB_DATABASE` - The name of the database, represented by `--database` (CLI) or `database` (Python).
+
+- `MONGODB_COLLECTION` - The name of the collection in the database, represented by `--collection` (CLI) or `collection` (Python).
+
+- `MONGODB_URI` - The URI for the cluster, represented by `--uri` (CLI) or `uri` (Python). 
+
+For a local MongoDB server, the following environment variables:
+
+- `MONGODB_HOST` - The host for the local MongoDB server, represented by `--host` (CLI) or `host` (Python).
+
+- `MONGODB_PORT` - The port for the local MongoDB server, represented by `--port` (CLI) or `port` (Python).
+

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,10 +1,4 @@
-The MongoDB connector dependencies:
-
-```bash CLI, Python
-pip install "unstructured-ingest[mongodb]"
-```
-
-A MongoDB Atlas deployment, or a local MongoDB server:
+The MongoDB prerequsites for a MongoDB Atlas deployment, or a local MongoDB server.
 
 For a MongoDB Atlas deployment:
 
@@ -16,22 +10,16 @@ For a MongoDB Atlas deployment:
 
 - The cluster must be configured to use your IP address. [Learn how](https://www.mongodb.com/docs/atlas/setup-cluster-security/#ip-access-list).
 
-- The cluster must have at least one database, the name of which is specified with `--database` (CLI) or `database` (Python) and represented in the following examples by the environment variable `MONGODB_DATABASE`.[Create a database](https://www.mongodb.com/docs/compass/current/databases/#create-a-database).
+- The cluster must have at least one database. [Create a database](https://www.mongodb.com/docs/compass/current/databases/#create-a-database).
 
 - The database must have at least one user, and that user must have sufficient access to the database. [Create a database user](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users). [Give the user database access](https://www.mongodb.com/docs/manual/core/authorization/).
 
-- The database must have at least one collection, the name of which is specified with `--collection` (CLI) or `collection` (Python) and represented in the following examples by the environment variable `MONGODB_COLLECTION`. [Create a collection](https://www.mongodb.com/docs/compass/current/collections/#create-a-collection).
+- The database must have at least one collection. [Create a collection](https://www.mongodb.com/docs/compass/current/collections/#create-a-collection).
 
-- The URI for the cluster, specified with `--uri` (CLI) or `uri` (Python) and is represented in the following examples by the environment variable `MONGODB_URI`. This URI must include the protocol, username, password, and host. [Learn how to get this value](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).
+- The URI for the cluster. This URI must include the protocol, username, password, and host. [Learn how to get this value](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).
 
 For a local MongoDB server:
 
 - Installation of a local MongoDB server. [Learn how](https://www.mongodb.com/docs/manual/installation/).
 
-- The host and port for the local MongoDB server (instead of `--uri` (CLI) or `uri` (Python)), as follows:
-
-  - The host is specified with `--host` (CLI) or `host` (Python), represented by the environment variable `MONGODB_HOST`.
-
-  - The port is specified with `--port` (CLI) or `port` (Python), represented by the environment variable `MONGODB_PORT`.
-
-    [Learn how to get these values](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).
+- The host and port for the local MongoDB server. [Learn how to get these values](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).

--- a/snippets/general-shared-text/s3-cli-api.mdx
+++ b/snippets/general-shared-text/s3-cli-api.mdx
@@ -1,0 +1,15 @@
+The S3 connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[s3]"
+```
+
+The following environment variables:
+
+- `AWS_S3_URL` - The S3 remote URL, formatted as `protocol://dir/path/` (for example, `s3://my-bucket/my-folder/`).
+- If the S3 bucket doesn't allow anonymous access, provide the AWS credentials:
+
+  - `AWS_ACCESS_KEY_ID` - The AWS access key ID, represented by `--key` (CLI) or `key` (Python).
+  - `AWS_SECRET_ACCESS_KEY` - The AWS secret access key, represented by `--secret` (CLI) or `secret` (Python).
+
+- If the S3 bucket allows access without local AWS credentials, set `--anonymous` (CLI) or `anonymous=True` (Python) instead.

--- a/snippets/general-shared-text/s3.mdx
+++ b/snippets/general-shared-text/s3.mdx
@@ -1,21 +1,6 @@
-The S3 connector dependencies:
+The Amzon S3 prerequisites
 
-```bash CLI, Python
-pip install "unstructured-ingest[s3]"
-```
-
-These environment variables:
-
-- `AWS_S3_URL` - The S3 remote URL, formatted as `protocol://dir/path/` (for example, `s3://my-bucket/my-folder/`).
-- If your S3 bucket doesn't allow anonymous access, provide your AWS credentials:
-
-- `--key` (CLI) or `key` (Python) - The AWS access key ID, represented as `AWS_ACCESS_KEY_ID`.
-- `--secret` (CLI) or `secret` (Python) - Your AWS secret access key, represented as `AWS_SECRET_ACCESS_KEY`.
-
-If your S3 bucket allows access without local AWS credentials, set `--anonymous` (CLI) or `anonymous=True` (Python) instead.
-
-Learn how to:
-
-- [Create an AWS account](https://aws.amazon.com/free).
-- [Create an AWS access key and secret access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey).
-- [Create an Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html).
+- An AWS account. [Create an AWS account](https://aws.amazon.com/free).
+- An AWS access key and secret access key for the account. [Create an AWS access key and secret access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey).
+- An S3 bucket. [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html).
+- The path to the target folder in the S3 bucket, formatted as `protocol://dir/path/` (for example, `s3://my-bucket/my-folder/`).

--- a/snippets/general-shared-text/singlestore-cli-api.mdx
+++ b/snippets/general-shared-text/singlestore-cli-api.mdx
@@ -1,0 +1,14 @@
+The SingleStore connector dependencies:
+
+```bash CLI, Python
+pip install "unstructured-ingest[singlestore]"
+```
+
+These environment variables:
+
+- `SINGLESTORE_HOST` - The hostname for the SingleStore deployment, represented by `--host` (CLI) or `host` (Python).
+- `SINGLESTORE_PORT` - The port for the host, represented by `--port` (CLI) or `port` (Python).
+- `SINGLESTORE_USER` - The username for the deployment, represented by `--user` (CLI) or `user` (Python).
+- `SINGLESTORE_PASSWORD` - The password for the user, represented by `--password` (CLI) or `password` (Python).
+- `SINGLESTORE_DB` - The name of the database in the deployment, represented by `--database` (CLI) or `database` (Python).
+- `SINGLESTORE_TABLE` - The name of the table in the database, represented by `--table-name` (CLI) or `table_name` (Python).

--- a/snippets/general-shared-text/singlestore.mdx
+++ b/snippets/general-shared-text/singlestore.mdx
@@ -1,41 +1,34 @@
-The SingleStore connector dependencies:
+The SingleStore prerequisites:
 
-```bash CLI, Python
-pip install "unstructured-ingest[singlestore]"
-```
+- A SingleStore deployment, database, and table. [Learn how](https://www.singlestore.com/blog/how-to-get-started-with-singlestore/).
+- The hostname for the SingleStore deployment.
+- The port for the host.
+- The username for the deployment. 
+- The password for the user.
+- The name of the database in the deployment.
+- The name of the table in the database.
 
-These environment variables:
-
-- `SINGLESTORE_HOST` - The hostname for the SingleStore deployment.
-- `SINGLESTORE_PORT` - The port for the host.
-- `SINGLESTORE_USER` - The username for the deployment. 
-- `SINGLESTORE_PASSWORD` - The password for the user.
-- `SINGLESTORE_DB` - The name of the database in the deployment.
-- `SINGLESTORE_TABLE` - The name of the table in the database.
-
-To get the values for the enviornment variables `SINGLESTORE_HOST`, `SINGLESTORE_PORT`, `SINGLESTORE_USER`, and `SINGLESTORE_PASSWORD`:
+To get the values for the hostname, port, username, and password:
 
 1. In your SingleStore account's dashboard sidebar, click **Deployments**.
 2. From the drop-down list at the top of the **Deployments** page, select your deployment.
 3. On the **Overview** tab, in the **Compute** area, in the **Connect** drop-down list for your deployment, select 
 **Your App**. 
-4. If a **Create User** dialog box appears, note the **User** name and **Password** values. Use these for the `SINGLESTORE_USER` and `SINGLESTORE_PASSWORD` environment variables.
+4. If a **Create User** dialog box appears, note the **User** name and **Password** values.
 5. In the **Connect to Workspace** pane's **Your App** tab, note the string in the following format:
 
 ```
 <user-name>:<password>@<host>:<port>
 ```
 
-- `<user-name>` is the username. Use this for the `SINGLESTORE_USER` environment variable.
-- `<password>` is the user's password. Use this for `SINGLESTORE_PASSWORD`.
-- `<host>` is the workspace's hostname. Use this for `SINGLESTORE_HOST`.
-- `<post>` is the host's port. Use this for `SINGLESTORE_PORT`.
+- `<user-name>` is the username.
+- `<password>` is the user's password.
+- `<host>` is the workspace's hostname.
+- `<post>` is the host's port.
 
-To get the values for the environment variables `SINGLESTORE_DB` and `SINGLESTORE_TABLE`:
+To get the values for the database and table names:
 
 1. In your SingleStore dashboard's sidebar, click **Deployments**.
 2. From the drop-down list at the top of the **Deployments** page, select your deployment.
-3. On the **Databases** tab, note **Name** of your database. Use this for `SINGLESTORE_DB`.
-4. Click the database and, on the **Tables** tab, note the name of your table. Use this for `SINGLESTORE_TABLE`.
-
-To create deployments, databases, and tables in SingleStore, [learn how](https://www.singlestore.com/blog/how-to-get-started-with-singlestore/).
+3. On the **Databases** tab, note **Name** of your database.
+4. Click the database and, on the **Tables** tab, note the name of your table.

--- a/snippets/sc-shared-text/astradb-cli-api.mdx
+++ b/snippets/sc-shared-text/astradb-cli-api.mdx
@@ -2,6 +2,8 @@ Connect Astra DB to your preprocessing pipeline, and use the Unstructured Ingest
 
 You will need: 
 
-import SharedAstraDB from '/snippets/general-shared-text/astradb.mdx';
+import AstraDBShared from '/snippets/general-shared-text/astradb.mdx';
+import AstraDBSharedCLIAPI from '/snippets/general-shared-text/astradb-cli-api.mdx';
 
-<SharedAstraDB />
+<AstraDBShared />
+<AstraDBSharedCLIAPI />

--- a/snippets/sc-shared-text/azure-cli-api.mdx
+++ b/snippets/sc-shared-text/azure-cli-api.mdx
@@ -3,5 +3,7 @@ Connect Azure Storage to your preprocessing pipeline, and use the Unstructured I
 You will need: 
 
 import SharedAzure from '/snippets/general-shared-text/azure.mdx';
+import SharedAzureCLIAPI from '/snippets/general-shared-text/azure-cli-api.mdx';
 
 <SharedAzure />
+<SharedAzureCLIAPI />

--- a/snippets/sc-shared-text/box-cli-api.mdx
+++ b/snippets/sc-shared-text/box-cli-api.mdx
@@ -3,5 +3,7 @@ Connect Box to your preprocessing pipeline, and use the Unstructured CLI or Pyth
 You will need: 
 
 import SharedBox from '/snippets/general-shared-text/box.mdx';
+import SharedBoxCLIAPI from '/snippets/general-shared-text/box-cli-api.mdx';
 
 <SharedBox />
+<SharedBoxCLIAPI />

--- a/snippets/sc-shared-text/dropbox-cli-api.mdx
+++ b/snippets/sc-shared-text/dropbox-cli-api.mdx
@@ -3,5 +3,7 @@ Connect Dropbox to your preprocessing pipeline, and use the Unstructured Ingest 
 You will need: 
 
 import SharedDropbox from '/snippets/general-shared-text/dropbox.mdx';
+import SharedDropboxCLIAPI from '/snippets/general-shared-text/dropbox-cli-api.mdx';
 
 <SharedDropbox />
+<SharedDropboxCLIAPI />

--- a/snippets/sc-shared-text/google-drive-cli-api.mdx
+++ b/snippets/sc-shared-text/google-drive-cli-api.mdx
@@ -3,6 +3,8 @@ Connect Google Drive to your preprocessing pipeline, and use the Unstructured In
 You will need:
 
 import SharedGoogleDrive from '/snippets/general-shared-text/google-drive.mdx';
+import SharedGoogleDriveCLIAPI from '/snippets/general-shared-text/google-drive-cli-api.mdx';
 
 <SharedGoogleDrive />
+<SharedGoogleDriveCLIAPI />
 

--- a/snippets/sc-shared-text/mongodb-cli-api.mdx
+++ b/snippets/sc-shared-text/mongodb-cli-api.mdx
@@ -3,5 +3,7 @@ Connect MongoDB to your preprocessing pipeline, and use the Unstructured Ingest 
 You will need: 
 
 import SharedMongoDB from '/snippets/general-shared-text/mongodb.mdx';
+import SharedMongoDBCLIAPI from '/snippets/general-shared-text/mongodb-cli-api.mdx';
 
 <SharedMongoDB />
+<SharedMongoDBCLIAPI />

--- a/snippets/sc-shared-text/s3-cli-api.mdx
+++ b/snippets/sc-shared-text/s3-cli-api.mdx
@@ -3,5 +3,7 @@ Connect S3 to your preprocessing pipeline, and use the Unstructured Ingest CLI o
 You will need: 
 
 import SharedS3 from '/snippets/general-shared-text/s3.mdx';
+import SharedS3CLIAPI from '/snippets/general-shared-text/s3-cli-api.mdx';
 
 <SharedS3 />
+<SharedS3CLIAPI />

--- a/snippets/source_connectors/box.sh.mdx
+++ b/snippets/source_connectors/box.sh.mdx
@@ -8,5 +8,8 @@ unstructured-ingest \
     --output-dir box-ingest-output \
     --num-processes 2 \
     --recursive \
-    --verbose
+    --verbose \
+    --partition-by-api \
+    --partition-endpoint $UNSTRUCTURED_API_URL \
+    --api-key $UNSTRUCTURED_API_KEY
 ```


### PR DESCRIPTION
The source/connection prerequisites, CLI/API installation commands, CLI option names, API parameter names, and environment variable names were all combined into the source/destination connector docs. 

This refactoring separates the source/connection prerequisites from the collections of CLI/API installation commands, CLI option names, API parameter names, and environment variable names. This enables much easier and quicker authoring/maintenance moving forward for the related content for Platform source/connection docs!

For a few of these refactoring examples, see:

- https://unstructured-53-docs-36-ingest-shared-refactor.mintlify.app/api-reference/ingest/source-connectors/astradb
- https://unstructured-53-docs-36-ingest-shared-refactor.mintlify.app/api-reference/ingest/source-connectors/box
- https://unstructured-53-docs-36-ingest-shared-refactor.mintlify.app/api-reference/ingest/destination-connector/mongodb
- https://unstructured-53-docs-36-ingest-shared-refactor.mintlify.app/api-reference/ingest/destination-connector/singlestore

