### PR TITLE
Add a warning to marketplace pages about cost prevention

### DIFF
--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -3,7 +3,7 @@ title: Unstructured API on AWS
 description: Follow these steps to deploy the Unstructured API service into your AWS account.
 ---
 
-<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to shut down the virtual machine when not in use.</Warning>
+<Warning>This article describes how to create several interrelated resources in your AWS account. Your AWS account will be charged on an ongoing basis for these resources, even if you are not actively using them. To stop accruing charges you must delete all of these resources. To do this, see [Manage related AWS account costs](#manage-related-aws-account-costs).</Warning>
 
 _Estimated time to complete: 30 minutes_
 

--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -3,6 +3,8 @@ title: Unstructured API on AWS
 description: Follow these steps to deploy the Unstructured API service into your AWS account.
 ---
 
+<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to shut down the virtual machine when not in use.</Warning>
+
 _Estimated time to complete: 30 minutes_
 
 You will need:

--- a/api-reference/api-services/azure.mdx
+++ b/api-reference/api-services/azure.mdx
@@ -4,6 +4,8 @@ title: Unstructured API on Azure
 
 Follow these steps to deploy the Unstructured API service into your Azure account.
 
+<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to shut down the virtual machine when not in use.</Warning>
+
 <Steps>
     <Step title=" Log in to the Azure Portal">
         Go to [https://portal.azure.com](https://portal.azure.com/).


### PR DESCRIPTION
It's not immediately clear that these deployments will spin up a VM which needs to be managed by the user. To prevent a surprise bill, you need to shut down the VM when the API is not in use.