### PR TITLE
curl example fixes: remove split-on-server params

### DIFF
--- a/api-reference/api-services/examples.mdx
+++ b/api-reference/api-services/examples.mdx
@@ -90,10 +90,7 @@ The `hi_res` strategy supports different models, and the default is `layout_v1.1
         -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
         -F 'files=@sample-docs/layout-parser-paper.pdf' \
         -F 'strategy=hi_res' \
-        -F 'hi_res_model_name=layout_v1.1.0' \
-        -F 'split-pdf-page True' \
-        -F 'split-pdf-allow-failed True' \
-        -F 'split-pdf-concurrency-level 15'
+        -F 'hi_res_model_name=layout_v1.1.0'
         ```
     </Accordion>
     <Accordion title="Python SDK">
@@ -242,10 +239,7 @@ For better OCR results, you can specify what languages your document is in using
         -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
         -F 'files=@sample-docs/korean.png' \
         -F 'strategy=ocr_only' \
-        -F 'languages=kor' \
-        -F 'split-pdf-page True' \
-        -F 'split-pdf-allow-failed True' \
-        -F 'split-pdf-concurrency-level 15'
+        -F 'languages=kor'
         ```
     </Accordion>
     <Accordion title="Python SDK">
@@ -391,10 +385,7 @@ Set the `coordinates` parameter to `true` to add this field to the elements in t
         -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
         -F 'files=@sample-docs/layout-parser-paper.pdf' \
         -F 'coordinates=true' \
-        -F 'strategy hi_res' \
-        -F 'split-pdf-page True' \
-        -F 'split-pdf-allow-failed True' \
-        -F 'split-pdf-concurrency-level 15'
+        -F 'strategy=hi_res'
         ```
     </Accordion>
     <Accordion title="Python SDK">
@@ -543,10 +534,7 @@ This can be helpful if you'd like to use the IDs as a primary key in a database,
         -H 'Content-Type: multipart/form-data' \
         -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
         -F 'files=@sample-docs/layout-parser-paper-fast.pdf' \
-        -F 'unique_element_ids=true' \
-        -F 'split-pdf-page True' \
-        -F 'split-pdf-allow-failed True' \
-        -F 'split-pdf-concurrency-level 15'
+        -F 'unique_element_ids=true'
         ```
     </Accordion>
     <Accordion title="Python SDK">
@@ -701,10 +689,7 @@ By default, the `chunking_strategy` is set to `None`, and no chunking is perform
         -F 'files=@sample-docs/layout-parser-paper-fast.pdf' \
         -F 'chunking_strategy=by_title' \
         -F 'max_characters=1024' \
-        -F 'strategy hi_res' \
-        -F 'split-pdf-page True' \
-        -F 'split-pdf-allow-failed True' \
-        -F 'split-pdf-concurrency-level 15'
+        -F 'strategy=hi_res'
         ```
     </Accordion>
     <Accordion title="Python SDK">

--- a/api-reference/api-services/post-requests.mdx
+++ b/api-reference/api-services/post-requests.mdx
@@ -26,9 +26,6 @@ Let's start with a simple example in which you send a PDF file (`*.pdf`) to part
   -H 'unstructured-api-key: $UNSTRUCTURED_API_KEY' \
   -F 'files=@sample-docs/report.pdf' \
   -F 'strategy=hi_res' \
-  -F 'split-pdf-page=True' \
-  -F 'split-pdf-allow-failed=True' \
-  -F 'split-pdf-concurrency-level=15' \
   -o 'sample-docs/report.json'
 ```
 

--- a/examplecode/codesamples/apioss/table-extraction-from-pdf.mdx
+++ b/examplecode/codesamples/apioss/table-extraction-from-pdf.mdx
@@ -63,9 +63,6 @@ curl -X 'POST' \
     -H 'Content-Type: multipart/form-data' \
     -F 'files=@sample-docs/layout-parser-paper-with-table.jpg' \
     -F 'strategy=hi_res' \
-    -F 'split-pdf-page True' \
-    -F 'split-pdf-allow-failed True' \
-    -F 'split-pdf-concurrency-level 15' \
     | jq -C . | less -R
 
 ```

--- a/faq/faq.mdx
+++ b/faq/faq.mdx
@@ -116,11 +116,8 @@ curl -X 'POST' \
   -H 'Content-Type: multipart/form-data' \
   -F 'files=@sample-docs/english-and-korean.png' \
   -F 'strategy=ocr_only' \
-  -F 'languages=eng'  \
-  -F 'languages=kor'  \
-  -F 'split-pdf-page True' \
-  -F 'split-pdf-allow-failed True' \
-  -F 'split-pdf-concurrency-level 15' \
+  -F 'languages=eng' \
+  -F 'languages=kor' \
   | jq -C . | less -R
 ```
 For comprehensive language support, refer to the [Tesseract documentation](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html), which provides a detailed list of supported languages and installation guidelines.


### PR DESCRIPTION
Removed these params:

```
...
-F 'split-pdf-page=true' \
-F 'split-pdf-allow-failed=true' \
-F 'split-pdf-concurrency-level=15' \
...
```

With `curl`, these parameters tell the server "I want you to split the doc," which we do not support. `curl` itself is the client, and does not split a doc itself. 