### PR TITLE
Additional ingest dependency extras

### DIFF
--- a/api-reference/ingest/ingest-cli.mdx
+++ b/api-reference/ingest/ingest-cli.mdx
@@ -15,7 +15,11 @@ pip install unstructured-ingest
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
-For additional installation options and dependencies, see [Unstructed Ingest CLI](/ingestion/overview#unstructured-ingest-cli) in the [Ingest](/ingestion/overview) section.
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
+For additional installation options, see [Unstructed Ingest CLI](/ingestion/overview#unstructured-ingest-cli) in the [Ingest](/ingestion/overview) section.
 
 <Info>To migrate from older, deprecated versions of the Ingest CLI that used `pip install unstructured`, see the [migration guide](/ingestion/overview#migration-guide).</Info>
 

--- a/api-reference/ingest/ingest-dependencies.mdx
+++ b/api-reference/ingest/ingest-dependencies.mdx
@@ -1,0 +1,108 @@
+---
+title: Ingest dependencies
+---
+
+When you install the [Unstructured Ingest CLI](/api-reference/ingest/ingest-cli) and the 
+[Unstructured Ingest Python library](/api-reference/ingest/python-ingest) by running the command
+`pip install unstructured-ingest` by itself, you get the following by default:
+
+- The [local source connector](/api-reference/ingest/source-connectors/local) and the [local destination connector](/api-reference/ingest/destination-connector/local).
+- Support for the following file types:
+
+| File type |
+| --- |
+| `.bmp` |
+| `.eml` |
+| `.heic` |
+| `.html` |
+| `.jpg` |
+| `.jpeg` |
+| `.tiff` |
+| `.png` | 
+| `.txt` |
+| `.xml` |
+
+To add support for additional file types, run the following:
+
+| Command | File type |
+| --- | --- |
+| `pip install "unstructured-ingest[csv]"` | `.csv` |
+| `pip install "unstructured-ingest[doc]"` | `.doc` |
+| `pip install "unstructured-ingest[docx]"` | `.docx` |
+| `pip install "unstructured-ingest[epub]"` | `.epub` |
+| `pip install "unstructured-ingest[md]"` | `.md` |
+| `pip install "unstructured-ingest[msg]"` | `.msg` |
+| `pip install "unstructured-ingest[odt]"` | `.odt` |
+| `pip install "unstructured-ingest[org]"` | `.org` |
+| `pip install "unstructured-ingest[pdf]"` | `.pdf` |
+| `pip install "unstructured-ingest[ppt]"` | `.ppt` |
+| `pip install "unstructured-ingest[pptx]"` | `.pptx` |
+| `pip install "unstructured-ingest[rtf]"` | `.rtf` |
+| `pip install "unstructured-ingest[rst]"` | `.rst` |
+| `pip install "unstructured-ingest[tsv]"` | `.tsv` |
+| `pip install "unstructured-ingest[xlsx]"` | `.xlsx` |
+
+To add support for additional connectors, run the following:
+
+| Command | Connector type |
+| --- | --- |
+| `pip install "unstructured-ingest[airtable]"` | Airtable |
+| `pip install "unstructured-ingest[astra]"` | Astra DB |
+| `pip install "unstructured-ingest[azure]"` | Azure Blob Storage |
+| `pip install "unstructured-ingest[azure-cognitive-search]"` | Azure Cognitive Search Service |
+| `pip install "unstructured-ingest[biomed]"` | Biomed |
+| `pip install "unstructured-ingest[box]"` | Box |
+| `pip install "unstructured-ingest[chroma]"` | Chroma |
+| `pip install "unstructured-ingest[clarifai]"` | Clarifai |
+| `pip install "unstructured-ingest[confluence]"` | Confluence |
+| `pip install "unstructured-ingest[couchbase]"` | Couchbase |
+| `pip install "unstructured-ingest[databricks-volumes]"` | Databricks Volumes |
+| `pip install "unstructured-ingest[delta-table]"` | Delta Tables |
+| `pip install "unstructured-ingest[discord]"` | Discord |
+| `pip install "unstructured-ingest[dropbox]"` | Dropbox |
+| `pip install "unstructured-ingest[elasticsearch]"` | Elasticsearch |
+| `pip install "unstructured-ingest[gcs]"` | Google Cloud Storage |
+| `pip install "unstructured-ingest[github]"` | GitHub |
+| `pip install "unstructured-ingest[gitlab]"` | GitLab |
+| `pip install "unstructured-ingest[google-drive]"` | Google Drive |
+| `pip install "unstructured-ingest[hubspot]"` | HubSpot |
+| `pip install "unstructured-ingest[jira]"` | JIRA |
+| `pip install "unstructured-ingest[kafka]"` | Apache Kafka |
+| `pip install "unstructured-ingest[milvus]"` | Milvus |
+| `pip install "unstructured-ingest[mongodb]"` | MongoDB |
+| `pip install "unstructured-ingest[notion]"` | Notion |
+| `pip install "unstructured-ingest[onedrive]"` | OneDrive |
+| `pip install "unstructured-ingest[opensearch]"` | OpenSearch |
+| `pip install "unstructured-ingest[outlook]"` | Outlook |
+| `pip install "unstructured-ingest[pinecone]"` | Pinecone |
+| `pip install "unstructured-ingest[postgres]"` | PostgreSQL, SQLite |
+| `pip install "unstructured-ingest[qdrant]"` | Qdrant |
+| `pip install "unstructured-ingest[reddit]"` | Reddit |
+| `pip install "unstructured-ingest[s3]"` | Amazon S3 |
+| `pip install "unstructured-ingest[sharepoint]"` | SharePoint |
+| `pip install "unstructured-ingest[salesforce]"` | Salesforce
+| `pip install "unstructured-ingest[singlestore]"` | SingleStore |
+| `pip install "unstructured-ingest[sftp]"` | SFTP |
+| `pip install "unstructured-ingest[slack]"` | Slack |
+| `pip install "unstructured-ingest[wikipedia]"` | Wikipedia |
+| `pip install "unstructured-ingest[weaviate]"` | Weaviate |
+
+To add support for available embedding libraries, run the following: 
+
+| Command | Embedding library type |
+| --- | --- |
+| `pip install "unstructured-ingest[bedrock]"` | Amazon Bedrock |
+| `pip install "unstructured-ingest[embed-huggingface]"` | Hugging Face |
+| `pip install "unstructured-ingest[embed-octoai]"` | OctoAI |
+| `pip install "unstructured-ingest[embed-vertexai]"` | Google Vertex AI  |
+| `pip install "unstructured-ingest[embed-voyageai]"` | Voyage AI |
+| `pip install "unstructured-ingest[openai]"` | OpenAI |
+
+For details about the specific dependencies that are installed, see:
+
+- [Common dependencies](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/requirements/common)
+- [File type dependencies](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/requirements/local_partition)
+- [Connector dependencies](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/requirements/connectors)
+- [Embedding library dependencies](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/requirements/embed)
+
+See also [setup.py](https://github.com/Unstructured-IO/unstructured-ingest/blob/main/setup.py).

--- a/api-reference/ingest/python-ingest.mdx
+++ b/api-reference/ingest/python-ingest.mdx
@@ -15,7 +15,11 @@ pip install unstructured-ingest
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
-For additional installation options and dependencies, and information about v2 and v1 implementations in this library, see the [Unstructed Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) in the [Ingest](/ingestion/overview) section.
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
+For additional installation options, and information about v2 and v1 implementations in this library, see the [Unstructed Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) in the [Ingest](/ingestion/overview) section.
 
 <Info>To migrate from older, deprecated versions of the Ingest Python library that used `pip install unstructured`, see the [migration guide](/ingestion/overview#migration-guide).</Info>
 

--- a/ingestion/overview.mdx
+++ b/ingestion/overview.mdx
@@ -98,7 +98,11 @@ pip install unstructured-ingest
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
-For additional installation options and dependencies, see:
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
+For additional installation options, see:
 
 - [Run the library in a container](https://github.com/Unstructured-IO/unstructured/tree/main?tab=readme-ov-file#run-the-library-in-a-container)
 - [Installing the library](https://github.com/Unstructured-IO/unstructured/tree/main?tab=readme-ov-file#installing-the-library)
@@ -147,7 +151,9 @@ pip install unstructured-ingest
 
 This default installation option enables the ingestion of plain text files, HTML, XML, JSON and emails that do not require any extra dependencies. This default option also enables you to specify local source and destination locations.
 
-For additional installation options and dependencies, see:
+<AdditionalIngestDependencies />
+
+For additional installation options, see:
 
 - [Run the library in a container](https://github.com/Unstructured-IO/unstructured/tree/main?tab=readme-ov-file#run-the-library-in-a-container)
 - [Installing the library](https://github.com/Unstructured-IO/unstructured/tree/main?tab=readme-ov-file#installing-the-library)

--- a/mint.json
+++ b/mint.json
@@ -263,6 +263,7 @@
           "api-reference/ingest/overview",
           "api-reference/ingest/ingest-cli",
           "api-reference/ingest/python-ingest",
+          "api-reference/ingest/ingest-dependencies",
           {
             "group": "Ingest configuration",
             "pages": [

--- a/snippets/general-shared-text/astradb-cli-api.mdx
+++ b/snippets/general-shared-text/astradb-cli-api.mdx
@@ -4,6 +4,10 @@ The Astra DB connector dependencies:
 pip install "unstructured-ingest[astradb]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 These environment variables:
 
 - `ASTRA_DB_API_ENDPOINT` - The API endpoint for the Astra DB database, represented by `--api-endpoint` (CLI) or `api_endpoint` (Python). To get the endpoint, see the **Database Details > API Endpoint** value on your database's **Overview** tab.

--- a/snippets/general-shared-text/azure-cli-api.mdx
+++ b/snippets/general-shared-text/azure-cli-api.mdx
@@ -4,6 +4,10 @@ The Azure Storage account connector dependencies:
 pip install "unstructured-ingest[azure]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 These environment variables:
 
 - `AZURE_STORAGE_ACCOUNT_URL` - The remote Azure Storage remote URL, represented by `--remote-url` (CLI) or `remote_url` (Python).

--- a/snippets/general-shared-text/box-cli-api.mdx
+++ b/snippets/general-shared-text/box-cli-api.mdx
@@ -4,6 +4,10 @@ The Box connector dependencies:
 pip install "unstructured-ingest[box]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `BOX_APP_CONFIG_PATH` - The local path to the downloaded private key configuration JSON file for the Box Custom App, represented by `--box-app-config` (CLI) or `box_app_config` (Python).

--- a/snippets/general-shared-text/couchbase-cli-api.mdx
+++ b/snippets/general-shared-text/couchbase-cli-api.mdx
@@ -4,6 +4,10 @@ The Couchbase DB connector dependencies:
 pip install "unstructured-ingest[couchbase]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 These environment variables are required for the Couchbase Connector:
 
 - `CB_CONN_STR` - The Connection String for the Couchbase server, represented by `--connection-string` (CLI) or `connection_string` (Python).

--- a/snippets/general-shared-text/dropbox-cli-api.mdx
+++ b/snippets/general-shared-text/dropbox-cli-api.mdx
@@ -4,6 +4,10 @@ The Dropbox connector dependencies:
 pip install "unstructured-ingest[dropbox]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `DROPBOX_ACCESS_TOKEN` - The value of your access token, represented by `--token` (CLI) or `token` (Python).

--- a/snippets/general-shared-text/google-drive-cli-api.mdx
+++ b/snippets/general-shared-text/google-drive-cli-api.mdx
@@ -4,6 +4,10 @@ The Google Drive connector dependencies:
   pip install "unstructured-ingest[google-drive]"
   ```
 
+  import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `GOOGLE_DRIVE_FOLDER_ID` - The folder ID, represented by `--drive-id` (CLI) or `drive_id` (Python).

--- a/snippets/general-shared-text/ingest-dependencies.mdx
+++ b/snippets/general-shared-text/ingest-dependencies.mdx
@@ -1,0 +1,1 @@
+You might also need to install additional dependencies, depending on your needs. [Learn more](/api-reference/ingest/ingest-dependencies).

--- a/snippets/general-shared-text/mongodb-cli-api.mdx
+++ b/snippets/general-shared-text/mongodb-cli-api.mdx
@@ -4,6 +4,10 @@ The MongoDB connector dependencies:
 pip install "unstructured-ingest[mongodb]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 For a MongoDB Atlas deployment, the following environment variables:
 
 - `MONGODB_DATABASE` - The name of the database, represented by `--database` (CLI) or `database` (Python).

--- a/snippets/general-shared-text/opensearch-cli-api.mdx
+++ b/snippets/general-shared-text/opensearch-cli-api.mdx
@@ -4,6 +4,10 @@ The OpenSearch connector dependencies:
 pip install "unstructured-ingest[opensearch]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `OPENSEARCH_HOST` - The hostname and port number, defined as `<hostname>:<port-number>` and represented by `--hosts` (CLI) or `hosts` (Python).

--- a/snippets/general-shared-text/s3-cli-api.mdx
+++ b/snippets/general-shared-text/s3-cli-api.mdx
@@ -4,6 +4,10 @@ The S3 connector dependencies:
 pip install "unstructured-ingest[s3]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `AWS_S3_URL` - The S3 remote URL, formatted as `protocol://dir/path/` (for example, `s3://my-bucket/my-folder/`).

--- a/snippets/general-shared-text/singlestore-cli-api.mdx
+++ b/snippets/general-shared-text/singlestore-cli-api.mdx
@@ -4,6 +4,10 @@ The SingleStore connector dependencies:
 pip install "unstructured-ingest[singlestore]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 These environment variables:
 
 - `SINGLESTORE_HOST` - The hostname for the SingleStore deployment, represented by `--host` (CLI) or `host` (Python).

--- a/snippets/general-shared-text/sql-cli-api.mdx
+++ b/snippets/general-shared-text/sql-cli-api.mdx
@@ -4,6 +4,10 @@ The PostgreSQL and SQLite connector dependencies:
 pip install "unstructured-ingest[postgres]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 For PostgreSQL:

--- a/snippets/general-shared-text/weaviate-cli-api.mdx
+++ b/snippets/general-shared-text/weaviate-cli-api.mdx
@@ -4,6 +4,10 @@ The Weaviate connector dependencies:
 pip install "unstructured-ingest[weaviate]"
 ```
 
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
+<AdditionalIngestDependencies />
+
 The following environment variables:
 
 - `WEAVIATE_URL` - THE REST endpoint for the Weaviate database cluster, represented by `--host-url` (CLI) or `host_url` (Python).

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -43,6 +43,7 @@ Learn more about these products:
 <Info>If you want to use your local machine for either your source (input) files, or the destination (output) location for Unstructured to deliver the processed data, you cannot use this quickstart. You must run code on your local machine instead: skip to the [Quickstart: Unstructured Serverless API services](#quickstart-unstructured-api-service) or [Quickstart: Unstructured open source library](#quickstart-unstructured-open-source-library), later in this article.</Info>
 
 import SharedPlatform from '/snippets/quickstarts/platform.mdx';
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
 
 <SharedPlatform />
 


### PR DESCRIPTION
This PR attempts to help educate customers about scenarios in which proactively installing dependency extras are needed. 

See https://unstructured-53-install-extras-2024-08-13.mintlify.app/api-reference/ingest/ingest-dependencies