### PR TITLE
Unstructured Platform: add lists of supported files types, connector types

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -413,7 +413,9 @@
       {
         "group": "Unstructured Platform",
         "pages": [
-          "platform/overview"
+          "platform/overview",
+          "platform/supported-file-types",
+          "platform/connectors"
        ]       
       },
       {
@@ -429,12 +431,12 @@
             "group": "Sources",
               "pages": [
                 "platform/platform-source-connectors/overview",
-                "platform/platform-source-connectors/s3",
                 "platform/platform-source-connectors/azure-blob-storage",
                 "platform/platform-source-connectors/elasticsearch",
                 "platform/platform-source-connectors/google-drive",
                 "platform/platform-source-connectors/onedrive-cloud-storage",
                 "platform/platform-source-connectors/opensearch",
+                "platform/platform-source-connectors/s3",
                 "platform/platform-source-connectors/salesforce",
                 "platform/platform-source-connectors/sftp-storage",
                 "platform/platform-source-connectors/sharepoint"
@@ -444,7 +446,6 @@
             "group": "Destinations",
             "pages": [
               "platform/platform-destination-connectors/overview",
-              "platform/platform-destination-connectors/s3",
               "platform/platform-destination-connectors/azure-cognitive-search",
               "platform/platform-destination-connectors/chroma",
               "platform/platform-destination-connectors/databricks",
@@ -452,7 +453,7 @@
               "platform/platform-destination-connectors/mongodb",
               "platform/platform-destination-connectors/opensearch",
               "platform/platform-destination-connectors/pinecone",
-              "platform/platform-destination-connectors/postgresql",
+              "platform/platform-destination-connectors/s3",
               "platform/platform-destination-connectors/weaviate"
             ]
           },

--- a/platform/connectors.mdx
+++ b/platform/connectors.mdx
@@ -1,0 +1,45 @@
+---
+title: Supported connectors
+---
+
+The Unstructured Platform supports connecting to the following source and destination types.
+
+```mermaid
+  flowchart LR
+    Sources-->Unstructured-->Destinations
+```
+
+## Sources
+
+- [Azure](/platform/platform-source-connectors/azure-blob-storage)
+- [Elasticsearch](/platform/platform-source-connectors/elasticsearch)
+- [Google Drive](/platform/platform-source-connectors/google-drive)
+- [OneDrive](/platform/platform-source-connectors/onedrive-cloud-storage)
+- [OpenSearch](/platform/platform-source-connectors/opensearch)
+- [S3](/platform/platform-source-connectors/s3)
+- [Salesforce](/platform/platform-source-connectors/salesforce)
+- [SFTP](/platform/platform-source-connectors/sftp-storage)
+- [SharePoint](/platform/platform-source-connectors/sharepoint)
+
+If your source is not listed here, you might still be able to connect Unstructured to it through scripts or code by using the 
+[Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the 
+[Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library). 
+[Learn more](/api-reference/ingest/source-connectors/overview).
+
+## Destinations
+
+- [Azure Cognitive Search](/platform/platform-destination-connectors/azure-cognitive-search)
+- [Chroma](/platform/platform-destination-connectors/chroma)
+- [Databricks Volumes](/platform/platform-destination-connectors/databricks)
+- [Elasticsearch](/platform/platform-destination-connectors/elasticsearch)
+- [MongoDB](/platform/platform-destination-connectors/mongodb)
+- [OpenSearch](/platform/platform-destination-connectors/opensearch)
+- [Pinecone](/platform/platform-destination-connectors/pinecone)
+- [S3](/platform/platform-destination-connectors/s3)
+- [Weaviate](/platform/platform-destination-connectors/weaviate)
+
+If your destination is not listed here, you might still be able to connect Unstructured to it through scripts or code by using the 
+[Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the 
+[Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library). 
+[Learn more](/api-reference/ingest/destination-connector/overview).
+

--- a/platform/overview.mdx
+++ b/platform/overview.mdx
@@ -15,7 +15,7 @@ To get your data RAG-ready, the Unstructured Platform moves it through the follo
 
 ```mermaid
   flowchart LR
-    Connect[1. Connect]-->Route[2. Route]-->Transform[3. Transform]-->Chunk[4. Chunk]-->Embed[5. Embed]-->Persist[6. Persist]
+    Connect[1. Connect]-->Route[2. Route]-->Transform[3. Transform]-->Chunk[4. Chunk]-->Emrich[5. Enrich]-->Embed[6. Embed]-->Persist[7. Persist]
 ```
 <Steps>
   <Step title="Connect">

--- a/platform/overview.mdx
+++ b/platform/overview.mdx
@@ -15,7 +15,7 @@ To get your data RAG-ready, the Unstructured Platform moves it through the follo
 
 ```mermaid
   flowchart LR
-    Connect[1. Connect]-->Route[2. Route]-->Transform[3. Transform]-->Chunk[4. Chunk]-->Emrich[5. Enrich]-->Embed[6. Embed]-->Persist[7. Persist]
+    Connect[1. Connect]-->Route[2. Route]-->Transform[3. Transform]-->Chunk[4. Chunk]-->Enrich[5. Enrich]-->Embed[6. Embed]-->Persist[7. Persist]
 ```
 <Steps>
   <Step title="Connect">

--- a/platform/platform-destination-connectors/overview.mdx
+++ b/platform/platform-destination-connectors/overview.mdx
@@ -12,6 +12,17 @@ To create a destination connector:
 1. On the sidebar, click **Destinations**.
 2. Click **New Destination**.
 3. In the **Type** drop-down list, select the connector type that matches your destination.
-4. Fill in the fields according to your connector type. To learn how, click your connector type in the list of destinations on the side of this page.
+4. Fill in the fields according to your connector type. To learn how, click your connector type in the following list:
+
+   - [Azure Cognitive Search](/platform/platform-destination-connectors/azure-cognitive-search)
+   - [Chroma](/platform/platform-destination-connectors/chroma)
+   - [Databricks Volumes](/platform/platform-destination-connectors/databricks)
+   - [Elasticsearch](/platform/platform-destination-connectors/elasticsearch)
+   - [MongoDB](/platform/platform-destination-connectors/mongodb)
+   - [OpenSearch](/platform/platform-destination-connectors/opensearch)
+   - [Pinecone](/platform/platform-destination-connectors/pinecone)
+   - [S3](/platform/platform-destination-connectors/s3)
+   - [Weaviate](/platform/platform-destination-connectors/weaviate)
+
 5. Click **Save and Test**.
 6. Click **Close**.

--- a/platform/platform-destination-connectors/s3.mdx
+++ b/platform/platform-destination-connectors/s3.mdx
@@ -1,5 +1,5 @@
 ---
-title: Amazon S3 
+title: S3 
 ---
 
 Send processed data from Unstructured to Amazon S3.

--- a/platform/platform-source-connectors/azure-blob-storage.mdx
+++ b/platform/platform-source-connectors/azure-blob-storage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure Blob Storage
+title: Azure
 ---
 
 Ingest your files into Unstructured from Azure Blob Storage.

--- a/platform/platform-source-connectors/overview.mdx
+++ b/platform/platform-source-connectors/overview.mdx
@@ -13,6 +13,17 @@ To create a source connector:
 1. On the sidebar, click **Sources**.
 2. Click **New Source**.
 3. In the **Type** drop-down list, select the connector type that matches your source.
-4. Fill in the fields according to your connector type. To learn how, click your connector type in the list of sources on the side of this page.
+4. Fill in the fields according to your connector type. To learn how, click your connector type in the following list:
+
+   - [Azure](/platform/platform-source-connectors/azure-blob-storage)
+   - [Elasticsearch](/platform/platform-source-connectors/elasticsearch)
+   - [Google Drive](/platform/platform-source-connectors/google-drive)
+   - [OneDrive](/platform/platform-source-connectors/onedrive-cloud-storage)
+   - [OpenSearch](/platform/platform-source-connectors/opensearch)
+   - [S3](/platform/platform-source-connectors/s3)
+   - [Salesforce](/platform/platform-source-connectors/salesforce)
+   - [SFTP](/platform/platform-source-connectors/sftp-storage)
+   - [SharePoint](/platform/platform-source-connectors/sharepoint)
+
 5. Click **Save and Test**.
 6. Click **Close**.

--- a/platform/platform-source-connectors/s3.mdx
+++ b/platform/platform-source-connectors/s3.mdx
@@ -1,5 +1,5 @@
 ---
-title: Amazon S3
+title: S3
 ---
 
 Ingest your files into Unstructured from Amazon S3.

--- a/platform/supported-file-types.mdx
+++ b/platform/supported-file-types.mdx
@@ -1,0 +1,7 @@
+---
+title: Supported file types
+---
+
+import SupportedFileTpes from '/snippets/general-shared-text/supported-file-types.mdx';
+
+<SupportedFileTpes />

--- a/snippets/quickstarts/platform.mdx
+++ b/snippets/quickstarts/platform.mdx
@@ -2,9 +2,9 @@ This quickstart uses a no-code, point-and-click user interface in your web brows
 
 You will need:
 
-- A compatible source (input) location in cloud storage that contains your documents for Unstructured to process. [See the list of supported source types](/platform/platform-source-connectors/overview).
-- Compatible files in your source location. [See the list of supported file types](/api-reference/api-services/overview#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
-- A compatible destination (output) location in cloud storage for Unstructured to put the processed data. [See the list of supported destination types](/platform/platform-destination-connectors/overview).
+- A compatible source (input) location in cloud storage that contains your documents for Unstructured to process. [See the list of supported source types](/platform/connectors#sources).
+- Compatible files in your source location. [See the list of supported file types](/platform/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
+- A compatible destination (output) location in cloud storage for Unstructured to put the processed data. [See the list of supported destination types](/platform/connectors#destinations).
 
 <Steps>
     <Step title="Sign up">


### PR DESCRIPTION
See:

- Supported file types in Platform: https://unstructured-53-platform-2024-09-06.mintlify.app/platform/supported-file-types
- Supported connector types in Platform: https://unstructured-53-platform-2024-09-06.mintlify.app/platform/connectors
- Added list of supported source connectors in Platform to Platform source connectors overview: https://unstructured-53-platform-2024-09-06.mintlify.app/platform/platform-source-connectors/overview
- Added list of supported destination connectors in Platform to Platform destination connectors overview: https://unstructured-53-platform-2024-09-06.mintlify.app/platform/platform-destination-connectors/overview
- Minor cleanup of some page titles to match UI (i.e. "Amazon S3" -> "S3")

Also:

- Added missing "Enrich" step to Platform pipeline flow overview diagram: https://unstructured-53-platform-2024-09-06.mintlify.app/platform/overview#how-does-it-work

