### PR TITLE
Add third-party embed-linked how-to videos for Airtable, Couchbase, and Snowflake

### DIFF
--- a/snippets/general-shared-text/airtable.mdx
+++ b/snippets/general-shared-text/airtable.mdx
@@ -2,7 +2,29 @@ The Airtable connector prerequisites:
 
 - An [Airtable](https://www.airtable.com/) account. [Create a free Airtable account](https://airtable.com/signup). 
 - An Airtable personal access token. [Create a personal access token](https://support.airtable.com/docs/creating-and-using-api-keys-and-access-tokens).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/c3gvIWAAcTY"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The ID of the Airtable base to access. [Create a base](https://www.airtable.com/guides/build/create-a-base). [Get a base's ID](https://support.airtable.com/docs/finding-airtable-ids#finding-base-url-ids).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/rU347YVMm2M"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The ID of the table to access in the base. [Create a table](https://www.airtable.com/guides/build/create-a-table). [Get a table's ID](https://support.airtable.com/docs/finding-airtable-ids#finding-base-url-ids).
 - The ID of the view to access in the table. [Create a view](https://www.airtable.com/guides/build/create-custom-views-of-data). [Get a view's ID](https://support.airtable.com/docs/finding-airtable-ids#finding-base-url-ids).
 

--- a/snippets/general-shared-text/couchbase.mdx
+++ b/snippets/general-shared-text/couchbase.mdx
@@ -3,12 +3,76 @@ The Couchbase database prerequisites for a Couchbase Capella deployment, or a lo
 For Couchbase Capella deployment:
 
 - A Couchbase Capella account. [Create an account](https://docs.couchbase.com/cloud/get-started/create-account.html).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/Henkxjmx9Ro?start=1008&end=1078"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+  
 - A Couchbase Capella cluster. [Create a cluster](https://docs.couchbase.com/cloud/clusters/create-database.html).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/46715VbaHvk?start=50&end=121"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - Bucket, Scopes and Collection [Data Tools](https://docs.couchbase.com/cloud/clusters/data-service/about-buckets-scopes-collections.html).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/46715VbaHvk?start=120&end=200"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+  
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/46715VbaHvk?start=290&end=319"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+  
 - Get cluster connection string and connect. [Learn how](https://docs.couchbase.com/cloud/get-started/connect.html).
 - Configure the cluster to use your IP address. [Learn how](https://docs.couchbase.com/cloud/clusters/allow-ip-address.html).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/46715VbaHvk?start=320&end=350"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+  
 - Configure the database credentials. [Learn how](https://docs.couchbase.com/cloud/clusters/manage-database-users.html).
 
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/46715VbaHvk?start=350&end=381"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+  
 For a local Couchbase server:
 
 - Installation of a local Couchbase server. [Learn how](https://docs.couchbase.com/server/current/getting-started/start-here.html).

--- a/snippets/general-shared-text/snowflake.mdx
+++ b/snippets/general-shared-text/snowflake.mdx
@@ -1,8 +1,62 @@
 The Snowflake prerequisites:
 
 - A Snowflake [account](https://signup.snowflake.com/) and its [identifier](https://docs.snowflake.com/user-guide/admin-account-identifier).
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/1ccJgiZRSTg"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The Snowflake [username and its password](https://docs.snowflake.com/user-guide/admin-user-management#creating-users) in the account.
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/5hPrJNEa4aA?start=64&end=267"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The Snowflake [hostname and its port number](https://docs.snowflake.com/sql-reference/functions/system_allowlist) in the account.
 - The name of the Snowflake [database](https://docs.snowflake.com/sql-reference/sql/create-database) in the account.
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/KrXCgpsRd0A"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The name of the [schema](https://docs.snowflake.com/sql-reference/sql/create-schema) in the database.
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/4SoS_c6rT_U?start=97&end=157"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
+
 - The name of the [table](https://docs.snowflake.com/sql-reference/sql/create-table) in the schema.
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/ZaZzqFMGe1g?end=169"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>


### PR DESCRIPTION
See:

- Airtable: i.e. https://unstructured-53-video-embed-links-2024-10-25.mintlify.app/api-reference/ingest/source-connectors/airtable
- Couchbase: i.e. https://unstructured-53-video-embed-links-2024-10-25.mintlify.app/api-reference/ingest/source-connectors/couchbase
- Snowflake: i.e. https://unstructured-53-video-embed-links-2024-10-25.mintlify.app/api-reference/ingest/source-connectors/snowflake