### PR TITLE
Elasticsearch connectors: how-to video links

### DIFF
--- a/snippets/general-shared-text/elasticsearch.mdx
+++ b/snippets/general-shared-text/elasticsearch.mdx
@@ -1,7 +1,41 @@
 The Elasticsearch prerequisites:
 
-- An Elasticsearch instance, such as an [Elastic Cloud](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#hosted-elasticsearch-service) service instance, or a [self-managed Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#elasticsearch-deployment-options) instance.
+- An Elasticsearch instance, such as an [Elastic Cloud](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#hosted-elasticsearch-service) service instance...
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/-bmVLeEti1Q"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
+  ...or a [self-managed Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#elasticsearch-deployment-options) instance.
+  
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/9znbAkNG1Ok"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The name of the index on the instance. See [Create index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html) and [Get index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-index.html).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/0f0tEcrvP8g"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - If you're connecting to an Elastic Cloud instance, the Cloud ID and API key. To get these, see your Elasticsearch Service web console.
 - If you're connecting to a self-managed instance, the instance's hostname and port number. See [Networking](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html).
 - If you're using basic authentication to the instance, the user's name and password.


### PR DESCRIPTION
Same video links on all of these pages. See:

Platform:

- Source: https://unstructured-53-docs-61-elasticsearch.mintlify.app/platform/platform-source-connectors/elasticsearch
- Destination: https://unstructured-53-docs-61-elasticsearch.mintlify.app/platform/platform-destination-connectors/elasticsearch

API:

- Source: https://unstructured-53-docs-61-elasticsearch.mintlify.app/api-reference/ingest/source-connectors/elastic-search
- Destination: https://unstructured-53-docs-61-elasticsearch.mintlify.app/api-reference/ingest/destination-connector/elasticsearch

Open source:

- Source: https://unstructured-53-docs-61-elasticsearch.mintlify.app/open-source/ingest/source-connectors/elastic-search
- Destination: https://unstructured-53-docs-61-elasticsearch.mintlify.app/open-source/ingest/destination-connectors/elasticsearch