### PR TITLE
Azure source connector: fix path abfs -> az

### DIFF
--- a/snippets/destination_connectors/azure.sh.mdx
+++ b/snippets/destination_connectors/azure.sh.mdx
@@ -14,7 +14,7 @@ unstructured-ingest \
     --embedding-provider langchain-huggingface \
     --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}" \
   azure \
-    --remote-url $AZURE_STORAGE_ACCOUNT_URL \
+    --remote-url $AZURE_STORAGE_REMOTE_URL \
     --account-name $AZURE_STORAGE_ACCOUNT_NAME \
     --account-key $AZURE_STORAGE_ACCOUNT_KEY
 ```

--- a/snippets/destination_connectors/azure.v1.py.mdx
+++ b/snippets/destination_connectors/azure.v1.py.mdx
@@ -24,7 +24,7 @@ def get_writer() -> Writer:
     return AzureWriter(
         connector_config=SimpleAzureBlobStorageConfig(
             access_config=AzureAccessConfig(account_name=os.getenv("AZURE_STORAGE_ACCOUNT_NAME")),
-            remote_url=os.getenv("AZURE_STORAGE_ACCOUNT_URL"),
+            remote_url=os.getenv("AZURE_STORAGE_REMOTE_URL"),
         ),
         write_config=AzureWriteConfig(),
     )

--- a/snippets/destination_connectors/azure.v2.py.mdx
+++ b/snippets/destination_connectors/azure.v2.py.mdx
@@ -45,6 +45,6 @@ if __name__ == "__main__":
                 account_key=os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
             )
         ),
-        uploader_config=AzureUploaderConfig(remote_url=os.getenv("AZURE_STORAGE_ACCOUNT_URL"))
+        uploader_config=AzureUploaderConfig(remote_url=os.getenv("AZURE_STORAGE_REMOTE_URL"))
     ).run()
 ```

--- a/snippets/general-shared-text/azure-cli-api.mdx
+++ b/snippets/general-shared-text/azure-cli-api.mdx
@@ -10,6 +10,12 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 These environment variables:
 
-- `AZURE_STORAGE_ACCOUNT_URL` - The remote Azure Storage remote URL, represented by `--remote-url` (CLI) or `remote_url` (Python).
+- `AZURE_STORAGE_REMOTE_URL` - The Azure Storage remote URL, represented by `--remote-url` (CLI) or `remote_url` (Python).
+
+  The remote URL takes the format `az://<container-name>/<path/to/file/or/folder/in/container/as/needed>`
+
+  For example, if your container is named `my-container`, and there is a folder in the container named `my-folder`, the 
+  Azure Storage remote URL would be `az://my-container/my-folder/`.
+
 - `AZURE_STORAGE_ACCOUNT_NAME` - The name of the Azure Storage account, represented by `--account-name` (CLI) or `account_name` (Python).
 - `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_STORAGE_CONNECTION_STRING`, or `AZURE_STORAGE_SAS_TOKEN` - The name of the key, connection string, or SAS token for the Azure Storage account, depending on your security configuration, represented by `--account-key` (CLI) or `account_key` (Python), `--connection-string` (CLI) or `connection_string` (Python), and `--sas_token` (CLI) or `sas_token` (Python), respectively.

--- a/snippets/general-shared-text/azure-platform.mdx
+++ b/snippets/general-shared-text/azure-platform.mdx
@@ -1,7 +1,11 @@
 Fill in the following fields:
 
 - **Name** (_required_): A unique name for this connector.
-- **Remote URL** (_required_): The Azure Storage remote URL.
+- **Remote URL** (_required_): The Azure Storage remote URL, with the format `az://<container-name>/<path/to/file/or/folder/in/container/as/needed>`
+
+  For example, if your container is named `my-container`, and there is a folder in the container named `my-folder`, the 
+  Azure Storage remote URL would be `az://my-container/my-folder/`.
+
 - **Azure Account Name**: The Azure Storage account name.
 - **Azure Account Key**: The key for the Azure Storage account, or...
 - **Azure Connection String**: The connection string for the Azure Storage account, or...

