### PR TITLE
SharePoint source connector: fix paths and environment variable names

### DIFF
--- a/snippets/general-shared-text/sharepoint-cli-api.mdx
+++ b/snippets/general-shared-text/sharepoint-cli-api.mdx
@@ -15,6 +15,6 @@ The following environment variables:
 - `SHAREPOINT_SITE` - The SharePoint site URL, represented by `--site` (CLI) or `site` (Python).
 - `SHAREPOINT_PATH` - The path in the SharePoint site from which to start parsing files, represented by `--path` (CLI) or `path` (Python).
 - `SHAREPOINT_APP_PERMISSIONS_CLIENT_ID` - The associated Azure application (client) ID, represented by `--permissions-application-id` (CLI) or `permissions_application_id` (Python).
-- `SHAREPOINT_APP_TENANT_ID` - The tenant ID for the Azure application, represented by `--permissions-tenant` (CLI) or `permissions_tenant` (Python).
 - `SHAREPOINT_APP_PERMISSIONS_CLIENT_SECRET` - The client secret for the Azure application, represented by `--permissions-client-cred` (CLI) or `permissions_client_cred` (Python).
+- `SHAREPOINT_APP_PERMISSIONS_TENANT` - The domian name of the tenant for the Azure application, which is typically `<organization-name>.onmicrosoft.com`, and which is represented by `--permissions-tenant` (CLI) or `permissions_tenant` (Python).
 

--- a/snippets/general-shared-text/sharepoint-platform.mdx
+++ b/snippets/general-shared-text/sharepoint-platform.mdx
@@ -4,6 +4,6 @@ Fill in the following fields:
 - **Client ID** (_required_): The client ID provided by SharePoint for the app registration.
 - **Client Credential** (_required_): The client secret associated with the client ID.
 - **Site URL** (_required_): The base URL of the SharePoint site to connect to.
-- **Path** (_required_): The path from which to start parsing files. The default is `Shared Documents`.
-- **Recursive**: Check this box to recursively ingest data from subfolders within the specified path.
+- **Path** (_required_): The path from which to start parsing files, for example `Shared Documents`.
+- **Recursive**: Check this box to recursively process data from subfolders within the specified path.
 - **Files Only**: Check this box to disregard the folder structure.

--- a/snippets/general-shared-text/sharepoint.mdx
+++ b/snippets/general-shared-text/sharepoint.mdx
@@ -8,7 +8,7 @@ The SharePoint prerequisites:
 
   [Learn more](https://learn.microsoft.com/microsoft-365/community/query-string-url-tricks-sharepoint-m365).
 
-- The path in the SharePoint site from which to start parsing files. If the connector is to process all sites within the tenant, this filter will be applied to all site document libraries. The default is `Shared Documents`.
+- The path in the SharePoint site from which to start parsing files, for example `"Shared Documents"`. If the connector is to process all sites within the tenant, this filter will be applied to all site document libraries.
 - A SharePoint application (client) ID, along with its client secret with access permissions to the SharePoint instance. [Get a client ID and client secret, and set access permissions](https://github.com/vgrem/Office365-REST-Python-Client/wiki/How-to-connect-to-SharePoint-Online-and-and-SharePoint-2013-2016-2019-on-premises--with-app-principal).
 
   <iframe

--- a/snippets/source_connectors/sharepoint.sh.mdx
+++ b/snippets/source_connectors/sharepoint.sh.mdx
@@ -6,16 +6,16 @@ unstructured-ingest \
     --client-id $SHAREPOINT_APP_CLIENT_ID \
     --client-cred $SHAREPOINT_APP_CLIENT_SECRET \
     --site $SHAREPOINT_SITE \
+    --path $SHAREPOINT_PATH \
     --permissions-application-id $SHAREPOINT_APP_PERMISSIONS_CLIENT_ID \
     --permissions-client-cred $SHAREPOINT_APP_PERMISSIONS_CLIENT_SECRET \
-    --permissions-tenant $SHAREPOINT_APP_TENANT_ID \
+    --permissions-tenant $SHAREPOINT_APP_PERMISSIONS_TENANT \
     --permissions-authority-url https://login.microsoftonline.com \
     --no-omit-files \
     --omit-pages \
     --omit-lists \
     --output-dir $LOCAL_FILE_OUTPUT_DIR \
     --num-processes 2 \
-    --path $SHAREPOINT_PATH \
     --verbose \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \

--- a/snippets/source_connectors/sharepoint.v1.py.mdx
+++ b/snippets/source_connectors/sharepoint.v1.py.mdx
@@ -29,7 +29,7 @@ if __name__ == "__main__":
             permissions_config=SharepointPermissionsConfig(
                 application_id=os.getenv("SHAREPOINT_APP_PERMISSIONS_CLIENT_ID"),
                 client_cred=os.getenv("SHAREPOINT_APP_PERMISSIONS_CLIENT_SECRET"),
-                tenant=os.getenv("SHAREPOINT_APP_TENANT_ID"),
+                tenant=os.getenv("SHAREPOINT_APP_PERMISSIONS_TENANT"),
             ),
             client_id=os.getenv("SHAREPOINT_APP_CLIENT_ID"),
             site=os.getenv("SHAREPOINT_SITE"),

--- a/snippets/source_connectors/sharepoint.v2.py.mdx
+++ b/snippets/source_connectors/sharepoint.v2.py.mdx
@@ -29,10 +29,10 @@ if __name__ == "__main__":
         context=ProcessorConfig(),
         indexer_config=SharepointIndexerConfig(
             path=os.getenv("SHAREPOINT_PATH"),
-            recursive=False,
-            omit_lists=True,
-            omit_pages=True,
-            omit_files=False
+            recursive=True,  # Recursively process files in their respective folders. (False (default) for no recursion.)
+            omit_lists=True, # Do not process lists. (False (default) to process lists.)
+            omit_pages=True, # Do not process site pages. (False (default) to process site pages.)
+            omit_files=False # Process files (default). (True to not process files.)
         ),
         downloader_config=SharepointDownloaderConfig(download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")),
         source_connection_config=SharepointConnectionConfig(
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             site=os.getenv("SHAREPOINT_SITE"),
             permissions_config=SharepointPermissionsConfig(
                 permissions_application_id=os.getenv("SHAREPOINT_APP_PERMISSIONS_CLIENT_ID"),
-                permissions_tenant=os.getenv("SHAREPOINT_APP_TENANT_ID"),
+                permissions_tenant=os.getenv("SHAREPOINT_APP_PERMISSIONS_TENANT"),
                 permissions_client_cred=os.getenv("SHAREPOINT_APP_PERMISSIONS_CLIENT_SECRET"),
                 authority_url="https://login.microsoftonline.com"
             )


### PR DESCRIPTION
Also doc'ing the `recursive` and `omit*` params better. 😄 

See:

- Platform:
- API:
- Open source: