### PR TITLE
remove incorrect info from partition_image description

### DIFF
--- a/open-source/core-functionality/partitioning.mdx
+++ b/open-source/core-functionality/partitioning.mdx
@@ -302,7 +302,7 @@ For more information about the `partition_html` function, you can check the [sou
 
 ## `partition_image`
 
-The `partition_image` function has the same API as `partition_pdf`, which is document above. The only difference is that `partition_image` does not need to convert a PDF to an image prior to processing. The `partition_image` function supports `.png`, `.heic`, and `.jpg` files.
+The `partition_image` function has the same API as `partition_pdf`. The only difference is that `partition_image` does not need to convert a PDF to an image prior to processing. The `partition_image` function supports `.png`, `.heic`, and `.jpg` files.
 
 You can also specify what languages to use for OCR with the `languages` kwarg. For example, use `languages=["eng", "deu"]` to use the English and German language packs. See the [Tesseract documentation](https://github.com/tesseract-ocr/tessdata) for a full list of languages and install instructions.
 


### PR DESCRIPTION
The docs refer to the partition method "above" as if it were `partition_pdf`, but it's not