### PR TITLE
Built-in embedding functions removed from Unstructured open-source

### DIFF
--- a/api-reference/how-to/embedding.mdx
+++ b/api-reference/how-to/embedding.mdx
@@ -5,9 +5,7 @@ title: Set embedding behavior
 <Note>
    The following information applies only to the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) and the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library).
 
-   For the Unstructured open-source library, see [Embedding](/open-source/core-functionality/embedding) instead.
-   
-   The Unstructured SDKs for Python and JavaScript/TypeScript do not support this functionality.
+   The Unstructured SDKs for Python and JavaScript/TypeScript, and the Unstructured open-source library, do not support this functionality.
 </Note>
 
 ## Concepts

--- a/open-source/core-functionality/embedding.mdx
+++ b/open-source/core-functionality/embedding.mdx
@@ -64,4 +64,13 @@ if __name__ == "__main__":
         print(f"Error: Unable to access file '{file_path}'.")
 ```
 
-[Learn more](https://python.langchain.com/v0.2/docs/integrations/text_embedding/huggingfacehub/).
+## Additional resources
+
+For information about how to use Python scripts to call various embedding providers, see for example:
+
+- [Amazon Bedrock](https://docs.aws.amazon.com/code-library/latest/ug/python_3_bedrock-runtime_code_examples.html#amazon_titan_text_embeddings)
+- [Hugging Face](https://huggingface.co/blog/getting-started-with-embeddings)
+- [OctoAI](https://octo.ai/blog/introducing-octoais-embedding-api-to-power-your-rag-needs/)
+- [OpenAI](https://platform.openai.com/docs/guides/embeddings)
+- [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings)
+- [Voyage AI](https://docs.voyageai.com/docs/embeddings)

--- a/open-source/core-functionality/embedding.mdx
+++ b/open-source/core-functionality/embedding.mdx
@@ -1,249 +1,67 @@
 ---
 title: Embedding 
-description: Embedding encoder classes in `unstructured` use document elements detected with `partition` or document elements grouped with `chunking` to obtain embeddings for each element, for uses cases such as Retrieval Augmented Generation (RAG).
 ---
 
-## `BaseEmbeddingEncoder`
-
-The `BaseEmbeddingEncoder` is an abstract base class that defines the methods to be implemented for each `EmbeddingEncoder` subclass.
-
-## `OpenAIEmbeddingEncoder`
-
-The `OpenAIEmbeddingEncoder` class uses langchain OpenAI integration under the hood to connect to the OpenAI Text&Embedding API to obtain embeddings for pieces of text.
-
-`embed_documents` will receive a list of Elements, and return an updated list which includes the `embeddings` attribute for each Element.
-
-`embed_query` will receive a query as a string, and return a list of floats which is the embedding vector for the given query string.
-
-`num_of_dimensions` is a metadata property that denotes the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector` is a metadata property that denotes if embedding vectors obtained via this class are unit vectors.
-
-The following code block shows an example of how to use `OpenAIEmbeddingEncoder`. You will see the updated elements list (with the `embeddings` attribute included for each element), the embedding vector for the query string, and some metadata properties about the embedding model. You will need to set an environment variable named `OPENAI_API_KEY` to be able to run this example. To obtain an api key, visit: [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.openai import OpenAIEmbeddingConfig, OpenAIEmbeddingEncoder
-
-# Initialize the encoder with OpenAI credentials
-embedding_encoder = OpenAIEmbeddingEncoder(config=OpenAIEmbeddingConfig(api_key=os.environ["OPENAI_API_KEY"]))
-
-# Embed a list of Elements
-elements = embedding_encoder.embed_documents(
-    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
-)
-
-# Embed a single query string
-query = "This is the query"
-query_embedding = embedding_encoder.embed_query(query=query)
-
-# Print embeddings
-[print(e.embeddings, e) for e in elements]
-print(query_embedding, query)
-print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())
-
-```
-
-
-## `HuggingFaceEmbeddingEncoder`
-
-The `HuggingFaceEmbeddingEncoder` class uses langchain HuggingFace integration under the hood to obtain embeddings for pieces of text using a local model.
-
-`embed_documents` will receive a list of Elements, and return an updated list which includes the `embeddings` attribute for each Element.
-
-`embed_query` will receive a query as a string, and return a list of floats which is the embedding vector for the given query string.
-
-`num_of_dimensions` is a metadata property that denotes the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector` is a metadata property that denotes if embedding vectors obtained via this class are unit vectors.
-
-The following code block shows an example of how to use `HuggingFaceEmbeddingEncoder`. You will see the updated elements list (with the `embeddings` attribute included for each element), the embedding vector for the query string, and some metadata properties about the embedding model.
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.huggingface import HuggingFaceEmbeddingConfig, HuggingFaceEmbeddingEncoder
-
-embedding_encoder = HuggingFaceEmbeddingEncoder(
-    config=HuggingFaceEmbeddingConfig()
-)
-elements = embedding_encoder.embed_documents(
-    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
-)
-
-query = "This is the query"
-query_embedding = embedding_encoder.embed_query(query=query)
-
-[print(e.embeddings, e) for e in elements]
-print(query_embedding, query)
-print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())
-
-```
-
-## `BedrockEmbeddingEncoder`
-
-The `BedrockEmbeddingEncoder` class provides an interface to obtain embeddings for text using the Bedrock embeddings via the langchain integration. It connects to the Bedrock Runtime using AWS’s boto3 package.
-
-Key methods and attributes include:
-
-`embed_documents`: This function takes a list of Elements as its input and returns the same list with an updated embeddings attribute for each Element.
-
-`embed_query`: This method takes a query as a string and returns the embedding vector for the given query string.
-
-`num_of_dimensions`: A metadata property that signifies the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector`: A metadata property that checks if embedding vectors obtained via this class are unit vectors.
-
-Initialization: To create an instance of the BedrockEmbeddingEncoder, AWS credentials and the region name are required.
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.bedrock import BedrockEmbeddingEncoder
-
-# Initialize the encoder with AWS credentials
-embedding_encoder = BedrockEmbeddingEncoder(
-    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-    region_name="us-west-2",
-)
-
-# Embed a list of Elements
-elements = embedding_encoder.embed_documents(elements=[Text("Sentence A"), Text("Sentence B")])
-
-# Embed a single query string
-query = "Example query"
-query_embedding = embedding_encoder.embed_query(query=query)
-
-# Print embeddings
-[print(e.embeddings, e) for e in elements]
-print(query_embedding, query)
-print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())
-
-```
-
-
-Dependencies: This class relies on several dependencies which include boto3, numpy, and langchain. Ensure these are installed and available in the environment where this class is utilized.
-
-## `OctoAIEmbeddingEncoder`
-
-The `OctoAIEmbeddingEncoder` class connects to the OctoAI Text&Embedding API to obtain embeddings for pieces of text.
-
-`embed_documents` will receive a list of Elements, and return an updated list which includes the `embeddings` attribute for each Element.
-
-`embed_query` will receive a query as a string, and return a list of floats which is the embedding vector for the given query string.
-
-`num_of_dimensions` is a metadata property that denotes the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector` is a metadata property that denotes if embedding vectors obtained via this class are unit vectors.
-
-The following code block shows an example of how to use `OctoAIEmbeddingEncoder`. You will see the updated elements list (with the `embeddings` attribute included for each element), the embedding vector for the query string, and some metadata properties about the embedding model. You will need to set an environment variable named `OCTOAI_API_KEY` to be able to run this example. To obtain an api key, visit: [https://octo.ai/docs/getting-started/how-to-create-an-octoai-access-token](https://octo.ai/docs/getting-started/how-to-create-an-octoai-access-token)
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.octoai import OctoAiEmbeddingConfig, OctoAIEmbeddingEncoder
-
-embedding_encoder = OctoAIEmbeddingEncoder(
-    config=OctoAiEmbeddingConfig(api_key=os.environ["OCTOAI_API_KEY"])
-)
-elements = embedding_encoder.embed_documents(
-    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
-)
-
-query = "This is the query"
-query_embedding = embedding_encoder.embed_query(query=query)
-
-[print(e.embeddings, e) for e in elements]
-print(query_embedding, query)
-print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())
-
-```
-
-
-## `VertexAIEmbeddingEncoder`
-
-The `VertexAIEmbeddingEncoder` class connects to the GCP VertexAI to obtain embeddings for pieces of text.
-
-`embed_documents` will receive a list of Elements, and return an updated list which includes the `embeddings` attribute for each Element.
-
-`embed_query` will receive a query as a string, and return a list of floats which is the embedding vector for the given query string.
-
-`num_of_dimensions` is a metadata property that denotes the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector` is a metadata property that denotes if embedding vectors obtained via this class are unit vectors.
-
-The following code block shows an example of how to use `VertexAIEmbeddingEncoder`. You will see the updated elements list (with the `embeddings` attribute included for each element), the embedding vector for the query string, and some metadata properties about the embedding model.
-
-To use Vertex AI PaLM tou will need to: - either, pass the full json content of your GCP VertexAI application credentials to the VertexAIEmbeddingConfig as the api\_key parameter. (This will create a file in the `/tmp` directory with the content of the json, and set the GOOGLE\_APPLICATION\_CREDENTIALS environment variable to the **path** of the created file.) - or, you’ll need to store the path to a manually created service account JSON file as the GOOGLE\_APPLICATION\_CREDENTIALS environment variable. (For more information: [https://python.langchain.com/docs/integrations/text\_embedding/google\_vertex\_ai\_palm](https://python.langchain.com/docs/integrations/text_embedding/google_vertex_ai_palm)) - or, you’ll need to have the credentials configured for your environment (gcloud, workload identity, etc…)
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.vertexai import VertexAIEmbeddingConfig, VertexAIEmbeddingEncoder
-
-embedding_encoder = VertexAIEmbeddingEncoder(
-    config=VertexAIEmbeddingConfig(api_key=os.environ["VERTEXAI_GCP_APP_CREDS_JSON_CONTENT"])
-)
-elements = embedding_encoder.embed_documents(
-    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
-)
-
-query = "This is the query"
-query_embedding = embedding_encoder.embed_query(query=query)
-
-[print(e.embeddings, e) for e in elements]
-print(query_embedding, query)
-print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())
-
-```
-
-
-## `VoyageAIEmbeddingEncoder`
-
-The `VoyageAIEmbeddingEncoder` class connects to the VoyageAI to obtain embeddings for pieces of text.
-
-`embed_documents` will receive a list of Elements, and return an updated list which includes the `embeddings` attribute for each Element.
-
-`embed_query` will receive a query as a string, and return a list of floats which is the embedding vector for the given query string.
-
-`num_of_dimensions` is a metadata property that denotes the number of dimensions in any embedding vector obtained via this class.
-
-`is_unit_vector` is a metadata property that denotes if embedding vectors obtained via this class are unit vectors.
-
-The following code block shows an example of how to use `VoyageAIEmbeddingEncoder`. You will see the updated elements list (with the `embeddings` attribute included for each element), the embedding vector for the query string, and some metadata properties about the embedding model.
-
-To use Voyage AI you will need to pass Voyage AI API Key (obtained from [https://dash.voyageai.com/](https://dash.voyageai.com/)) as the `api_key` parameter.
-
-The `model_name` parameter is mandatory, please check the available models at [https://docs.voyageai.com/docs/embeddings](https://docs.voyageai.com/docs/embeddings)
-
-```python
-import os
-
-from unstructured.documents.elements import Text
-from unstructured.embed.voyageai import VoyageAIEmbeddingConfig, VoyageAIEmbeddingEncoder
-
-embedding_encoder = VoyageAIEmbeddingEncoder(
-    config=VoyageAIEmbeddingConfig(
-        api_key=os.environ["VOYAGE_API_KEY"],
-        model_name="voyage-law-2"
+The Unstructured open-source library does not offer built-in support for calling embedding providers to obtain embeddings for pieces of text.
+
+Alternatively, the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) and the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) 
+offer built-in support for calling embedding providers as part of an ingest pipeline. [Learn how](/api-reference/how-to/embedding).
+
+Also, you can use common third-party tools and libraries to get embeddings for document elements' text within JSON files that are 
+produced by calling the Unstructured open-source library. For example, the following sample Python script:
+
+1. Takes an Unstructured open-source library-generated JSON file as input.
+2. Reads in the JSON file's contents as a JSON object.
+2. Uses the [sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) 
+   model on Hugging Face to generate embeddings for each `text` field of each document element in the JSON file. 
+3. Adds the generated embeddings next to each corresponding `text` field in the original JSON.
+4. Saves the results back to the original JSON file.
+
+```python Python
+# Filename: embeddings.py
+# pip install langchain sentence_transformers
+
+import sys
+import json
+from langchain_huggingface.embeddings import HuggingFaceEmbeddings
+
+if __name__ == "__main__":
+    embeddings = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-MiniLM-L6-v2"
     )
-)
-elements = embedding_encoder.embed_documents(
-    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
-)
+    
+    # Get the JSON file's path.
+    if len(sys.argv) < 2:
+        print("Error: Specify the path to the input JSON file.")
+        print("For example, 'python embeddings.py myfile.json'")
+        sys.exit(1)
 
-query = "This is the query"
-query_embedding = embedding_encoder.embed_query(query=query)
+    file_path = sys.argv[1]
+    
+    try:
+        # Get the JSON file's contents.
+        with open(file_path, 'r') as file:
+            file_elements = json.load(file)
 
-[print(e, e.embeddings) for e in elements]
-print(query, query_embedding)
-print(embedding_encoder.is_unit_vector, embedding_encoder.num_of_dimensions)
+        # Process each element in the JSON file.
+        for element in file_elements:
+            # Get the element's "text" field.
+            text = element["text"]
+            # Generate the embeddings for that "text" field.
+            query_result = embeddings.embed_query(text)
+            # Add the embeddings to that element as an "embeddings" field.
+            element["embeddings"] = query_result
 
+        # Save the updated JSON back into the original file.
+        with open(file_path, 'w') as file:
+            json.dump(file_elements, file, indent=2)
+
+        print(f"Done! Updated JSON saved to '{file_path}'.")
+
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.")
+    except IOError:
+        print(f"Error: Unable to access file '{file_path}'.")
 ```
+
+[Learn more](https://python.langchain.com/v0.2/docs/integrations/text_embedding/huggingfacehub/).

--- a/open-source/introduction/overview.mdx
+++ b/open-source/introduction/overview.mdx
@@ -29,9 +29,7 @@ and use cases.
     *   [Staging](/open-source/core-functionality/staging): Staging functions help prepare your data for ingestion into downstream systems. Please note that this functionality is being deprecated in favor of `Destination Connectors`.
         
     *   [Chunking](/open-source/core-functionality/chunking): The chunking process in Unstructured is distinct from conventional methods. Instead of relying solely on text-based features to form chunks, Unstructured uses a deep understanding of document formats to partition documents into semantic units (document elements).
-        
-    *   [Embedding](/open-source/core-functionality/embedding): The embedding encoder classes in Unstructured leverage document elements detected through partitioning or grouped via chunking to obtain embeddings for each element. This is particularly useful for applications like Retrieval Augmented Generation (RAG), where precise and contextually relevant embeddings are crucial.
-        
+                
 *   **High-performant Connectors**: The platform includes optimized connectors for efficient data ingestion and output. These comprise [Source Connectors](../ingest/source-connectors/overview) for data input and [Destination Connectors](../ingest/destination-connectors/overview) for data export.
     
 


### PR DESCRIPTION
As such, I updated the embedding page in the Unstructured open-source library docs to indicate that this built-in functionality is no longer available. I also point to alternatives such as the Unstructured Ingest CLI and Ingest Python library, as well as provide an example Python script I wrote and successfully tested that calls Hugging Face to generate and add embeddings to an existing JSON file that is generated by calling the Unstructured open-source library.

See https://unstructured-53-embeddings-2024-09-12.mintlify.app/open-source/core-functionality/embedding