### PR TITLE
Emphasize Ingest in how-to's and best practices

### DIFF
--- a/api-reference/best-practices/speed-up-large-files-batches.mdx
+++ b/api-reference/best-practices/speed-up-large-files-batches.mdx
@@ -70,11 +70,11 @@ In Python, to specify the maximum number of available local logical CPUs that ca
 
 ## PDF files
 
-To speed up PDF file processing, the [Unstructured SDK for Python](/api-reference/api-services/sdk-python) and the [Unstructured SDK for JavaScript/TypeScript](/api-reference/api-services/sdk-jsts) provide the following parameters to help speed up processing a large PDF file:
+To speed up PDF file processing, the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), the [Unstructured SDK for Python](/api-reference/api-services/sdk-python), and the [Unstructured SDK for JavaScript/TypeScript](/api-reference/api-services/sdk-jsts) provide the following parameters to help speed up processing a large PDF file:
 
-- `split_pdf_page` (Python) or `splitPdfPage` (JavaScript/TypeScript), when set to true, splits the PDF file on the client side before sending it as batches to Unstructured for processing. The number of pages in each batch is determined internally. Batches can contain between 2 and 20 pages.
-- `split_pdf_concurrency_level` (Python) or `splitPdfConcurrencyLevel` (JavaScript/TypeScript) is an integer that specifies the number of parallel requests. The default is 5. The maximum is 15. This behavior is ignored unless `split_pdf_page` (Python) or `splitPdfPage` (JavaScript/TypeScript) is also set to true.
-- `split_pdf_allow_failed` (Python) or splitPdfAllowFailed` (JavaScript/TypeScript), when set to true, allows partitioning to continue even if some pages fail.
-- `split_pdf_page_range` (Python only) is a list of two integers that specify the beginning and ending page numbers of the PDF file to be sent. A `ValueError` is raised if the specified range is not valid. This behavior is ignored unless `split_pdf_page` is also set to true.
+- `split_pdf_page` (CLI/Python) or `splitPdfPage` (JavaScript/TypeScript), when set to true, splits the PDF file on the client side before sending it as batches to Unstructured for processing. The number of pages in each batch is determined internally. Batches can contain between 2 and 20 pages.
+- `split_pdf_concurrency_level` (CLI/Python) or `splitPdfConcurrencyLevel` (JavaScript/TypeScript) is an integer that specifies the number of parallel requests. The default is 5. The maximum is 15. This behavior is ignored unless `split_pdf_page` (CLI/Python) or `splitPdfPage` (JavaScript/TypeScript) is also set to true.
+- `split_pdf_allow_failed` (CLI/Python) or splitPdfAllowFailed` (JavaScript/TypeScript), when set to true, allows partitioning to continue even if some pages fail.
+- `split_pdf_page_range` (CLI/Python only) is a list of two integers that specify the beginning and ending page numbers of the PDF file to be sent. A `ValueError` is raised if the specified range is not valid. This behavior is ignored unless `split_pdf_page` is also set to true.
 
 [Learn more](/api-reference/api-services/sdk#page-splitting).

--- a/api-reference/how-to/extract-image-block-types.mdx
+++ b/api-reference/how-to/extract-image-block-types.mdx
@@ -8,7 +8,7 @@ You want to get, decode, and show elements, such as images and tables, that are 
 
 ## Approach
 
-Use the Unstructured Python SDK to extract the Base64-encoded representation of specific elements, such as images and tables, in the document. 
+Extract the Base64-encoded representation of specific elements, such as images and tables, in the document. 
 For each of these extracted elements, decode the Base64-encoded representation of the element into its original visual representation 
 and then show it.
 
@@ -18,15 +18,25 @@ You will need a document that is one of the document types supported by the `ext
 See the `extract_image_block_types` entry in [API Parameters](/api-reference/api-services/api-parameters). 
 This example uses a PDF file with embedded images and tables.
 
+import ExtractImageBlockTypesIngestPy from '/snippets/how-to-api/extract_image_block_types_ingest.py.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
-
-<SharedAPIKeyURL />
+import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_image_block_types.py.mdx';
 
 ## Code
 
-import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_image_block_types.py.mdx';
-
-<ExtractImageBlockTypesPy />
+<AccordionGroup>
+    <Accordion title="Ingest Python library">
+        For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
+        [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
+        file that the Ingest Python library outputs.
+        <ExtractImageBlockTypesIngestPy />
+    </Accordion>
+    <Accordion title="Python SDK">
+        For the [Unstructured Python SDK](/api-reference/api-services/sdk-python), you'll need:
+        <SharedAPIKeyURL />
+        <ExtractImageBlockTypesPy />
+    </Accordion>
+</AccordionGroup>
 
 ## See also 
 

--- a/api-reference/how-to/extract-image-block-types.mdx
+++ b/api-reference/how-to/extract-image-block-types.mdx
@@ -28,7 +28,7 @@ import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_image_block_t
     <Accordion title="Ingest Python library">
         For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
         [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
-        file that the Ingest Python library outputs.
+        file that the Ingest Python library outputs after the processing is complete.
         <ExtractImageBlockTypesIngestPy />
     </Accordion>
     <Accordion title="Python SDK">

--- a/api-reference/how-to/get-chunked-elements.mdx
+++ b/api-reference/how-to/get-chunked-elements.mdx
@@ -48,19 +48,27 @@ The contents of the `orig_elements` field is in compressed Base64 gzipped format
 
 ## To run this example
 
-You will need to chunk a document during processing. This example chunks a PDF file into 200- to 300-character elements.
-
-import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
-
-<SharedAPIKeyURL />
+You will need to chunk a document during processing. This example uses a PDF file chunked into 200- to 300-character elements.
 
 ## Code
 
-This example uses the Unstructured SDK for Python.
-
+import GetChunkedElementsIngestPy from '/snippets/how-to-api/get_chunked_elements_ingest.py.mdx';
 import GetChunkedElementsPy from '/snippets/how-to-api/get_chunked_elements.py.mdx';
+import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
-<GetChunkedElementsPy />
+<AccordionGroup>
+    <Accordion title="Ingest Python library">
+        For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
+        [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
+        file that the Ingest Python library outputs after the processing is complete.
+        <GetChunkedElementsIngestPy />
+    </Accordion>
+    <Accordion title="Python SDK">
+        For the [Unstructured Python SDK](/api-reference/api-services/sdk-python), you'll need:
+        <SharedAPIKeyURL />
+        <GetChunkedElementsPy />
+    </Accordion>
+</AccordionGroup>
 
 ## See also 
 

--- a/api-reference/how-to/get-elements.mdx
+++ b/api-reference/how-to/get-elements.mdx
@@ -10,11 +10,51 @@ You want to get, manipulate, and print or save, the contents of the [document el
 
 Each element in the document elements contains fields for that element's type, its ID, the extracted text, and associated metadata.
 
-The programmatic approach you take to get these document elements will depend on whether you use the [Unstructured Python SDK](/api-reference/api-services/sdk-python), the [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts), or the [Unstructured open source library](/open-source/introduction/overview).
+The programmatic approach you take to get these document elements will depend on which tool, SDK, or library you use:
 
 <AccordionGroup>
+    <Accordion title="Ingest CLI">
+        For the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you can use a tool such as [jq](https://jqlang.github.io/jq/) 
+        to work with a JSON file that the CLI outputs. 
+        
+        For example, the following script uses `jq` to access and print each element's ID, text, and originating file name:
+
+        ```bash Shell
+        #!/usr/bin/env bash
+        
+        JSON_FILE="local-ingest-output/my-file.json"
+
+        jq -r '.[] | "ID: \(.element_id)\nText: \(.text)\nFilename: \(.metadata.filename)\n"' \
+            "$JSON_FILE"
+        ```
+    </Accordion>
+    <Accordion title="Ingest Python library">
+        For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
+        [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
+        file that the Ingest Python library outputs.
+
+        For example, the following code example uses standard Python to access and print each element's ID, text, and originating file name:
+
+        ```python Python
+        import json
+
+        def parse_json_file(input_file_path: str):
+            with open(input_file_path, 'r') as file:
+                file_elements = json.load(file)
+
+            for element in file_elements:
+                print(f"ID: {element["element_id"]}")
+                print(f"Text: {element["text"]}")
+                print(f"Filename: {element["metadata"]["filename"]}\n")
+
+        if __name__ == "__main__":
+            parse_json_file(
+                input_file_path="local-ingest-output/my-file.json"
+            )
+        ```
+    </Accordion>
     <Accordion title="Python SDK">
-        Calling an `UnstructuredClient` object's `general.partition` method returns a `PartitionResponse` object. 
+        For the [Unstructured Python SDK](/api-reference/api-services/sdk-python), calling an `UnstructuredClient` object's `general.partition` method returns a `PartitionResponse` object. 
         
         This `PartitionResponse` object's `elements` variable contains a list of key-value dictionaries (`List[Dict[str, Any]]`). For example:
 
@@ -85,7 +125,7 @@ The programmatic approach you take to get these document elements will depend on
         ```
     </Accordion>
     <Accordion title="JavaScript/TypeScript SDK">
-        Calling an `UnstructuredClient` object's `general.partition` method returns a `Promise<PartitionResponse>` object. 
+        For the [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts), calling an `UnstructuredClient` object's `general.partition` method returns a `Promise<PartitionResponse>` object. 
         
         This `PartitionResponse` object's `elements` property contains an `Array` of string-value objects (`{ [k: string]: any; }[]`). For example:
 
@@ -160,8 +200,8 @@ The programmatic approach you take to get these document elements will depend on
         } // ...
         ```
     </Accordion>
-    <Accordion title="Open source library">
-        Calling the `partition_via_api` function returns a list of elements (`list[Element]`). For example:
+    <Accordion title="Open-source library">
+        For the [Unstructured open-source library](/api-reference/api-services/partition-via-api), calling the `partition_via_api` function returns a list of elements (`list[Element]`). For example:
 
         ```python Python
         # ...

