### PR TITLE
Revise code example to not show printing out all elements

### DIFF
--- a/api-reference/api-services/examples.mdx
+++ b/api-reference/api-services/examples.mdx
@@ -155,7 +155,7 @@ The `hi_res` strategy supports different models, and the default is `layout_v1.1
             splitPdfAllowFailed: true
         }).then((res: PartitionResponse) => {
             if (res.statusCode == 200) {
-                console.log(res.elements);
+                console.log(res.elements?.[0]);
             }
         }).catch((e) => {
             console.log(e.statusCode);
@@ -307,7 +307,7 @@ For better OCR results, you can specify what languages your document is in using
             splitPdfAllowFailed: true
         }).then((res: PartitionResponse) => {
             if (res.statusCode == 200) {
-                console.log(res.elements);
+                console.log(res.elements?.[0]);
             }
         }).catch((e) => {
             console.log(e.statusCode);
@@ -456,7 +456,7 @@ Set the `coordinates` parameter to `true` to add this field to the elements in t
             splitPdfAllowFailed: true
         }).then((res: PartitionResponse) => {
             if (res.statusCode == 200) {
-                console.log(res.elements);
+                console.log(res.elements?.[0]);
             }
         }).catch((e) => {
             console.log(e.statusCode);
@@ -608,7 +608,7 @@ This can be helpful if you'd like to use the IDs as a primary key in a database,
             splitPdfAllowFailed: true
         }).then((res: PartitionResponse) => {
             if (res.statusCode == 200) {
-                console.log(res.elements);
+                console.log(res.elements?.[0]);
             }
         }).catch((e) => {
             console.log(e.statusCode);
@@ -768,7 +768,7 @@ By default, the `chunking_strategy` is set to `None`, and no chunking is perform
             splitPdfAllowFailed: true
         }).then((res: PartitionResponse) => {
             if (res.statusCode == 200) {
-                console.log(res.elements);
+                console.log(res.elements?.[0]);
             }
         }).catch((e) => {
             console.log(e.statusCode);

--- a/api-reference/api-services/partition-via-api.mdx
+++ b/api-reference/api-services/partition-via-api.mdx
@@ -47,12 +47,13 @@ elements = partition_via_api(
 )
 
 element_dicts = [element.to_dict() for element in elements]
-json_elements = json.dumps(element_dicts, indent=2)
 
-# Print the processed data.
-print(json_elements)
+# Print the processed data's first element only.
+print(element_dicts[0])
 
 # Write the processed data to a local file.
+json_elements = json.dumps(element_dicts, indent=2)
+
 with open("example-docs/pdf/DA-1p.pdf.json", "w") as file:
     file.write(json_elements)
 ```

--- a/api-reference/api-services/sdk-jsts.mdx
+++ b/api-reference/api-services/sdk-jsts.mdx
@@ -81,12 +81,12 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         }
     }).then((res: PartitionResponse) => {
         if (res.statusCode == 200) {
-            const jsonElements = JSON.stringify(res.elements, null, 2)
-       
-            // Print the processed data.
-            console.log(jsonElements);
+            // Print the processed data's first element only.
+            console.log(res.elements?.[0])
 
             // Write the processed data to a local file.
+            const jsonElements = JSON.stringify(res.elements, null, 2)
+
             fs.writeFileSync("PATH_TO_OUTPUT_FILE", jsonElements)
         }
     }).catch((e) => {
@@ -125,7 +125,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         languages: ['eng']
     }).then((res: PartitionResponse) => {
         if (res.statusCode == 200) {
-            console.log(res.elements);
+            console.log(res.elements?.[0]);
         }
     }).catch((e) => {
       if (e.statusCode) {

--- a/api-reference/api-services/sdk-python.mdx
+++ b/api-reference/api-services/sdk-python.mdx
@@ -77,12 +77,13 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     try:
         res = client.general.partition(request=req)
         element_dicts = [element for element in res.elements]
-        json_elements = json.dumps(element_dicts, indent=2)
-    
-        # Print the processed data.
-        print(json_elements)
+        
+        # Print the processed data's first element only.
+        print(element_dicts[0])
 
         # Write the processed data to a local file.
+        json_elements = json.dumps(element_dicts, indent=2)
+
         with open("PATH_TO_OUTPUT_FILE", "w") as file:
             file.write(json_elements)
     except Exception as e:

--- a/api-reference/how-to/get-elements.mdx
+++ b/api-reference/how-to/get-elements.mdx
@@ -63,7 +63,8 @@ The programmatic approach you take to get these document elements will depend on
 
         res = client.general.partition(request=req)
 
-        print(res.elements)
+        # Do something with the elements, for example:
+        save_elements_to_file(res.elements)
 
         # ...
         ```
@@ -82,9 +83,10 @@ The programmatic approach you take to get these document elements will depend on
         res = client.general.partition(request=req)
 
         for element in res.elements:
-            print(f"ID: {element["element_id"]}")
-            print(f"Text: {element["text"]}")
-            print(f"Filename: {element["metadata"]["filename"]}\n")
+            # Do something with each element, for example:
+            save_element_to_database(f"{element["element_id"]}")
+            save_element_to_database(f"{element["text"]}")
+            save_element_to_database(f"{element["metadata"]["filename"]}\n")
 
         # ...
         ```
@@ -107,15 +109,6 @@ The programmatic approach you take to get these document elements will depend on
             element_dicts=res.elements
         )
 
-        # Print as JSON...
-        json_elements = elements_to_json(
-            elements=dict_elements,
-            indent=2
-        )
-
-        print(json_elements)
-
-        # ...or save as JSON.
         elements_to_json(
             elements=dict_elements,
             indent=2,
@@ -145,7 +138,8 @@ The programmatic approach you take to get these document elements will depend on
             }
         }).then((res) => {
             if (res.statusCode == 200) {
-                console.log(res.elements)
+                // Do something with the elements, for example:
+                saveElementsToFile(res.elements)
             }
         } // ...
         ```
@@ -171,9 +165,10 @@ The programmatic approach you take to get these document elements will depend on
         }).then((res) => {
             if (res.statusCode == 200) {
                 res.elements?.forEach(element => {
-                    console.log(`ID: ${element["element_id"]}`)
-                    console.log(`Text: ${element["text"]}`)
-                    console.log(`Filename: ${element["metadata"]["filename"]}`)
+                    // Do something with each element, for example:
+                    saveElementToDatabase(`${element["element_id"]}`)
+                    saveElementToDatabase(`${element["text"]}`)
+                    saveElementToDatabase(`${element["metadata"]["filename"]}`)
                 }
             }
         } // ...
@@ -198,8 +193,6 @@ The programmatic approach you take to get these document elements will depend on
         }).then((res) => {
             if (res.statusCode == 200) {    
                 const jsonElements = JSON.stringify(res.elements, null, 2)
-       
-                console.log(jsonElements)
 
                 fs.writeFileSync(outputFilepath, jsonElements)
             }
@@ -251,9 +244,10 @@ The programmatic approach you take to get these document elements will depend on
         )
 
         for element in elements:
-            print(f"ID: {element.id}")
-            print(f"Text: {element.text}")
-            print(f"Filename: {element.metadata.filename}")
+            # Do something with each element, for example:
+            save_element_to_database(f"{element.id}")
+            save_element_to_database(f"{element.text}")
+            save_element_to_database(f"{element.metadata.filename}")
 
         ```
 
@@ -271,7 +265,7 @@ The programmatic approach you take to get these document elements will depend on
             strategy="hi_res"
         )
 
