### PR TITLE
[Hold] Databricks volume - update auth

### DIFF
--- a/snippets/general-shared-text/databricks-volumes-platform.mdx
+++ b/snippets/general-shared-text/databricks-volumes-platform.mdx
@@ -18,8 +18,8 @@ Also fill in the following fields based on your authentication type, depending o
 
 - For OAuth machine-to-machine (M2M) authentication (AWS, Azure, and GCP):
 
-  - **Client ID** : The Databricks username value.
-  - **Client Secret** : The associated Databricks password value.
+  - **Client ID** : The Databricks client ID value for the corresponding service principal.
+  - **Client Secret** : The associated Databricks service principal OAuth secret.
 
 The following authentication types are currently not supported:
 

--- a/snippets/general-shared-text/databricks-volumes-platform.mdx
+++ b/snippets/general-shared-text/databricks-volumes-platform.mdx
@@ -16,14 +16,14 @@ Also fill in the following fields based on your authentication type, depending o
 
   - **Token** : The Databricks personal access token value.
 
-- For username and password (basic) authentication (AWS only):
+- For OAuth machine-to-machine (M2M) authentication (AWS, Azure, and GCP):
 
-  - **Username** : The Databricks username value.
-  - **Password** : The associated Databricks password value.
+  - **Client ID** : The Databricks username value.
+  - **Client Secret** : The associated Databricks password value.
 
 The following authentication types are currently not supported:
 
-- OAuth machine-to-machine (M2M) authentication (AWS, Azure, and GCP).
+- Username and password (basic) authentication (AWS only).
 - OAuth user-to-machine (U2M) authentication (AWS, Azure, and GCP).
 - Azure managed identities (MSI) authentication (Azure only).
 - Microsoft Entra ID service principal authentication (Azure only).


### PR DESCRIPTION
Changes:
- Removed basic auth. 
- Added client id/secret auth method.

Not sure if `- For username and password (basic) authentication (AWS only): The user's name and password values.` shouldn't be also noted as not working in `snippets/general-shared-text/databricks-volumes.mdx`

See also https://github.com/Unstructured-IO/docs/pull/269