### PR TITLE
Remove langchain- from embedding provider programmatic IDs

### DIFF
--- a/snippets/destination_connectors/postgresql.v2.py.mdx
+++ b/snippets/destination_connectors/postgresql.v2.py.mdx
@@ -53,7 +53,7 @@ if __name__ == "__main__":
             }
         ),
         chunker_config=ChunkerConfig(chunking_strategy="by_title"),
-        embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
+        embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         destination_connection_config=PostgresConnectionConfig(
             access_config=PostgresAccessConfig(password=os.getenv("PGPASSWORD")),
             host=os.getenv("PGHOST"),

--- a/snippets/destination_connectors/sqlite.v2.py.mdx
+++ b/snippets/destination_connectors/sqlite.v2.py.mdx
@@ -53,7 +53,7 @@ if __name__ == "__main__":
             }
         ),
         chunker_config=ChunkerConfig(chunking_strategy="by_title"),
-        embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
+        embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         destination_connection_config=SQLiteConnectionConfig(
             access_config=SQLiteAccessConfig(),
             database_path=os.getenv("SQLITE_DB_PATH")


### PR DESCRIPTION
There were a few stray mentions to fix here.