### PR TITLE
Fix paths unstructured -> unstructured-ingest

### DIFF
--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -288,7 +288,7 @@ curl http://<application-load-balancer-dns-name>/healthcheck
 Data processing can be performed by using any of the available Unstructured API tools, libraries, or SDKs. For example, run one of the following, replacing:
 
 - `<load-balancer-address>` with `http://`, followed by your application load balancer's DNS name, followed by `/general/v0/general`.
-- `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in GitHub.
+- `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
 - `<path/to/output-file>` with the path on your local machine to the processed output in JSON format.
 
 import CodeExamplesAzure from '/snippets/how-to-api/azure-aws.mdx';

--- a/api-reference/api-services/azure.mdx
+++ b/api-reference/api-services/azure.mdx
@@ -115,7 +115,7 @@ Before you click **Review + create**, click the **Networking** tab and follow th
         Data processing can be performed by using any of the available Unstructured API tools, libraries, or SDKs. For example, run one of the following, replacing:
 
         - `<load-balancer-address>` with `http://`, followed by your load balancer's public IP address, followed by `/general/v0/general`.
-        - `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in GitHub.
+        - `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
         - `<path/to/output-file>` with the path on your local machine to the processed output in JSON format.
 
     </Step>

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -68,7 +68,7 @@ curl -X POST $UNSTRUCTURED_API_URL \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 [Learn more about how to use POST requests](/api-reference/api-services/post-requests).
 