--- a/snippets/general-shared-text/azure.mdx
+++ b/snippets/general-shared-text/azure.mdx
@@ -34,7 +34,11 @@ The Azure Storage account prerequisites:
   allowfullscreen
   ></iframe>
 
-- The Azure Storage remote URL, using the format `abfs://<container-name>@<storage-account-name>.blob.core.windows.net/<path/to/file/or/folder/in/container/as/needed>`
+- The Azure Storage remote URL, using the format `az://<container-name>/<path/to/file/or/folder/in/container/as/needed>`
+
+  For example, if your container is named `my-container`, and there is a folder in the container named `my-folder`, the 
+  Azure Storage remote URL would be `az://my-container/my-folder/`.
+
 - An SAS token (recommended), access key, or connection string for the Azure Storage account.  [Create an SAS token (recommended)](https://learn.microsoft.com/azure/ai-services/translator/document-translation/how-to-guides/create-sas-tokens). [Get an access key](https://learn.microsoft.com/azure/storage/common/storage-account-keys-manage#view-account-access-keys). [Get a connection string](https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account).
 
   Create an SAS token (recommended):

--- a/snippets/source_connectors/azure.sh.mdx
+++ b/snippets/source_connectors/azure.sh.mdx
@@ -5,7 +5,7 @@
 
 unstructured-ingest \
   azure \
-    --remote-url $AZURE_STORAGE_ACCOUNT_URL \
+    --remote-url $AZURE_STORAGE_REMOTE_URL \
     --account-name $AZURE_STORAGE_ACCOUNT_NAME \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \

--- a/snippets/source_connectors/azure.v1.py.mdx
+++ b/snippets/source_connectors/azure.v1.py.mdx
@@ -30,7 +30,7 @@ if __name__ == "__main__":
             access_config=AzureAccessConfig(
                 account_name=os.getenv("AZURE_STORAGE_ACCOUNT_NAME"),
             ),
-            remote_url=os.getenv("AZURE_STORAGE_ACCOUNT_URL"),
+            remote_url=os.getenv("AZURE_STORAGE_REMOTE_URL"),
         ),
     )
     runner.run()

--- a/snippets/source_connectors/azure.v2.py.mdx
+++ b/snippets/source_connectors/azure.v2.py.mdx
@@ -20,7 +20,7 @@ from unstructured_ingest.v2.processes.connectors.local import LocalUploaderConfi
 if __name__ == "__main__":
     Pipeline.from_configs(
         context=ProcessorConfig(),
-        indexer_config=AzureIndexerConfig(remote_url=os.getenv("AZURE_STORAGE_ACCOUNT_URL")),
+        indexer_config=AzureIndexerConfig(remote_url=os.getenv("AZURE_STORAGE_REMOTE_URL")),
         downloader_config=AzureDownloaderConfig(download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")),
         source_connection_config=AzureConnectionConfig(
             access_config=AzureAccessConfig(


### PR DESCRIPTION
Azure Storage remote URLs that start with `abfs://` work under some circumstances, but `az://` seems to work under all circumstances during my testing. I confirmed this with Engineering. 

Also, for consistency, changed `AZURE_STORAGE_ACCOUNT_URL` to `AZURE_STORAGE_REMOTE_URL` to more closely match related parameter names.

See:

- Platform: 

  - Source: https://unstructured-53-azure-2024-09-11.mintlify.app/platform/platform-source-connectors/azure-blob-storage

- API: 

  - Source: https://unstructured-53-azure-2024-09-11.mintlify.app/api-reference/ingest/source-connectors/azure
  - Destination: https://unstructured-53-azure-2024-09-11.mintlify.app/api-reference/ingest/destination-connector/azure

- Open source:

  - Source: https://unstructured-53-azure-2024-09-11.mintlify.app/open-source/ingest/source-connectors/azure
  - Destination: https://unstructured-53-azure-2024-09-11.mintlify.app/open-source/ingest/destination-connectors/azure