-        print(elements_to_dicts(elements))
+        elements_dicts = elements_to_dicts(elements)
         ```
 
         To serialize this list as JSON, you can use the `elements_to_json` function to convert the list of elements (`Iterable[Element]`) into a JSON-formatted string and then print or save that string. For example:
@@ -288,15 +282,11 @@ The programmatic approach you take to get these document elements will depend on
             strategy="hi_res"
         )
 
-        # Print as JSON...
         json_elements = elements_to_json(
             elements=elements,
             indent=2
         )
 
-        print(json_elements)
-
-        # ...or save as JSON.
         elements_to_json(
             elements=elements,
             indent=2,

--- a/snippets/how-to-api/extract_image_block_types.py.mdx
+++ b/snippets/how-to-api/extract_image_block_types.py.mdx
@@ -56,20 +56,6 @@ if __name__ == "__main__":
                 image = Image.open(io.BytesIO(image_data))
                 image.show()
 
-        # Print the elements as JSON...
-        json_elements = elements_to_json(
-            elements=dict_elements,
-            indent=2
-        )
-
-        print(json_elements)
-
-        # ...or save as JSON.
-        elements_to_json(
-            elements=dict_elements,
-            indent=2,
-            filename=local_output_filepath
-        )
     except Exception as e:
         print(e)
 ```

--- a/snippets/how-to-api/extract_text_as_html.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html.py.mdx
@@ -60,15 +60,7 @@ if __name__ == "__main__":
             element_dicts=result.elements
         )
 
-        # Print the elements as JSON...
-        json_elements = elements_to_json(
-            elements=dict_elements,
-            indent=2
-        )
-
-        print(json_elements)
-
-        # ...or save as JSON.
+        # Save the elements as JSON.
         elements_to_json(
             elements=dict_elements,
             indent=2,

--- a/snippets/how-to-api/get_chunked_elements.py.mdx
+++ b/snippets/how-to-api/get_chunked_elements.py.mdx
@@ -66,9 +66,6 @@ try:
     
     # Convert the elements into a JSON object.
     orig_elements_json = json.dumps(orig_elements_dict, indent=2)
-    
-    # Print out the JSON.
-    print(orig_elements_json)
 
     # Write the JSON to a file.
     with open(output_filepath, "w") as file:

--- a/snippets/how-to-api/get_chunked_elements_ingest.py.mdx
+++ b/snippets/how-to-api/get_chunked_elements_ingest.py.mdx
@@ -41,9 +41,6 @@ if __name__ == "__main__":
 
     # Convert the elements into a JSON object.
     orig_elements_json = json.dumps(orig_elements_dict, indent=2)
-    
-    # Print out the JSON.
-    print(orig_elements_json)
 
     # Write the JSON to a file.
     with open(output_filepath, "w") as file:


### PR DESCRIPTION
Printing out all of the elements can sometimes crash some notebooks. 

In some cases, the point of a particular code example is about how to get elements. In these cases, just print out the first element only, or save the results to a file for later examination. 

See:

- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/api-services/examples - Revised the Python SDK and JS/TS SDK examples
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/api-services/partition-via-api#basics
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/api-services/sdk-jsts#basics
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/api-services/sdk-python#basics
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/how-to/get-elements - Revised the Python SDK, JS/TS SDK, and open-source library examples
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/how-to/extract-image-block-types - Revised the Python SDK example
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/how-to/text-as-html#python-sdk - Revised the Python SDK example
- https://unstructured-53-docs-62-print-elements.mintlify.app/api-reference/how-to/get-chunked-elements#python-sdk - Revised the Python SDK example 