@@ -104,7 +104,7 @@ unstructured-ingest \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
@@ -226,7 +226,7 @@ client.general.partition({
 ```
 </CodeGroup>
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
 
@@ -275,7 +275,7 @@ with open(output_filepath, "w") as file:
     file.write(json_elements)
 ```
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 [Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
 

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -74,7 +74,7 @@ curl -X POST $UNSTRUCTURED_API_URL \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 [Learn more about how to use POST requests](/api-reference/api-services/post-requests).
 
@@ -114,7 +114,7 @@ unstructured-ingest \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 ### Unstructured Python SDK and JavaScript/TypeScript SDK
 
@@ -241,7 +241,7 @@ client.general.partition({
 
 After the code successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and the [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
 
@@ -290,7 +290,7 @@ with open(output_filepath, "w") as file:
 
 After the code successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 [Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
 

--- a/examplecode/codesamples/apioss/table-extraction-from-pdf.mdx
+++ b/examplecode/codesamples/apioss/table-extraction-from-pdf.mdx
@@ -16,7 +16,7 @@ To extract the tables from PDF files using the [partition\_pdf](/open-source/cor
 ```python
 from unstructured.partition.pdf import partition_pdf
 
-fname = "example-docs/layout-parser-paper.pdf"
+fname = "example-docs/pdf/layout-parser-paper.pdf"
 
 elements = partition_pdf(filename=fname,
                          infer_table_structure=True,
@@ -40,7 +40,7 @@ By default, table extraction from all file types is enabled. To extract tables f
 ```python
 from unstructured.partition.auto import partition
 
-filename = "example-docs/layout-parser-paper.pdf"
+filename = "example-docs/pdf/layout-parser-paper.pdf"
 
 elements = partition(filename=filename,
                      strategy='hi_res',

--- a/ingestion/overview.mdx
+++ b/ingestion/overview.mdx
@@ -155,11 +155,11 @@ For additional installation options and dependencies, see:
 
 Some source and destination connectors provide newer v2 and older v1 implementations, while some provide only older v1 implementations. You should use the v2 implementations wherever they are available, to help ensure better forward-compatibility of your code. For the lists of available v2 and v1 connectors, see:
 
-- [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors)
-- [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors/fsspec)
-- [v1 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector)
-- [v1 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/fsspec)
-- [v1 Notion connector](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/notion)
+- [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/v2/processes/connectors)
+- [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/v2/processes/connectors/fsspec)
+- [v1 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector)
+- [v1 fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector/fsspec)
+- [v1 Notion connector](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector/notion)
 
 To begin using the Unstructured Ingest Python library, see the code examples for the [source](/api-reference/ingest/source-connectors/overview) and [destination](/api-reference/ingest/destination-connector/overview) connectors.
 

--- a/open-source/concepts/models.mdx
+++ b/open-source/concepts/models.mdx
@@ -41,7 +41,7 @@ from unstructured.partition.pdf import partition_pdf
 
 os.environ["UNSTRUCTURED_HI_RES_MODEL_NAME"] = "yolox"
 
-out_yolox = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy="hi_res")
+out_yolox = partition_pdf("example-docs/pdf/layout-parser-paper-fast.pdf", strategy="hi_res")
 
 ```
 
@@ -50,7 +50,7 @@ out_yolox = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy=
 
 
 ```python
-filename = "example-docs/layout-parser-paper-fast.pdf"
+filename = "example-docs/pdf/layout-parser-paper-fast.pdf"
 
 elements = partition(filename=filename,
                      strategy="hi_res",

--- a/open-source/core-functionality/partitioning.mdx
+++ b/open-source/core-functionality/partitioning.mdx
@@ -104,7 +104,7 @@ with open("mydoc.docx", "rb") as f:
 ```python
 from unstructured.partition.auto import partition
 
-elements = partition(filename="example-docs/layout-parser-paper-fast.pdf")
+elements = partition(filename="example-docs/pdf/layout-parser-paper-fast.pdf")
 
 ```
 
@@ -207,20 +207,20 @@ Examples:
 ```python
 from unstructured.partition.email import partition_email
 
-elements = partition_email(filename="example-docs/fake-email.eml")
+elements = partition_email(filename="example-docs/eml/fake-email.eml")
 
-with open("example-docs/fake-email.eml", "r") as f:
+with open("example-docs/eml/fake-email.eml", "r") as f:
     elements = partition_email(file=f)
 
-with open("example-docs/fake-email.eml", "r") as f:
+with open("example-docs/eml/fake-email.eml", "r") as f:
     text = f.read()
 elements = partition_email(text=text)
 
-with open("example-docs/fake-email.eml", "r") as f:
+with open("example-docs/eml/fake-email.eml", "r") as f:
     text = f.read()
 elements = partition_email(text=text, content_source="text/plain")
 
-with open("example-docs/fake-email.eml", "r") as f:
+with open("example-docs/eml/fake-email.eml", "r") as f:
     text = f.read()
 elements = partition_email(text=text, include_headers=True)
 
@@ -316,10 +316,10 @@ Examples:
 from unstructured.partition.image import partition_image
 
 # Returns a List[Element] present in the pages of the parsed image document
-elements = partition_image("example-docs/layout-parser-paper-fast.jpg")
+elements = partition_image("example-docs/img/layout-parser-paper-fast.jpg")
 
 # Applies the English and Swedish language pack for ocr
-elements = partition_image("example-docs/layout-parser-paper-fast.jpg", languages=["eng", "swe"])
+elements = partition_image("example-docs/img/layout-parser-paper-fast.jpg", languages=["eng", "swe"])
 
 ```
 
@@ -337,7 +337,7 @@ It is helpful to use `"ocr_only"` instead of `"hi_res"` if `detectron2_onnx` doe
 ```python
 from unstructured.partition.image import partition_image
 
-filename = "example-docs/english-and-korean.png"
+filename = "example-docs/img/english-and-korean.png"
 elements = partition_image(filename=filename, languages=["eng", "kor"], strategy="ocr_only")
 
 ```
@@ -413,7 +413,7 @@ Examples:
 ```python
 from unstructured.partition.api import partition_multiple_via_api
 
-filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]
+filenames = ["example-docs/eml/fake-email.eml", "example-docs/fake.docx"]
 
 documents = partition_multiple_via_api(filenames=filenames)
 
@@ -425,7 +425,7 @@ from contextlib import ExitStack
 
 from unstructured.partition.api import partition_multiple_via_api
 
-filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]
+filenames = ["example-docs/eml/fake-email.eml", "example-docs/fake.docx"]
 files = [open(filename, "rb") for filename in filenames]
 
 with ExitStack() as stack:
@@ -481,11 +481,11 @@ Examples:
 from unstructured.partition.pdf import partition_pdf
 
 # Returns a List[Element] present in the pages of the parsed pdf document
-elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf")
+elements = partition_pdf("example-docs/pdf/layout-parser-paper-fast.pdf")
 
 # Applies the English and Swedish language pack for ocr. OCR is only applied
 # if the text is not available in the PDF.
-elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf", languages=["eng", "swe"])
+elements = partition_pdf("example-docs/pdf/layout-parser-paper-fast.pdf", languages=["eng", "swe"])
 
 ```
 
@@ -528,10 +528,10 @@ Examples:
 from unstructured.partition.pdf import partition_pdf
 
 # This will process without issue
-elements = partition_pdf("example-docs/copy-protected.pdf", strategy="hi_res")
+elements = partition_pdf("example-docs/pdf/copy-protected.pdf", strategy="hi_res")
 
 # This will output a warning and fall back to hi_res
-elements = partition_pdf("example-docs/copy-protected.pdf", strategy="fast")
+elements = partition_pdf("example-docs/pdf/copy-protected.pdf", strategy="fast")
 
 ```
 
@@ -691,7 +691,7 @@ You can pass additional settings such as `strategy`, `languages` and `encoding` 
 ```python
 from unstructured.partition.api import partition_via_api
 
-filename = "example-docs/DA-1p.pdf"
+filename = "example-docs/pdf/DA-1p.pdf"
 
 elements = partition_via_api(
   filename=filename, api_key=api_key, strategy="auto"

--- a/open-source/core-functionality/staging.mdx
+++ b/open-source/core-functionality/staging.mdx
@@ -609,7 +609,7 @@ import weaviate
 from weaviate.util import generate_uuid5
 
 
-filename = "example-docs/layout-parser-paper-fast.pdf"
+filename = "example-docs/pdf/layout-parser-paper-fast.pdf"
 elements = partition_pdf(filename=filename, strategy="fast")
 data_objects = stage_for_weaviate(elements)
 

--- a/open-source/installation/docker-installation.mdx
+++ b/open-source/installation/docker-installation.mdx
@@ -56,7 +56,7 @@ Once inside the running Docker container, you can directly test the library usin
 python3
 
 >>> from unstructured.partition.pdf import partition_pdf
->>> elements = partition_pdf(filename="example-docs/layout-parser-paper-fast.pdf")
+>>> elements = partition_pdf(filename="example-docs/pdf/layout-parser-paper-fast.pdf")
 
 >>> from unstructured.partition.text import partition_text
 >>> elements = partition_text(filename="example-docs/fake-text.txt")

--- a/open-source/introduction/quick-start.mdx
+++ b/open-source/introduction/quick-start.mdx
@@ -39,7 +39,7 @@ If you’ve opted for the “local-inference” installation, you should also be
 
 ```python
 from unstructured.partition.auto import partition
-elements = partition("example-docs/layout-parser-paper.pdf")
+elements = partition("example-docs/pdf/layout-parser-paper.pdf")
 
 ```
 
@@ -55,7 +55,7 @@ The following section will cover basic concepts and usage patterns in `unstructu
 *   Convert a document to a dictionary and/or save it as a JSON.
     
 
-The example documents in this section come from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) directory in the `unstructured` repo.
+The example documents in this section come from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) directory in the `unstructured` repo.
 
 Before running the code in this make sure you’ve installed the `unstructured` library and all dependencies using the instructions in the [quickstart](../installation/overview#quick-start) section.
 

--- a/openapi.json
+++ b/openapi.json
@@ -110,7 +110,7 @@
             "required": "true",
             "example": {
               "summary": "File to be partitioned",
-              "externalValue": "https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/layout-parser-paper.pdf"
+              "externalValue": "https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/pdf/layout-parser-paper.pdf"
             }
           },
           "strategy": {

--- a/snippets/destination_connectors/sql.sh.mdx
+++ b/snippets/destination_connectors/sql.sh.mdx
@@ -14,7 +14,7 @@ text_as_html,regex_metadata,detection_class_prob"
 
 unstructured-ingest \
   local \
-    --input-path example-docs/fake-memo.pdf \
+    --input-path example-docs/pdf/fake-memo.pdf \
     --output-dir local-output-to-SQL \
     --num-processes 2 \
     --verbose \

--- a/snippets/destination_connectors/sql.v1.py.mdx
+++ b/snippets/destination_connectors/sql.v1.py.mdx
@@ -58,7 +58,7 @@ if __name__ == "__main__":
             num_processes=2,
         ),
         connector_config=SimpleLocalConfig(
-            input_path="example-docs/fake-memo.pdf",
+            input_path="example-docs/pdf/fake-memo.pdf",
         ),
         read_config=ReadConfig(),
         partition_config=PartitionConfig(

--- a/snippets/how-to-api/extract_image_block_types.py.mdx
+++ b/snippets/how-to-api/extract_image_block_types.py.mdx
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         server_url=os.getenv("UNSTRUCTURED_API_URL")
     )
 
-    # Source: https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/embedded-images-tables.pdf
+    # Source: https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/pdf/embedded-images-tables.pdf
     local_filepath = "embedded-images-tables.pdf"
 
     with open(local_filepath, "rb") as f:

--- a/snippets/how-to-api/extract_text_as_html.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html.py.mdx
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         server_url=os.getenv("UNSTRUCTURED_API_URL")
     )
 
-    # Source: https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/embedded-images-tables.pdf
+    # Source: https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/pdf/embedded-images-tables.pdf
 
     # Where to get the local file, relative to this .py file.
     local_input_filepath = "local-ingest-pdf/embedded-images-tables.pdf"

--- a/snippets/how-to-oss/set_ocr_agent.py.mdx
+++ b/snippets/how-to-oss/set_ocr_agent.py.mdx
@@ -3,7 +3,7 @@ import json
 
 from unstructured.partition.image import partition_image
 
-# Source: https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/img/english-and-korean.png
+# Source: https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/img/english-and-korean.png
 # Path to the local file to process, relative to this .py file.
 filename = "local-ingest-png/english-and-korean.png"
 

--- a/snippets/ingest-configuration-shared/overview.mdx
+++ b/snippets/ingest-configuration-shared/overview.mdx
@@ -14,8 +14,8 @@ Some connectors implement only version 2 (v2) of the connector specification; so
 If you're looking for parameters specific to a connector (such as authentication options)&mdash;or to determine whether a connector provides a v2 implementation, a v1 implementation, or both&mdash;browse the
 corresponding connector's source code:
 
-- [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors)
-- [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/v2/processes/connectors/fsspec)
-- [v1 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector)
-- [v1 fsspec connectors](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/fsspec)
-- [v1 Notion connector](https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest/connector/notion)
+- [v2 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/v2/processes/connectors)
+- [v2 fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/v2/processes/connectors/fsspec)
+- [v1 non-fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector)
+- [v1 fsspec connectors](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector/fsspec)
+- [v1 Notion connector](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest/connector/notion)

--- a/snippets/quickstarts/platform.mdx
+++ b/snippets/quickstarts/platform.mdx
@@ -3,7 +3,7 @@ This quickstart uses a no-code, point-and-click user interface in your web brows
 You will need:
 
 - A compatible source (input) location in cloud storage that contains your documents for Unstructured to process. [See the list of supported source types](/platform/platform-source-connectors/overview).
-- Compatible files in your source location. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+- Compatible files in your source location. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 - A compatible destination (output) location in cloud storage for Unstructured to put the processed data. [See the list of supported destination types](/platform/platform-destination-connectors/overview).
 
 <Steps>

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -63,7 +63,7 @@ This quickstart uses your local machine, with the [Unstructured Python SDK](/api
 You will need:
 
 - Python installed on your local machine.
-- A compatible file on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+- A compatible file on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 <Steps>
     <Step title="Sign up">
@@ -155,7 +155,7 @@ This quickstart uses your local machine for a single-file source (input) locatio
 You will need:
 
 - Python installed on your local machine.
-- A compatible file on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+- A compatible file on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 <Steps>
     <Step title="Install the open source library">


### PR DESCRIPTION
These GitHub paths will be going away in the next few releases: https://github.com/Unstructured-IO/unstructured/tree/main/example-docs and https://github.com/Unstructured-IO/unstructured/tree/main/unstructured/ingest

Proactively updating these paths now to the new GitHub paths, which also work now: https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs and https://github.com/Unstructured-IO/unstructured-ingest/tree/main/unstructured_ingest

Also, many paths in the examples to `example-docs` did not use the same folder path structure (i.e. `examples-docs/DA-1p.pdf` instead of `example-docs/pdf/DA-1p.pdf`, which could make these examples slightly more difficult to locate in their original sources. I updated these for clarity.