### PR TITLE
Notebooks page reorganized

### DIFF
--- a/examplecode/notebooks.mdx
+++ b/examplecode/notebooks.mdx
@@ -21,28 +21,9 @@ description: "Notebooks contain complete working sample code for end to end solu
        ``Unstructured``
     <br/>
     </Card>
-    <Card title="Simple PDF and HTML parsing" href="https://colab.research.google.com/drive/1U8VCjY2-x8c6y5TYMbSFtQGlQVFHCVIW#scrollTo=jZp37lfueaeZ">
-    <br/>
-       Quickstart guide for parsing simple PDF and HTML documents with Unstructured.
-       <br/>
-       ``Unstructured``
-    <br/>
-    </Card>
-    <Card title="Llama 3 Local RAG with emails" href="https://colab.research.google.com/drive/1ieDJ4LoxARrHFqxXWif8Lv8e8aZTgmtH?usp=sharing">
-    <br/>
-       Build a local RAG app for your emails with Unstructured, LangChain and Ollama.
-    <br/>
-    ```Unstructured``` ```LangChain``` ```Ollama``` ```Llama 3```
-    </Card>
     <Card title="RAG with PDFs, LangChain and Llama 3" href="https://colab.research.google.com/drive/1BJYYyrPVe0_9EGyXqeNyzmVZDrCRZwsg?usp=sharing">
     <br/>
         A RAG system with the Llama 3 model from Hugging Face. 
-    <br/>
-    ```Unstructured```  ```🤗 Hugging Face``` ```LangChain``` ```Llama 3``` 
-    </Card>
-    <Card title="Building RAG With PowerPoint presentations" href="https://colab.research.google.com/drive/1NmLSmUMb9ozlELnWa3J4WwdrBfGomwPk?usp=sharing">
-    <br/>
-        A RAG solution that is based on PowerPoint files.
     <br/>
     ```Unstructured```  ```🤗 Hugging Face``` ```LangChain``` ```Llama 3``` 
     </Card>
@@ -51,26 +32,6 @@ description: "Notebooks contain complete working sample code for end to end solu
         Learn to ingest, partition, chunk, embed and load data from an S3 bucket into SingleStore DB.
     <br/>
     ```Unstructured```  ```SingleStoreDB``` ```AWS S3```
-    </Card>
-    <Card title="LLM chatbot with Databricks" href="https://notebooks.databricks.com/demos/llm-rag-chatbot/index.html#">
-    <br/>
-        A Chatbot on Databricks with RAG, DBRX Instruct & Vector Search
-    <br/>
-    ```Unstructured``` ```Databricks``` ```LangChain``` 
-    </Card>
-    <Card title="Synthetic test dataset generation" href="https://colab.research.google.com/drive/1VvOauC46xXeZrhh8nlTyv77yvoroMQjr?usp=sharing">
-    <br/>
-       Build a Synthetic Test Dataset for your RAG system in 5 easy steps
-    <br/>
-       ``Unstructured`` ``GPT-4o`` ``Ragas`` ``LangChain``
-    <br/>
-    </Card>
-    <Card title="LLama3.1 RAG evaluation on unstructured text" href="https://colab.research.google.com/drive/1VeK-z8499WV_7wY4JAkWmxpxR2LiR2-m?usp=sharing">
-    <br/>
-       Build a Synthetic Test Dataset for your RAG system in 5 easy steps
-    <br/>
-       ``Unstructured`` ``GPT-4o`` ``Ragas`` ``LangChain`` ``Llama3.1``
-    <br/>
     </Card>
     <Card title="Google Drive to DataStax Astra DB" href="https://colab.research.google.com/drive/1Img_qGCTKavImbz7dlRtxg8mNUjiWjJT?usp=sharing">
     <br/>
@@ -112,6 +73,32 @@ description: "Notebooks contain complete working sample code for end to end solu
         Send a PDF to Unstructured for processing, and send a subset of the returned PDF's processed text to [HuggingChat](https://huggingface.co/chat/) for chatbot-style querying.
     <br/>
     ```Unstructured```  ```🤗 Hugging Face``` ```🤗 HuggingChat```
+    </Card>
+        <Card title="Llama 3 Local RAG with emails" href="https://colab.research.google.com/drive/1ieDJ4LoxARrHFqxXWif8Lv8e8aZTgmtH?usp=sharing">
+    <br/>
+       Build a local RAG app for your emails with Unstructured, LangChain and Ollama.
+    <br/>
+    ```Unstructured``` ```LangChain``` ```Ollama``` ```Llama 3```
+    </Card>
+    <Card title="Building RAG With PowerPoint presentations" href="https://colab.research.google.com/drive/1NmLSmUMb9ozlELnWa3J4WwdrBfGomwPk?usp=sharing">
+    <br/>
+        A RAG solution that is based on PowerPoint files.
+    <br/>
+    ```Unstructured```  ```🤗 Hugging Face``` ```LangChain``` ```Llama 3```
+    </Card>
+    <Card title="Synthetic test dataset generation" href="https://colab.research.google.com/drive/1VvOauC46xXeZrhh8nlTyv77yvoroMQjr?usp=sharing">
+    <br/>
+       Build a Synthetic Test Dataset for your RAG system in 5 easy steps
+    <br/>
+       ``Unstructured`` ``GPT-4o`` ``Ragas`` ``LangChain``
+    <br/>
+    </Card>
+    <Card title="LLama3.1 RAG evaluation on unstructured text" href="https://colab.research.google.com/drive/1VeK-z8499WV_7wY4JAkWmxpxR2LiR2-m?usp=sharing">
+    <br/>
+       Build a Synthetic Test Dataset for your RAG system in 5 easy steps
+    <br/>
+       ``Unstructured`` ``GPT-4o`` ``Ragas`` ``LangChain`` ``Llama3.1``
+    <br/>
     </Card>
 </CardGroup>
 


### PR DESCRIPTION
1) Removed the quick start guide as it’s too old. 
2) Removed the databricks notebook - it’s old and we can’t fix it (external)
3) Moved notebooks that have not yet been updated to ingest v2 to the bottom of the page. 