--- a/api-reference/how-to/get-elements.mdx
+++ b/api-reference/how-to/get-elements.mdx
@@ -15,7 +15,7 @@ The programmatic approach you take to get these document elements will depend on
 <AccordionGroup>
     <Accordion title="Ingest CLI">
         For the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you can use a tool such as [jq](https://jqlang.github.io/jq/) 
-        to work with a JSON file that the CLI outputs. 
+        to work with a JSON file that the CLI outputs after the processing is complete. 
         
         For example, the following script uses `jq` to access and print each element's ID, text, and originating file name:
 
@@ -31,7 +31,7 @@ The programmatic approach you take to get these document elements will depend on
     <Accordion title="Ingest Python library">
         For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
         [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
-        file that the Ingest Python library outputs.
+        file that the Ingest Python library outputs after the processing is complete.
 
         For example, the following code example uses standard Python to access and print each element's ID, text, and originating file name:
 

--- a/api-reference/how-to/text-as-html.mdx
+++ b/api-reference/how-to/text-as-html.mdx
@@ -8,7 +8,7 @@ You want to get, save, or show the contents of elements that are represented as 
 
 ## Approach
 
-Use the Unstructured Python SDK to extract the contents of an element's `text_as_html` JSON object, which is nested inside of its parent `metadata` object.
+Extract the contents of an element's `text_as_html` JSON object, which is nested inside of its parent `metadata` object.
 
 ## To run this example
 
@@ -16,15 +16,25 @@ You will need a document that is one of the document types that can output the `
 
 This example uses a PDF file with an embedded table.
 
+import ExtractImageBlockTypesIngestPy from '/snippets/how-to-api/extract_text_as_html_ingest.py.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
-
-<SharedAPIKeyURL />
+import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_text_as_html.py.mdx';
 
 ## Code
 
-import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_text_as_html.py.mdx';
-
-<ExtractImageBlockTypesPy />
+<AccordionGroup>
+    <Accordion title="Ingest Python library">
+        For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
+        [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
+        file that the Ingest Python library outputs.
+        <ExtractImageBlockTypesIngestPy />
+    </Accordion>
+    <Accordion title="Python SDK">
+        For the [Unstructured Python SDK](/api-reference/api-services/sdk-python), you'll need:
+        <SharedAPIKeyURL />
+        <ExtractImageBlockTypesPy />
+    </Accordion>
+</AccordionGroup>
 
 ## See also 
 

--- a/api-reference/how-to/text-as-html.mdx
+++ b/api-reference/how-to/text-as-html.mdx
@@ -16,9 +16,9 @@ You will need a document that is one of the document types that can output the `
 
 This example uses a PDF file with an embedded table.
 
-import ExtractImageBlockTypesIngestPy from '/snippets/how-to-api/extract_text_as_html_ingest.py.mdx';
+import ExtractTextAsHTMLIngestPy from '/snippets/how-to-api/extract_text_as_html_ingest.py.mdx';
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
-import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_text_as_html.py.mdx';
+import ExtractTextAsHTMLPy from '/snippets/how-to-api/extract_text_as_html.py.mdx';
 
 ## Code
 
@@ -26,13 +26,13 @@ import ExtractImageBlockTypesPy from '/snippets/how-to-api/extract_text_as_html.
     <Accordion title="Ingest Python library">
         For the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library), you can use the standard Python 
         [json.load](https://docs.python.org/3/library/json.html#json.load) function to load into a Python dictionary the contents of a JSON 
-        file that the Ingest Python library outputs.
-        <ExtractImageBlockTypesIngestPy />
+        file that the Ingest Python library outputs after the processing is complete.
+        <ExtractTextAsHTMLIngestPy />
     </Accordion>
     <Accordion title="Python SDK">
         For the [Unstructured Python SDK](/api-reference/api-services/sdk-python), you'll need:
         <SharedAPIKeyURL />
-        <ExtractImageBlockTypesPy />
+        <ExtractTextAsHTMLIngestPy />
     </Accordion>
 </AccordionGroup>
 

--- a/snippets/how-to-api/extract_image_block_types_ingest.py.mdx
+++ b/snippets/how-to-api/extract_image_block_types_ingest.py.mdx
@@ -1,0 +1,25 @@
+```python Python
+import json, base64, io
+from PIL import Image
+
+def get_image_block_types(input_json_file_path: str):
+    with open(input_json_file_path, 'r') as file:
+        file_elements = json.load(file)
+
+    for element in file_elements:
+        if "image_base64" in element["metadata"]:
+            # Decode the Base64-encoded representation of the 
+            # processed "Image" or "Table" element into its original
+            # visual representation, and then show it.
+            image_data = base64.b64decode(element["metadata"]["image_base64"])
+            image = Image.open(io.BytesIO(image_data))
+            image.show()
+
+if __name__ == "__main__":
+    # Source: https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/pdf/embedded-images-tables.pdf
+
+    # Specify where to get the local file, relative to this .py file.
+    get_image_block_types(
+        input_json_file_path="local-ingest-output/embedded-images-tables.json"
+    )
+```

--- a/snippets/how-to-api/extract_text_as_html_ingest.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html_ingest.py.mdx
@@ -1,0 +1,37 @@
+```python Python
+import json, os, webbrowser
+
+def get_tables_as_html(
+        input_json_file_path: str,
+        output_html_dir_path: str
+    ):
+    with open(input_json_file_path, 'r') as file:
+        file_elements = json.load(file)
+
+    # Provide some minimal CSS for better table readability.
+    table_css = "<head><style>table, th, td { border: 1px solid; }</style></head>"
+
+    for element in file_elements:
+        if "text_as_html" in element["metadata"]:
+            # Surround the element's HTML with basic <html> and <body> tags, and add the minimal CSS.
+            html_string = f"<!DOCTYPE html><html>{table_css}<body>{element["metadata"]["text_as_html"]}</body></html>"
+
+            # Save the element's HTML to a local file.
+            save_path = f"{output_html_dir_path}/{element["element_id"]}.html"
+            file = open(save_path, 'w')
+            file.write(html_string)
+            file.close()
+
+            # View the locally saved file in the local default web browser.
+            webbrowser.open_new(f"file:///{os.getcwd()}/{save_path}")
+
+if __name__ == "__main__":
+    # Source: https://github.com/Unstructured-IO/unstructured-ingest/blob/main/example-docs/pdf/embedded-images-tables.pdf
+
+    # Specify where to get the local file, relative to this .py file, and
+    # where to store the retrieved HTML, relative to this .py file.
+    get_tables_as_html(
+        input_json_file_path="local-ingest-output/embedded-images-tables.pdf.json",
+        output_html_dir_path="local-ingest-output/html/"
+    )
+```

--- a/snippets/how-to-api/extract_text_as_html_ingest.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html_ingest.py.mdx
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     # Specify where to get the local file, relative to this .py file, and
     # where to store the retrieved HTML, relative to this .py file.
     get_tables_as_html(
-        input_json_file_path="local-ingest-output/embedded-images-tables.pdf.json",
+        input_json_file_path="local-ingest-output/embedded-images-tables.json",
         output_html_dir_path="local-ingest-output/html/"
     )
 ```

--- a/snippets/how-to-api/get_chunked_elements.py.mdx
+++ b/snippets/how-to-api/get_chunked_elements.py.mdx
@@ -50,7 +50,7 @@ try:
     # a transposed version of the returned elements. 
     # For instance, we just want to capture each element's ID,
     # the chunk's text, and the chunk's associated elements in context.
-    orig_elemenents_dict: List[Dict[str, Any]] = []
+    orig_elements_dict: List[Dict[str, Any]] = []
 
     for element in res.elements:
         # For each chunk that has an "orig_elements" field...
@@ -58,14 +58,14 @@ try:
             # ...get the chunk's associated elements in context...
             orig_elements = extract_orig_elements(element["metadata"]["orig_elements"])
             # ...and then transpose it and other associated fields into a separate dictionary.
-            orig_elemenents_dict.append({
+            orig_elements_dict.append({
                 "element_id": element["element_id"],
                 "text": element["text"],
                 "orig_elements": json.loads(orig_elements)
             })
     
     # Convert the elements into a JSON object.
-    orig_elements_json = json.dumps(orig_elemenents_dict, indent=2)
+    orig_elements_json = json.dumps(orig_elements_dict, indent=2)
     
     # Print out the JSON.
     print(orig_elements_json)

--- a/snippets/how-to-api/get_chunked_elements_ingest.py.mdx
+++ b/snippets/how-to-api/get_chunked_elements_ingest.py.mdx
@@ -1,0 +1,51 @@
+```python Python
+import json, base64, zlib
+from typing import List, Dict, Any
+
+# Extract the contents of an orig_elements field.
+def extract_orig_elements(orig_elements):
+    decoded_orig_elements = base64.b64decode(orig_elements)
+    decompressed_orig_elements = zlib.decompress(decoded_orig_elements)
+    return decompressed_orig_elements.decode('utf-8')
+
+def get_chunked_elements(input_json_file_path: str) -> List[Dict[str, Any]]:
+    # Create a dictionary that will hold only
+    # a transposed version of the returned elements. 
+    # For instance, we just want to capture each element's ID,
+    # the chunk's text, and the chunk's associated elements in context.
+    orig_elemenents_dict: List[Dict[str, Any]] = []
+
+    with open(input_json_file_path, 'r') as file:
+        file_elements = json.load(file)
+
+    for element in file_elements:
+        # For each chunk that has an "orig_elements" field...
+        if "orig_elements" in element["metadata"]:
+            # ...get the chunk's associated elements in context...
+            orig_elements = extract_orig_elements(element["metadata"]["orig_elements"])
+            # ...and then transpose it and other associated fields into a separate dictionary.
+            orig_elemenents_dict.append({
+                "element_id": element["element_id"],
+                "text": element["text"],
+                "orig_elements": json.loads(orig_elements)
+            })
+    
+    return orig_elemenents_dict
+
+if __name__ == "__main__":
+    # Source file: https://www.fda.gov/files/drugs/published/Portable-Document-Format-Specifications.pdf
+    input_filepath = "local-ingest-output-json/Portable-Document-Format-Specifications.json"
+    output_filepath = "local-ingest-output-orig/Portable-Document-Format-Specifications-Orig-Elements-Only.json"
+
+    orig_elements_dict = get_chunked_elements(input_json_file_path = input_filepath)
+
+    # Convert the elements into a JSON object.
+    orig_elements_json = json.dumps(orig_elements_dict, indent=2)
+    
+    # Print out the JSON.
+    print(orig_elements_json)
+
+    # Write the JSON to a file.
+    with open(output_filepath, "w") as file:
+        file.write(orig_elements_json)
+```


### PR DESCRIPTION
Added Ingest post-processing examples for how-to:

- Get elements: https://unstructured-53-docs-57-ingest.mintlify.app/api-reference/how-to/get-elements
- Get tables as HTML: https://unstructured-53-docs-57-ingest.mintlify.app/api-reference/how-to/text-as-html
- Get images and tables from documents: https://unstructured-53-docs-57-ingest.mintlify.app/api-reference/how-to/extract-image-block-types
- Get chunked elements: https://unstructured-53-docs-57-ingest.mintlify.app/api-reference/how-to/get-chunked-elements