### PR TITLE
Pinecone: envrionment name no longer required (nor works)

### DIFF
--- a/snippets/destination_connectors/pinecone.sh.mdx
+++ b/snippets/destination_connectors/pinecone.sh.mdx
@@ -18,6 +18,5 @@ unstructured-ingest \
   pinecone \
     --api-key "$PINECONE_API_KEY" \
     --index-name "$PINECONE_INDEX_NAME" \
-    --environment "$PINECONE_ENVIRONMENT" \
     --batch-size 80
 ```

--- a/snippets/destination_connectors/pinecone.v1.py.mdx
+++ b/snippets/destination_connectors/pinecone.v1.py.mdx
@@ -25,8 +25,7 @@ def get_writer() -> Writer:
     return PineconeWriter(
         connector_config=SimplePineconeConfig(
             access_config=PineconeAccessConfig(api_key=os.getenv("PINECONE_API_KEY")),
-            index_name=os.getenv("PINECONE_INDEX_NAME"),
-            environment=os.getenv("PINECONE_ENVIRONMENT_NAME"),
+            index_name=os.getenv("PINECONE_INDEX_NAME")
         ),
         write_config=PineconeWriteConfig(batch_size=80),
     )

--- a/snippets/destination_connectors/pinecone.v2.py.mdx
+++ b/snippets/destination_connectors/pinecone.v2.py.mdx
@@ -41,8 +41,7 @@ if __name__ == "__main__":
             access_config=PineconeAccessConfig(
                 api_key=os.getenv("PINECONE_API_KEY")
             ),
-            index_name=os.getenv("PINECONE_INDEX_NAME"),
-            environment=os.getenv("PINECONE_ENVIRONMENT_NAME")
+            index_name=os.getenv("PINECONE_INDEX_NAME")
         ),
         stager_config=PineconeUploadStagerConfig(),
         uploader_config=PineconeUploaderConfig()

--- a/snippets/general-shared-text/pinecone-cli-api.mdx
+++ b/snippets/general-shared-text/pinecone-cli-api.mdx
@@ -12,6 +12,3 @@ The following environment variables:
 
 - `PINECONE_API_KEY` - The Pinecone API, represented by `--api-key` (CLI) or `api_key` (Python, in the `PineconeAccessConfig` object).
 - `PINECONE_INDEX_NAME` - The Pinecone serverless index name, represented by `--index-name` (CLI) or `index_name` (Python).
-- `PINECONE_ENVIRONMENT_NAME` - The Pinecone environment name, represented by `--environment` (CLI) or `environment` (Python).
-
-<Note>As of January 2024, a Pinecone environment name is no longer required. However, the connector still requires it. You can set `PINECONE_ENVIRONMENT_NAME` to an empty string.</Note>


### PR DESCRIPTION
Related:

- https://github.com/Unstructured-IO/unstructured-ingest/issues/25
- https://github.com/Unstructured-IO/unstructured-ingest/pull/30
