### PR TITLE
Unstructured SDKs: when using the Free API, you can now use the short string 'free-api' instead of the URL

### DIFF
--- a/api-reference/api-services/examples.mdx
+++ b/api-reference/api-services/examples.mdx
@@ -38,7 +38,7 @@ from unstructured_client.models import shared
 from unstructured_client.models.errors import SDKError
 
 client = UnstructuredClient(
-    api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
     api_url=os.getenv("UNSTRUCTURED_API_URL"),
 )
 

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -126,7 +126,7 @@ Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured AP
 
 Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
-<Tip>With the Unstructured SDKs, for the Free Unstructured API only, you can use the short string `free-api` instead of the Free Unstructured API URL.</Tip>
+<Tip>With the Unstructured SDKs, for the Free edition only, you can set the `server` parameter to use the short string `free-api` instead of setting `server_url` (Python) or `serverURL` (JavaScript/TypeScript) to the Free Unstructured API URL.</Tip>
 
 Now, call the API, replacing:
 
@@ -142,7 +142,7 @@ from unstructured_client import UnstructuredClient
 from unstructured_client.models import operations, shared
 
 client = unstructured_client.UnstructuredClient(
-    api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
     server_url=os.getenv("UNSTRUCTURED_API_URL")
 )
 

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -126,6 +126,8 @@ Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured AP
 
 Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
+<Tip>With the Unstructured SDKs, for the Free Unstructured API only, you can use the short string `free-api` instead of the Free Unstructured API URL.</Tip>
+
 Now, call the API, replacing:
 
 - `<local/path/to/input/file>` with the path to the source (input) file on your local machine.

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -76,6 +76,8 @@ You will need:
     <Step title="Set enviromnent variables">
         1. Set an environment variable named `UNSTRUCTURED_API_KEY` to the value of your Unstructured API key.
         2. Set another environment variable named `UNSTRUCTURED_API_URL` to the Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
+
+        <Tip>With the Unstructured SDKs, for the Free edition only, you can use the short string `free-api` instead of the Free Unstructured API URL.</Tip>
     </Step>
     <Step title="Install the SDK">
         Run the following command:

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -77,7 +77,7 @@ You will need:
         1. Set an environment variable named `UNSTRUCTURED_API_KEY` to the value of your Unstructured API key.
         2. Set another environment variable named `UNSTRUCTURED_API_URL` to the Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
-        <Tip>With the Unstructured SDKs, for the Free edition only, you can use the short string `free-api` instead of the Free Unstructured API URL.</Tip>
+        <Tip>With the Unstructured SDKs, for the Free edition only, you can set the `server` parameter to use the short string `free-api` instead of setting `server_url` (Python) or `serverURL` (JavaScript/TypeScript) to the Free Unstructured API URL.</Tip>
     </Step>
     <Step title="Install the SDK">
         Run the following command:


### PR DESCRIPTION
Also, use `server` parameter to set `free-api` instead of `server_url` (Python) or `serverURL` (JS/TS). 

For the Python SDK only, the API key parameter is named `api_key_auth`. 