### PR TITLE
PII notebook

### DIFF
--- a/examplecode/notebooks.mdx
+++ b/examplecode/notebooks.mdx
@@ -2,11 +2,18 @@
 title: Notebooks
 sidebarTitle: Notebooks
 mode: wide
-description: "Notebooks contain complete working sample code for end to end solutions."
+description: "Notebooks contain complete working sample code for end-to-end solutions."
 ---
 
 <CardGroup cols={2}>
 
+    <Card title="PII removal with GLiNER in unstructured data ETL" href="https://colab.research.google.com/drive/1HwOMnGjrNbcHZ1vlhaAG0MSDBcwQfexF?usp=sharing">
+    <br/>
+       Remove Personally Identifiable Information (PII) as a part of unstructured data preprocessing.
+       <br/>
+       ``Unstructured`` ``Advanced`` ``PII`` ``GLiNER``
+    <br/>
+    </Card>
     <Card title="Custom metadata extraction and self-querying retrieval" href="https://colab.research.google.com/drive/1v2SKPEmCr0p2AFyckrYvC3heYKyKff_t?usp=sharing">
     <br/>
        Extract custom metadata, and enable metadata pre-filtering in your RAG.


### PR DESCRIPTION
The PR adds a new notebook example to the docs: PII removal as a part of unstructured ETL pipeline. 