### PR TITLE
Remove mention of non-Ingest tools from the welcome page

### DIFF
--- a/welcome.mdx
+++ b/welcome.mdx
@@ -31,7 +31,7 @@ Learn more about these products:
   <Icon icon="blog"/>&nbsp;&nbsp;[Read the announcement](https://unstructured.io/blog/introducing-unstructured-platform).
 </Card>
 <Card title="Unstructured Serverless API services" icon="square-terminal" href="/api-reference/api-services/overview">
-  <br/>Use scripts or code to call the Unstructured Ingest CLI or Ingest Python library, the Unstructured Python or JavaScript/TypeScript SDKs, or with a direct POST request to the Unstructured API, to get all of your data RAG-ready.<br/><br/>
+  <br/>Use scripts or code to call the Unstructured Ingest CLI or Ingest Python library, to get all of your data RAG-ready.<br/><br/>
   Unstructured Serverless API services have a [Serverless](api-reference/api-services/saas-api-development-guide) pay-as-you-go edition and a [Free](/api-reference/api-services/free-api_) [limited](/api-reference/api-services/free-api#free-unstructured-api-limitations) edition that process data on Unstructured-hosted compute resources.<br/><br/>
   If you need to use compute resources that you host instead, there are also [Azure](/api-reference/api-services/azure) pay-as-you-go and [AWS](/api-reference/api-services/aws) pay-as-you-go editions; these editions process data by using the Unstructured API installed on compute resources hosted in your own Azure or AWS account.<br/><br/>
   [Try the quickstart](#quickstart-unstructured-serverless-api).<br/><br/>


### PR DESCRIPTION
See the 2nd card from the top, titled "Unstructured Serverless API services:" https://unstructured-53-emphasize-ingest-welcome-2024-08-21.mintlify.app/welcome#product-offerings