### PR TITLE
Change 'use Ingest instead' recommendation from caution to informative note

### DIFF
--- a/snippets/general-shared-text/use-ingest-instead.mdx
+++ b/snippets/general-shared-text/use-ingest-instead.mdx
@@ -1,7 +1,9 @@
-<Warning>
+<Info>
     Unstructured recommends that you use the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli) or the 
-    [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) instead. 
+    [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) if any of the following apply 
+    to you:
     
-    The Ingest CLI and Ingest Python library provide faster processing of larger individual files, 
-    and faster and easier processing of multiple files at a time in batches.
-</Warning>
+    - You need to work with documents in cloud storage.
+    - You want faster processing of larger individual files.
+    - You want to process multiple files in batches.
+</Info>


### PR DESCRIPTION
See for instance:

- https://unstructured-53-use-ingest-2024-09-13.mintlify.app/api-reference/api-services/accessing-unstructured-api
- https://unstructured-53-use-ingest-2024-09-13.mintlify.app/api-reference/api-services/sdk-python
- https://unstructured-53-use-ingest-2024-09-13.mintlify.app/api-reference/api-services/sdk-jsts
- https://unstructured-53-use-ingest-2024-09-13.mintlify.app/api-reference/api-services/post-requests
- https://unstructured-53-use-ingest-2024-09-13.mintlify.app/api-reference/api-services/partition-via-api

(Prompted by https://github.com/Unstructured-IO/unstructured-python-client/issues/171) 