### PR TITLE
Emphasize Ingest over POST, SDKs, and open source

### DIFF
--- a/api-reference/api-services/accessing-unstructured-api.mdx
+++ b/api-reference/api-services/accessing-unstructured-api.mdx
@@ -14,7 +14,9 @@ Choose your preferred method:
 
 The API parameters for all these methods are documented on the [API parameters](/api-reference/api-services/api-parameters) page.
 
-<Note>To process files in batches instead, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+import UseIngestInstead from '/snippets/general-shared-text/use-ingest-instead.mdx';
+
+<UseIngestInstead />
 
 If you'd like to try out the Unstructured API interactively by using the Free Unstructured API to process a single file, you can do so by using the [Swagger UI](https://api.unstructured.io/general/docs#/default/pipeline_1_general_v0_general_post).
 

--- a/api-reference/api-services/api-parameters.mdx
+++ b/api-reference/api-services/api-parameters.mdx
@@ -3,6 +3,16 @@ title: API parameters
 description: Unstructured API services provide parameters to customize the processing of documents. Below are the details for these parameters.
 ---
 
+<Warning>
+    The following parameters apply only to POST requests, the Unstructured Python SDK, and the Unstructured JavaScript/TypeScript SDK.
+
+    Unstructured recommends that you use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the 
+    [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead. 
+    
+    The Ingest CLI and Ingest Python library provide faster processing of larger individual files, 
+    and faster and easier processing of multiple files at a time in batches.
+</Warning>
+
 ## Parameters
 
 The only required parameter is `files` -  the file you wish to process.

--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -285,11 +285,11 @@ curl http://<application-load-balancer-dns-name>/healthcheck
 
 ## Data processing
 
-Data processing can be performed by using any of the available Unstructured API tools, libraries, or SDKs. For example, run one of the following, replacing:
+For example, run one of the following, replacing:
 
 - `<load-balancer-address>` with `http://`, followed by your application load balancer's DNS name, followed by `/general/v0/general`.
-- `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
-- `<path/to/output-file>` with the path on your local machine to the processed output in JSON format.
+- `<path/to/input>` with the path on your local machine to the files to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
+- `<path/to/output>` with the path on your local machine to the processed output in JSON format.
 
 import CodeExamplesAzure from '/snippets/how-to-api/azure-aws.mdx';
 

--- a/api-reference/api-services/azure.mdx
+++ b/api-reference/api-services/azure.mdx
@@ -112,11 +112,11 @@ Before you click **Review + create**, click the **Networking** tab and follow th
 ![retrieve public ip](/img/api/Azure_Step7.png)
     </Step>
     <Step title="Data processing">
-        Data processing can be performed by using any of the available Unstructured API tools, libraries, or SDKs. For example, run one of the following, replacing:
+        For example, run one of the following, replacing:
 
         - `<load-balancer-address>` with `http://`, followed by your load balancer's public IP address, followed by `/general/v0/general`.
-        - `<path/to/input-file>` with the path on your local machine to a file to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
-        - `<path/to/output-file>` with the path on your local machine to the processed output in JSON format.
+        - `<path/to/input>` with the path on your local machine to the files to process. If you do not have any input files available, you can download any of the ones from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in GitHub.
+        - `<path/to/output>` with the path on your local machine to the processed output in JSON format.
 
     </Step>
 </Steps>

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -37,7 +37,7 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-These examples use your local machine. They preprocess source (input) files on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
+These examples use your local machine. They send source (input) files from your local machine to the Unstructured Serverless API which delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
 ### Unstructured Ingest CLI
 

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -26,7 +26,7 @@ import FreeKeyNoServerlessURL from '/snippets/general-shared-text/free-api-key-n
 
 The Free Unstructured API is designed for prototyping purposes, and not for production use:
 * The API usage is limited to 1000 pages per month.
-* Unlike the users of Unstructured Serverless API, users of the Free Unstructured API to do not get their own dedicated infrastructure.
+* Unlike the users of Unstructured Serverless API, users of the Free Unstructured API do not get their own dedicated infrastructure.
 * The data sent over the Free Unstructured API can be used for model training purposes, and other service improvements.
 
 If you require a production-ready API, consider using the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) instead.
@@ -37,47 +37,9 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-These examples use your local machine. They preprocess a single-file source (input) file on your local machine, and the Free Unstructured API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
-
-<Info>
-    These examples work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
-</Info> 
-
-There are several ways to use the Free Serverless API, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-ingest-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-free-unstructured-api-from-the-unstructured-open-source-library).
-
-### POST request
-
-To work with the Unstructured Serverless API by calling the Unstructured REST API POST with `curl`, first do the following:
-
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
-- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
-
-Now, use `curl` to call the API, replacing:
-
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
-
-```bash
-curl -X POST $UNSTRUCTURED_API_URL \
-     -H 'accept: application/json' \
-     -H 'Content-Type: multipart/form-data' \
-     -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
-     -F 'files=@<local/path/to/input/file>' \
-     -F 'split-pdf-page True' \
-     -F 'split-pdf-allow-failed True' \
-     -F 'split-pdf-concurrency-level 15' \
-     -o '<local/path/to/output/file>'
-```
-
-After the command successfully runs, see the results in the specified output path on your local machine.
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-[Learn more about how to use POST requests](/api-reference/api-services/post-requests).
+These examples use your local machine. They preprocess source (input) files on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
 ### Unstructured Ingest CLI
-
-<Info>Although this example works with only a single file at a time and only with local source and destination locations, the Unstructured Ingest CLI works with multiple files at a time and with non-local source and destination locations. [Learn more](/ingestion/overview#unstructured-ingest-cli).</Info>
 
 To work with the Free Unstructured API by using the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you will need to:
 
@@ -90,16 +52,18 @@ To work with the Free Unstructured API by using the [Unstructured Ingest CLI](/i
 - Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
 - Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
 
+- Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+
 Now, use the CLI to call the API, replacing:
 
-- `<local/path/to/input/files>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/files>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
+- `<path/to/input>` with the source (input) path to the directory on your local machine that contains the compatible files for Unstructured to process on its hosted compute resources.
+- `<path/to/output>` with the destination (output) path to the directory on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
 
 ```bash CLI
 unstructured-ingest \
   local \
-    --input-path <local/path/to/input/file> \
-    --output-dir <local/path/to/output/file> \
+    --input-path <path/to/input> \
+    --output-dir <path/to/output> \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
     --partition-endpoint $UNSTRUCTURED_API_URL \
@@ -108,184 +72,35 @@ unstructured-ingest \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+### Unstructured Ingest Python library
 
-### Unstructured Python SDK and JavaScript/TypeScript SDK
+To work with the Unstructured Serverless API by using the [Unstructured Python library](/ingestion/overview#unstructured-ingest-python-library), you will need to:
 
-To work with the Free Unstructured API in Python or JavaScript, use the
-[Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or the
-[Unstructured JavaScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
-
-<CodeGroup>
-```bash Python
-pip install unstructured-client
-```
-
-```bash  JavaScript/TypeScript
-npm install unstructured-client
-```
-</CodeGroup>
-
-Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
-
-Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
-
-<Tip>With the Unstructured SDKs, for the Free edition only, you can set the `server` parameter to use the short string `free-api` instead of setting `server_url` (Python) or `serverURL` (JavaScript/TypeScript) to the Free Unstructured API URL.</Tip>
-
-Now, call the API, replacing:
-
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data.
-
-<CodeGroup>
-
-```python Python
-import json, os
-
-from unstructured_client import UnstructuredClient
-from unstructured_client.models import operations, shared
-
-client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-input_filepath = "<local/path/to/input/file>"
-output_filepath = "<local/path/to/output/file>"
-
-with open(input_filepath, "rb") as f:
-    files = shared.Files(
-        content=f.read(),
-        file_name=input_filepath
-    )
-
-req = operations.PartitionRequest(
-    shared.PartitionParameters(
-        files=files,
-        split_pdf_page=True,
-        split_pdf_allow_failed=True,
-        split_pdf_concurrency_level=15
-    )
-)
-
-try:
-    res = client.general.partition(request=req)
-    element_dicts = [element for element in res.elements]
-    json_elements = json.dumps(element_dicts, indent=2)
-    
-    # Print the processed data.
-    print(json_elements)
-
-    # Write the processed data to a local file.
-    with open(output_filepath, "w") as file:
-      file.write(json_elements)
-except Exception as e:
-    print(e)
-```
-
-```typescript TypeScript
-import { UnstructuredClient } from "unstructured-client";
-import { Strategy } from "unstructured-client/sdk/models/shared/index.js";
-import * as fs from "fs";
-
-const inputFilepath = "<local/path/to/input/file>" || '';
-const outputFilepath = "<local/path/to/output/file>" || '';
-
-const key = process.env.UNSTRUCTURED_API_KEY;
-const url = process.env.UNSTRUCTURED_API_URL;
-
-const client = new UnstructuredClient({
-    security: {
-        apiKeyAuth: key,
-    },
-    serverUrl: url
-});
-
-const data = fs.readFileSync(inputFilepath);
-
-client.general.partition({
-    partitionParameters: {
-        files: {
-            content: data,
-            fileName: inputFilepath
-        },
-        splitPdfPage: true,
-        splitPdfAllowFailed: true,
-        splitPdfConcurrencyLevel: 15
-    }
-}).then((res) => {
-    if (res.statusCode == 200) {
-       const jsonElements = JSON.stringify(res.elements, null, 2)
-       
-       // Print the processed data.
-       console.log(jsonElements);
-
-       // Write the processed data to a local file.
-       fs.writeFileSync(outputFilepath, jsonElements)
-    }
-}).catch((e) => {
-    if (e.statusCode) {
-        console.log(e.statusCode);
-        console.log(e.body);
-    } else {
-        console.log(e);
-    }
-});
-```
-</CodeGroup>
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
-
-### Calling the Free Unstructured API from the Unstructured open source library
-
-You can call the Free Unstructured API directly from the Unstructured open source library. Unstructured recommends this approach only for rapid local script or code prototyping or simple proofs-of-concept, not for production scenarios.
-
-You will need to: 
-
-- Install Python, and then install the open source library:
+- Install Python, and then install the CLI package:
 
   ```bash
-  pip install unstructured
+  pip install unstructured-ingest
   ```
 
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your Free Unstructured API key.
-- Set the `UNSTRUCTURED_API_URL` environment variable to your Free Unstructured API URL, which is `https://api.unstructured.io/general/v0/general`
+- Set the following environment variables:
 
-Now, call the API, replacing:
+  - Set `UNSTRUCTURED_API_KEY` to your API key.
+  - Set `UNSTRUCTURED_API_URL` to your API URL.
+  
+  [Get your API key and API URL](#get-started).
 
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
+- Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-```python
-import os, json
+Now, use the CLI to call the API, replacing:
 
-from unstructured.partition.api import partition_via_api
+- `<path/to/input>` with the source (input) path to the directory on your local machine that contains the compatible files for Unstructured to process on its hosted compute resources.
+- `<path/to/output>` with the destination (output) path to the directory on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
 
-input_filepath = "<local/path/to/input/file>"
-output_filepath = "<local/path/to/output/file>"
+import LocalToLocalPythonIngestLibrary from '/snippets/ingestion/local-to-local.v2.py.mdx';
 
-elements = partition_via_api(
-  filename=filename,
-  api_key=os.getenv("UNSTRUCTURED_API_KEY"),
-  parition_endpoint=os.getenv("UNSTRUCTURED_API_URL")
-)
+<LocalToLocalPythonIngestLibrary />
 
-element_dicts = [element.to_dict() for element in elements]
-json_elements = json.dumps(element_dicts, indent=2)
-
-# Print the processed data to a local file.
-print(json_elements)
-
-# Write the processed data to a local file.
-with open(output_filepath, "w") as file:
-    file.write(json_elements)
-```
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-[Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
+After the command successfully runs, see the results in the specified output path on your local machine.
 
 ## Telemetry
 

--- a/api-reference/api-services/partition-via-api.mdx
+++ b/api-reference/api-services/partition-via-api.mdx
@@ -8,7 +8,9 @@ would like to leverage the advanced capabilities of Unstructured API services, y
 Whether you're using the Free Unstructured API, the Unstructured Serverless API,
 the Unstructured API on Azure/AWS, or your local deployment of the Unstructured API, you can use the open source library to send an individual file through `partition_via_api` for processing with Unstructured API services.
 
-<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+import UseIngestInstead from '/snippets/general-shared-text/use-ingest-instead.mdx';
+
+<UseIngestInstead />
 
 To use the open source library, you'll also need:
 

--- a/api-reference/api-services/post-requests.mdx
+++ b/api-reference/api-services/post-requests.mdx
@@ -6,7 +6,9 @@ sidebarTitle: POST request
 Whether you're using the free Unstructured API, the Unstructured Serverless API, Unstructured API on Azure/AWS, or your local
 deployment of Unstructured API, you can work with the API by sending single-file POST requests to it. 
 
-<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+import UseIngestInstead from '/snippets/general-shared-text/use-ingest-instead.mdx';
+
+<UseIngestInstead />
 
 To make POST requests, you will need:
 

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -41,7 +41,7 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-These examples use your local machine. They preprocess source (input) files on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
+These examples use your local machine. They send source (input) files from your local machine to the Unstructured Serverless API which delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
 ### Unstructured Ingest CLI
 

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -41,56 +41,16 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 ## Quickstart
 
-These examples use your local machine. They preprocess a single-file source (input) file on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
-
-<Info>
-    These examples work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
-</Info>
-
-There are several ways to use the Unstructured Serverless API, which all lead to the same result, so pick your preferred method: [POST](#post-request), [CLI](#unstructured-ingest-cli), [SDK](#unstructured-python-sdk-and-javascript-typescript-sdk), or [open source](#calling-the-unstructured-api-from-the-unstructured-open-source-library).
-
-### POST request
-
-To work with the Unstructured Serverless API by calling the Unstructured REST API POST with `curl`, you will need to:
-
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your Unstructured Serverless API key.
-- Set the `UNSTRUCTURED_API_URL` environment variable to your Unstructured Serverless API URL.
-
-[Get your API key and API URL](#get-started).
-
-Now, use `curl` to call the API, replacing:
-
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
-
-```bash
-curl -X POST $UNSTRUCTURED_API_URL \
-     -H 'accept: application/json' \
-     -H 'Content-Type: multipart/form-data' \
-     -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
-     -F 'files=@<local/path/to/input/file>' \
-     -F 'split-pdf-page True' \
-     -F 'split-pdf-allow-failed True' \
-     -F 'split-pdf-concurrency-level 15' \
-     -o '<local/path/to/output/file>'
-```
-
-After the command successfully runs, see the results in the specified output path on your local machine.
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-[Learn more about how to use POST requests](/api-reference/api-services/post-requests).
+These examples use your local machine. They preprocess source (input) files on your local machine, and the Unstructured Serverless API delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
 ### Unstructured Ingest CLI
-
-<Info>Although this example works with only a single file at a time and only with local source and destination locations, the Unstructured Ingest CLI works with multiple files at a time and with non-local source and destination locations. [Learn more](/ingestion/overview#unstructured-ingest-cli).</Info>
 
 To work with the Unstructured Serverless API by using the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you will need to:
 
 - Install Python, and then install the CLI package:
 
   ```bash
-  pip install unstructured
+  pip install unstructured-ingest
   ```
 
 - Set the following environment variables:
@@ -100,16 +60,18 @@ To work with the Unstructured Serverless API by using the [Unstructured Ingest C
   
   [Get your API key and API URL](#get-started).
 
+- Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+
 Now, use the CLI to call the API, replacing:
 
-- `<local/path/to/input/files>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
+- `<path/to/input>` with the source (input) path to the directory on your local machine that contains the compatible files for Unstructured to process on its hosted compute resources.
+- `<path/to/output>` with the destination (output) path to the directory on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
 
 ```bash CLI
 unstructured-ingest \
   local \
-    --input-path <local/path/to/input/file> \
-    --output-dir <local/path/to/output/file> \
+    --input-path <path/to/input> \
+    --output-dir <path/to/output> \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
     --partition-endpoint $UNSTRUCTURED_API_URL \
@@ -118,158 +80,15 @@ unstructured-ingest \
 
 After the command successfully runs, see the results in the specified output path on your local machine.
 
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+### Unstructured Ingest Python library
 
-### Unstructured Python SDK and JavaScript/TypeScript SDK
+To work with the Unstructured Serverless API by using the [Unstructured Python library](/ingestion/overview#unstructured-ingest-python-library), you will need to:
 
-To work with the Unstructured Serverless API in Python, JavaScript, or TypeScript, use the
-[Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) or the 
-[Unstructured JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/unstructured-js-client).
+- Install Python, and then install the CLI package:
 
-To get started with the Unstructured Python SDK even faster than following the steps below, simply sign up for a 14-day trial of the Unstructured Serverless API at [https://app.unstructured.io](https://app.unstructured.io), and then follow along with this 3-minute video:
-
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/bi4yrImGbHc"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
-
-First, install your preferred SDK:
-<CodeGroup>
-
-```bash  Python
-pip install unstructured-client
-```
-
-```bash  JavaScript/TypeScript
-npm install unstructured-client
-```
-</CodeGroup>
-
-Next, set the following environment variables:
-
-- Set `UNSTRUCTURED_API_URL` environment variable to your API URL.
-- Set the `UNSTRUCTURED_API_KEY` environment variable to your API key.
-
-[Get your API key and API URL](#get-started). 
-
-Now, call the API, replacing:
-
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data.
-
-<NoURLForServerlessAPI/>
-
-<CodeGroup>
-
-```python Python
-import json, os
-
-from unstructured_client import UnstructuredClient
-from unstructured_client.models import operations, shared
-
-input_filepath = "<local/path/to/input/file>"
-output_filepath = "<local/path/to/output/file>"
-
-client = UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-    server_url=os.getenv("UNSTRUCTURED_API_URL"),
-)
-
-with open(input_filepath, "rb") as f:
-    files = shared.Files(
-        content=f.read(),
-        file_name=input_filepath
-    )
-
-req = operations.PartitionRequest(
-    shared.PartitionParameters(
-        files=files,
-        split_pdf_page=True,
-        split_pdf_allow_failed=True,
-        split_pdf_concurrency_level=15
-    )
-)
-
-try:
-    res = client.general.partition(request=req)
-    element_dicts = [element for element in res.elements]
-    json_elements = json.dumps(element_dicts, indent=2)
-    
-    # Print the processed data.
-    print(json_elements)
-
-    # Write the processed data to a local file.
-    with open(output_filepath, "w") as file:
-      file.write(json_elements)
-except Exception as e:
-    print(e)
-```
-
-```typescript TypeScript
-import { UnstructuredClient } from "unstructured-client";
-import { Strategy } from "unstructured-client/sdk/models/shared/index.js";
-import * as fs from "fs";
-
-const inputFilepath = "<local/path/to/input/file>" || '';
-const outputFilepath = "<local/path/to/output/file>" || ''
-
-const key = process.env.UNSTRUCTURED_API_KEY || '';
-const url = process.env.UNSTRUCTURED_API_URL || '';
-
-const client = new UnstructuredClient({
-    security: { apiKeyAuth: key },
-    serverURL: url
-});
-
-const data = fs.readFileSync(inputFilepath);
-
-client.general.partition({
-    partitionParameters: {
-        files: {
-            content: data,
-            fileName: inputFilepath
-        },
-        splitPdfPage: true,
-        splitPdfAllowFailed: true,
-        splitPdfConcurrencyLevel: 15
-    }
-}).then((res) => {
-    if (res.statusCode == 200) {
-       const jsonElements = JSON.stringify(res.elements, null, 2)
-       
-       // Print the processed data.
-       console.log(jsonElements);
-
-       // Write the processed data to a local file.
-       fs.writeFileSync(outputFilepath, jsonElements)
-    }
-}).catch((e) => {
-    if (e.statusCode) {
-        console.log(e.statusCode);
-        console.log(e.body);
-    } else {
-        console.log(e);
-    }
-});
-```
-</CodeGroup>
-
-After the code successfully runs, see the results in the specified output path on your local machine.
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-Learn more about how to use the [Unstructured Python SDK](/api-reference/api-services/sdk-python) and the [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
-
-### Calling the Unstructured API from the Unstructured open source library
-
-You can call the Unstructured Serverless API directly from the Unstructured open source library. Unstructured recommends this approach only for rapid local script or code prototyping or simple proofs-of-concept, not for production scenarios.
-
-You will need to: 
+  ```bash
+  pip install unstructured-ingest
+  ```
 
 - Set the following environment variables:
 
@@ -278,41 +97,18 @@ You will need to:
   
   [Get your API key and API URL](#get-started).
 
-Now, call the API, replacing:
+- Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
-- `<local/path/to/input/file>` with the path to the source (input) file on your local machine.
-- `<local/path/to/output/file>` with the path to the destination (output) on your local machine where Unstructured will deliver the processed data. 
+Now, use the CLI to call the API, replacing:
 
-```python
-import os, json
+- `<path/to/input>` with the source (input) path to the directory on your local machine that contains the compatible files for Unstructured to process on its hosted compute resources.
+- `<path/to/output>` with the destination (output) path to the directory on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
 
-from unstructured.partition.api import partition_via_api
+import LocalToLocalPythonIngestLibrary from '/snippets/ingestion/local-to-local.v2.py.mdx';
 
-input_filepath = "<local/path/to/input/file>"
-output_filepath = "<local/path/to/output/file>"
+<LocalToLocalPythonIngestLibrary />
 
-elements = partition_via_api(
-  filename=input_filepath,
-  api_key=os.getenv("UNSTRUCTURED_API_KEY"),
-  api_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-element_dicts = [element.to_dict() for element in elements]
-json_elements = json.dumps(element_dicts, indent=2)
-
-# Print the processed data.
-print(json_elements)
-
-# Write the processed data to a local file.
-with open(output_filepath, "w") as file:
-    file.write(json_elements)
-```
-
-After the code successfully runs, see the results in the specified output path on your local machine.
-
-If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-[Learn more about how to use the Unstructured open source library](/open-source/introduction/overview).
+After the command successfully runs, see the results in the specified output path on your local machine.
 
 ## Manage your account
 

--- a/api-reference/api-services/sdk-jsts.mdx
+++ b/api-reference/api-services/sdk-jsts.mdx
@@ -7,7 +7,9 @@ The [Unstructured JavaScript/TypeScript SDK](https://github.com/Unstructured-IO/
 Free Unstructured API, the Unstructured Serverless API, the Unstructured API on Azure/AWS, or your local
 deployment of the Unstructured API, you can access the API using the JavaScript/TypeScript SDK. 
 
-<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+import UseIngestInstead from '/snippets/general-shared-text/use-ingest-instead.mdx';
+
+<UseIngestInstead />
 
 To use the JavaScript/TypeScript SDK, you'll need:
 

--- a/api-reference/api-services/sdk-python.mdx
+++ b/api-reference/api-services/sdk-python.mdx
@@ -7,7 +7,9 @@ The [Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-py
 Free Unstructured API, the Unstructured Serverless API, the Unstructured API on Azure/AWS, or your local
 deployment of the Unstructured API, you can access the API using the Python SDK. 
 
-<Note>To process files in batches instead, and to use non-local source and destination locations, see the options for [Batch processing and ingestion](/api-reference/ingest/overview).</Note>
+import UseIngestInstead from '/snippets/general-shared-text/use-ingest-instead.mdx';
+
+<UseIngestInstead />
 
 To use the Python SDK, you'll need:
 

--- a/snippets/general-shared-text/use-ingest-instead.mdx
+++ b/snippets/general-shared-text/use-ingest-instead.mdx
@@ -1,0 +1,7 @@
+<Warning>
+    Unstructured recommends that you use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the 
+    [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead. 
+    
+    The Ingest CLI and Ingest Python library provide faster processing of larger individual files, 
+    and faster and easier processing of multiple files at a time in batches.
+</Warning>

--- a/snippets/how-to-api/azure-aws.mdx
+++ b/snippets/how-to-api/azure-aws.mdx
@@ -1,168 +1,28 @@
 <AccordionGroup>
-    <Accordion title="POST">
-
-        This example uses `curl`.
-
-        For better code portability, it is recommended to first set the environment variable `UNSTRUCTURED_API_URL` to `<load-balancer-address>`, instead of hard-coding it as the URL endpoint in this POST request.
-
-        ```bash POST
-        curl -q -X POST $UNSTRUCTURED_API_URL \
-          -H 'accept: application/json' \
-          -H 'Content-Type: multipart/form-data' \
-          -F files=@<path/to/input-file> \
-          -F 'split-pdf-page True' \
-          -F 'split-pdf-allow-failed True' \
-          -F 'split-pdf-concurrency-level 15' \
-          -o <path/to/output-file>.json
-        ```
-
-        After this command runs successfully, check the contents of `<path/to/output-file>.json`.
-
-        [Learn more about POST requests](/api-reference/api-services/post-requests). 
-        
-        <Info>In this case, you do not need to specify an Unstructured API key with POST, because you are calling a private API.</Info>
-
-    </Accordion>
-
-    <Accordion title="Python SDK">
-
-        You must first [install the Unstructured Python SDK](/api-reference/api-services/sdk-python).
-
-        For better code portability, it is recommended to first set the environment variable `UNSTRUCTURED_API_URL` to `<load-balancer-address>`, instead of hard-coding it in the parameter `server_url`.
-
-        Because you are calling a private API and therefore do not need an Unstructured API key, you can omit the parameter `api_key_auth`. Or, for better code portability, it is recommended that you first set the environment variable `UNSTRUCTURED_API_KEY` to an empty string and then include the parameter `api_key_auth`.
-
-        ```python Python
-        from unstructured_client import UnstructuredClient
-        from unstructured_client.models import operations, shared
-
-        import json, os
-
-        input_filepath = "<path/to/input-file>"
-        output_filepath = "<path/to/output-file>.json"
-
-        client = UnstructuredClient(
-            api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-            server_url=os.getenv("UNSTRUCTURED_API_URL"),
-        )
-
-        with open(input_filepath, "rb") as f:
-            files = shared.Files(
-                content=f.read(),
-                file_name=input_filepath
-            )
-
-        req = operations.PartitionRequest(
-            shared.PartitionParameters(
-                files=files,
-                strategy=shared.Strategy.AUTO,
-                split_pdf_page=True,
-                split_pdf_allow_failed=True,
-                split_pdf_concurrency_level=15
-            )
-        )
-
-        try:
-            res = client.general.partition(request=req)
-            element_dicts = [element for element in res.elements]
-            json_elements = json.dumps(element_dicts, indent=2)
-            
-            print(json_elements)
-
-            with open(output_filepath, "w") as file:
-            file.write(json_elements)
-        except Exception as e:
-            print(e)
-        ```
-
-    </Accordion>
-
-    <Accordion title="JavaScript/TypeScript SDK">
-
-        You must first [install the Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts).
-
-        For better code portability, it is recommended to first set the variable `url` to the environment variable `UNSTRUCTURED_API_URL` that is set to `<load-balancer-address>`, instead of hard-coding it in the parameter `serverUrl`.
-
-        Because you are calling a private API and therefore do not need an Unstructured API key, you can omit the variable `key` and the parameter `security`. Or, for better code portability, it is recommended that you first set the environment variable `UNSTRUCTURED_API_KEY` to an empty string and then include the variable `key` and parameter `security`.
-
-        ```typescript TypeScript
-        import { UnstructuredClient } from "unstructured-client";
-        import { Strategy } from "unstructured-client/sdk/models/shared/index.js";
-        import * as fs from "fs";
-
-        const inputFilepath = "<path/to/input-file>" || '';
-        const outputFilepath = "<path/to/output-file>.json" || ''
-
-        const key = process.env.UNSTRUCTURED_API_KEY || '';
-        const url = process.env.UNSTRUCTURED_API_URL || '';
-
-        const client = new UnstructuredClient({
-            security: { apiKeyAuth: key },
-            serverURL: url
-        });
-
-        const data = fs.readFileSync(inputFilepath);
-
-        client.general.partition({
-            partitionParameters: {
-                files: {
-                    content: data,
-                    fileName: inputFilepath
-                },
-                strategy: Strategy.Auto
-            }
-        }).then((res) => {
-            if (res.statusCode == 200) {
-            const jsonElements = JSON.stringify(res.elements, null, 2)
-            
-            console.log(jsonElements);
-
-            fs.writeFileSync(outputFilepath, jsonElements)
-            }
-        }).catch((e) => {
-            if (e.statusCode) {
-                console.log(e.statusCode);
-                console.log(e.body);
-            } else {
-                console.log(e);
-            }
-        });
-        ```
-
-    </Accordion>
-
     <Accordion title="Ingest CLI">
-
         You must first [install the Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli).
 
         For better code portability, it is recommended to first set the environment variable `UNSTRUCTURED_API_URL` to `<load-balancer-address>`, instead of hard-coding it for the command-line option `--partition-endpoint`.
 
         Because you are calling a private API and therefore do not need an Unstructured API key, you can omit the command-line option `--api-key` Or, for better code portability, it is recommended that you first set the environment variable `UNSTRUCTURED_API_KEY` to an empty string and then include the command-line option `--api-key`.
-
-        Because the Unstructured Ingest Python library can work with multiple files at a time, you specify the input and output directory paths instead of paths to individual input and output files.
         
         ```bash CLI
         unstructured-ingest \
           local \
-            --input-path <path/to/input-files/directory> \
-            --output-dir <path/to/output-files/director> \
+            --input-path <path/to/input> \
+            --output-dir <path/to/output> \
             --partition-by-api \
             --api-key $UNSTRUCTURED_API_KEY \
             --partition-endpoint $UNSTRUCTURED_API_URL \
             --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}"
         ```
-
     </Accordion>
-
     <Accordion title="Ingest Python library">
-
         You must first [install the Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library).
 
         For better code portability, it is recommended to first set the environment variable `UNSTRUCTURED_API_URL` to `<load-balancer-address>`, instead of hard-coding it for the parameter `partition_endpoint`.
 
         Because you are calling a private API and therefore do not need an Unstructured API key, you can omit the parameter `api_key`. Or, for better code portability, it is recommended that you first set the environment variable `UNSTRUCTURED_API_KEY` to an empty string and then include the parameter `api_key`.
-
-        Because the Unstructured Ingest Python library can work with multiple files at a time, you specify the input and output directory paths instead of paths to individual input and output files.
 
         ```python Python Ingest v2
         import os
@@ -180,7 +40,7 @@
         if __name__ == "__main__":
             Pipeline.from_configs(
                 context=ProcessorConfig(),
-                indexer_config=LocalIndexerConfig(input_path="<path/to/input-files/directory>"),
+                indexer_config=LocalIndexerConfig(input_path="<path/to/input>"),
                 downloader_config=LocalDownloaderConfig(),
                 source_connection_config=LocalConnectionConfig(),
                 partitioner_config=PartitionerConfig(
@@ -193,43 +53,8 @@
                         "split_pdf_concurrency_level": 15
                     }
                 ),
-                uploader_config=LocalUploaderConfig(output_dir="<path/to/output-files/directory>")
+                uploader_config=LocalUploaderConfig(output_dir="<path/to/output>")
             ).run()
         ```
-
     </Accordion>
-
-    <Accordion title="Open source library with Python">
-
-        You must first [install the Unstructured open source library](/open-source/introduction/quick-start).
-
-        For better code portability, it is recommended to first set the environment variable `UNSTRUCTURED_API_URL` to `<load-balancer-address>`, instead of hard-coding it for the parameter `api_url`.
-
-        Because you are calling a private API and therefore do not need an Unstructured API key, you can omit the parameter `api_key`. Or, for better code portability, it is recommended that you first set the environment variable `UNSTRUCTURED_API_KEY` to an empty string and then include the parameter `api_key`.
-
-        ```bash Python
-        import os, json
-
-        from unstructured.partition.api import partition_via_api
-
-        input_filepath = "<path/to/input-file>"
-        output_filepath = "<path/to/output-file>.json"
-
-        elements = partition_via_api(
-            filename=input_filepath,
-            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
-            api_url=os.getenv("UNSTRUCTURED_API_URL")
-        )
-
-        element_dicts = [element.to_dict() for element in elements]
-        json_elements = json.dumps(element_dicts, indent=2)
-            
-        print(json_elements)
-
-        with open(output_filepath, "w") as file:
-            file.write(json_elements)
-        ```
-
-    </Accordion>
-
 </AccordionGroup>

--- a/snippets/ingestion/local-to-local.v2.py.mdx
+++ b/snippets/ingestion/local-to-local.v2.py.mdx
@@ -1,0 +1,32 @@
+```python Python Ingest v2
+import os
+
+from unstructured_ingest.v2.pipeline.pipeline import Pipeline
+from unstructured_ingest.v2.interfaces import ProcessorConfig
+from unstructured_ingest.v2.processes.connectors.local import (
+    LocalIndexerConfig,
+    LocalDownloaderConfig,
+    LocalConnectionConfig,
+    LocalUploaderConfig
+)
+from unstructured_ingest.v2.processes.partitioner import PartitionerConfig
+
+if __name__ == "__main__":
+    Pipeline.from_configs(
+        context=ProcessorConfig(),
+        indexer_config=LocalIndexerConfig(input_path="<path/to/input>"),
+        downloader_config=LocalDownloaderConfig(),
+        source_connection_config=LocalConnectionConfig(),
+        partitioner_config=PartitionerConfig(
+            partition_by_api=True,
+            api_key=os.getenv("UNSTRUCTURED_API_KEY"),
+            partition_endpoint=os.getenv("UNSTRUCTURED_API_URL"),
+            additional_partition_args={
+                "split_pdf_page": True,
+                "split_pdf_allow_failed": True,
+                "split_pdf_concurrency_level": 15
+            }
+        ),
+        uploader_config=LocalUploaderConfig(output_dir="<path/to/output>")
+    ).run()
+```

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -18,11 +18,8 @@ This 40-second video demonstrates a simple use case that Unstructured helps solv
 
 ### Product offerings
 
-Unstructured offers three products:
-
 <Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="computer" />&nbsp;&nbsp;[Unstructured Platform](/platform/overview) - No-code UI. Production-ready. Pay as you go.<br/><br/>
 <Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="square-terminal" />&nbsp;&nbsp;[Unstructured Serverless API services](/api-reference/api-services/overview) - Use scripts or code. Production-ready. Pay as you go. (There is also a non-production, free edition with [limits](/api-reference/api-services/free-api#free-unstructured-api-limitations).)<br/><br/>
-<Icon icon="dash" iconType="duotone"/>&nbsp;&nbsp;<Icon icon="door-open" />&nbsp;&nbsp;[Unstructured open source library](/open-source/introduction/overview/) - Use scripts or code. Not production-ready. [Limited](/open-source/introduction/overview#limits).
 
 Learn more about these products:
 
@@ -37,15 +34,9 @@ Learn more about these products:
   <br/>Use scripts or code to call the Unstructured Ingest CLI or Ingest Python library, the Unstructured Python or JavaScript/TypeScript SDKs, or with a direct POST request to the Unstructured API, to get all of your data RAG-ready.<br/><br/>
   Unstructured Serverless API services have a [Serverless](api-reference/api-services/saas-api-development-guide) pay-as-you-go edition and a [Free](/api-reference/api-services/free-api_) [limited](/api-reference/api-services/free-api#free-unstructured-api-limitations) edition that process data on Unstructured-hosted compute resources.<br/><br/>
   If you need to use compute resources that you host instead, there are also [Azure](/api-reference/api-services/azure) pay-as-you-go and [AWS](/api-reference/api-services/aws) pay-as-you-go editions; these editions process data by using the Unstructured API installed on compute resources hosted in your own Azure or AWS account.<br/><br/>
-  [Try the quickstart](#quickstart-serverless-api).<br/><br/>
+  [Try the quickstart](#quickstart-unstructured-serverless-api).<br/><br/>
   [Learn more](/api-reference/api-services/overview).<br/><br/>
   <Icon icon="blog"/>&nbsp;&nbsp;[Read the launch announcement](https://unstructured.io/blog/introducing-unstructured-serverless-api).
-</Card>
-<Card title="Unstructured open source library" icon="door-open" href="/open-source/introduction/overview/">
-  <br/>Recommended only for rapid local script or code prototyping or simple proofs-of-concept. It is not designed for production scenarios.<br/><br/>
-  Data processing is done only on your local machine and only with local compute resources, and there are no charges. However, features and performance are [limited](/open-source/introduction/overview#limits) compared to the Platform and API service products.<br/><br/>
-  [Try the quickstart](#quickstart-unstructured-open-source-library).<br/><br/>
-  [Learn more](/open-source/introduction/overview/).
 </Card>
 
 ---
@@ -60,10 +51,9 @@ import SupportedFileTpes from '/snippets/general-shared-text/supported-file-type
 
 ### <Icon icon="computer" />   Quickstart: Unstructured Platform
 
-<Info>If you want to use your local machine for either your source (input) files, or the destination (output) location for Unstructured to deliver the processed data, you cannot use this quickstart. You must run code on your local machine instead: skip to the [Quickstart: Unstructured Serverless API](#quickstart-serverless-api) or [Quickstart: Unstructured open source library](#quickstart-unstructured-open-source-library), later in this article.</Info>
+<Info>If you want to use your local machine for either your source (input) files, or the destination (output) location for Unstructured to deliver the processed data, you cannot use this quickstart. You must run code on your local machine instead: skip to the [Quickstart: Unstructured Serverless API](#quickstart-unstructured-serverless-api), later in this article.</Info>
 
 import SharedPlatform from '/snippets/quickstarts/platform.mdx';
-import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
 
 <SharedPlatform />
 
@@ -71,30 +61,17 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 ---
 
+import LocalToLocalPythonIngestLibrary from '/snippets/ingestion/local-to-local.v2.py.mdx';
+import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-dependencies.mdx';
+
 ### <Icon icon="square-terminal" />   Quickstart: Unstructured Serverless API
 
-This quickstart uses your local machine, with the [Unstructured Python SDK](/api-reference/api-services/sdk-python) installed. It preprocess a single-file source (input) file on your local machine, and it uses the Unstructured Serverless API to deliver the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
-
-To get started even faster than following the steps below, simply sign up for a 14-day trial of the Unstructured Serverless API at [https://app.unstructured.io](https://app.unstructured.io), and then follow along with this 3-minute video:
-
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/bi4yrImGbHc"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
-
-<Info>
-    The Unstructured Python SDK (and the Unstructured JavaScript/TypeScript SDK) work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.
-</Info>
+This quickstart uses your local machine, with the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) installed. It preprocesses source (input) files on your local machine, and it uses the Unstructured Serverless API to deliver the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
 You will need:
 
 - Python installed on your local machine.
-- A compatible file on your local machine to be processed. [See the list of supported file types](#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+- Compatible files on your local machine to be processed. [See the list of supported file types](#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
 <Steps>
     <Step title="Sign up">
@@ -113,64 +90,21 @@ You will need:
         1. Set an environment variable named `UNSTRUCTURED_API_KEY` to the value of your Unstructured API key.
         2. Set another environment variable named `UNSTRUCTURED_API_URL` to the value of your Unstructured API URL.
     </Step>
-    <Step title="Install the SDK">
+    <Step title="Install the Ingest Python library">
         Run the following command:
         ```bash
-        pip install unstructured-client
+        pip install unstructured-ingest
         ```
+        <AdditionalIngestDependencies />
     </Step>
     <Step title="Run the code">
         Run the following code, replacing:
 
-        - `<path/to/input/file>` with the source (input) path on your local machine that contains the compatible file for Unstructured to process on its hosted compute resources.
-        - `<path/to/output/file>` with the destination (output) path on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
+        - `<path/to/input>` with the source (input) path to the directory on your local machine that contains the compatible files for Unstructured to process on its hosted compute resources.
+        - `<path/to/output>` with the destination (output) path to the directory on your local machine that will contain the processed data that Unstructured returns from its hosted compute resources.
 
-        <Tip>For the Unstructured Serverless API, you can set the `server` parameter to the string `saas-api` instead of setting `server_url` (Python) or `serverURL` (JavaScript/TypeScript) to your Unstructured Serverless API URL.</Tip>
-    
-        ```python
-        import json, os
-
-        from unstructured_client import UnstructuredClient
-        from unstructured_client.models import operations, shared
-
-        input_filepath = "<local/path/to/input/file>"
-        output_filepath = "<local/path/to/output/file>"
-
-        client = UnstructuredClient(
-            api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
-        )
-
-        with open(input_filepath, "rb") as f:
-            files = shared.Files(
-                content=f.read(),
-                file_name=input_filepath
-            )
-
-        req = operations.PartitionRequest(
-            shared.PartitionParameters(
-                files=files,
-                split_pdf_page=True,
-                split_pdf_allow_failed=True,
-                split_pdf_concurrency_level=15
-            )
-        )
-
-        try:
-            res = client.general.partition(request=req)
-            element_dicts = [element for element in res.elements]
-            json_elements = json.dumps(element_dicts, indent=2)
-            
-            # Print the processed data.
-            print(json_elements)
-
-            # Write the processed data to a local file.
-            with open(output_filepath, "w") as file:
-            file.write(json_elements)
-        except Exception as e:
-            print(e)
-        ```
-        </Step>
+        <LocalToLocalPythonIngestLibrary />
+    </Step>
     <Step title="View the processed data">
         Go to your destination location to view the processed data.
     </Step>
@@ -180,70 +114,8 @@ You will need:
 
 ---
 
-### <Icon icon="door-open" />   Quickstart: Unstructured open source library
-
-This quickstart uses your local machine for a single-file source (input) location, and a destination (output) location for the processed data. This quickstart also uses local data processing. It does not call Unstructured Serverless API services.
-
-<Warning>
-    The open source library is not designed for use in production. It is designed as a starting point for quick prototyping and is [limited](/open-source/introduction/overview#limits). For production scenarios, use the [Unstructured Platform](/platform/overview) and [Unstructured API services](/api-reference/api-services/overview).
-</Warning>
-
-<Info>
-    The open source library is designed primarily to work with only a single file at a time and only with local source and destination locations. To process multiple files at a time, or to use non-local source or destination locations, use the [Unstructured Python Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead.    
-</Info>
-
-You will need:
-
-- Python installed on your local machine.
-- A compatible file on your local machine to be processed. [See the list of supported file types](#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-
-<Steps>
-    <Step title="Install the open source library">
-        Run the following command:
-        ```bash
-        pip install "unstructured[all-docs]"
-        ```
-    </Step>
-    <Step title="Run the code">
-        Run the following command, replacing:
-
-        - `<path/to/input/file>` with the source (input) path on your local machine that contains the compatible file to process.
-        - `<path/to/output/file>` with the destination (output) path on your local machine that will contain the processed data.
-
-        ```python
-        import json
-
-        from unstructured.partition.auto import partition
-
-        input_filepath = "<path/to/input/file>"
-        output_filepath = "<path/to/output/file>"
-
-        elements = partition(
-        filename=input_filepath
-        )
-
-        element_dicts = [element.to_dict() for element in elements]
-        json_elements = json.dumps(element_dicts, indent=2)
-
-        # Print the processed data.
-        print(json_elements)
-
-        # Write the processed data to a local file.
-        with open(output_filepath, "w") as file:
-            file.write(json_elements)
-        ```
-    </Step>
-    <Step title="View the processed data">
-        Go to your destination location to view the processed data.
-    </Step>
-</Steps>
-
-[Learn more about the Unstructured open source library](/open-source/introduction/overview).
-
----
-
 ## Get in touch
 
-If you don't find the information you're looking for in the documentation, or require assistance,
+If you can't find the information you're looking for in the documentation, or if you need help,
 get in touch with our Support team at [support@unstructured.io](mailto:support%40unstructured.io),
 or [join our Slack](https://short.unstructured.io/pzw05l7) where our team and community can help you.


### PR DESCRIPTION
Ingest is faster for larger individual files--and better at handling multiple files at a time in batches--than POST requests, the SDKs, or the open-source library. As such, this PR seeks to emphasize the Ingest CLI and Ingest Python library, and de-emphasize POST requests, the SDKs, and the open-source library (although the docs for these are still there). See:

- Welcome page's quickstarts: https://unstructured-53-docs-56-ingest.mintlify.app/welcome#quickstart-unstructured-serverless-api
- Unstructured Serverless API page's quickstarts: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/saas-api-development-guide#quickstart
- Free Unstructured API page's quickstarts: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/free-api#quickstart

Cautionary usage notes in:

- Python SDK page: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/sdk-python 
- JS/TS SDK page: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/sdk-jsts
- POST requests page: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/post-requests
- API via open source page: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/partition-via-api
- API parameters page: https://unstructured-53-docs-56-ingest.mintlify.app/api-reference/api-services/api-parameters
