### PR TITLE
Marketplace offerings: add links to shutdown how-to articles

### DIFF
--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -3,7 +3,13 @@ title: Unstructured API on AWS
 description: Follow these steps to deploy the Unstructured API service into your AWS account.
 ---
 
-<Warning>This article describes how to create several interrelated resources in your AWS account. Your AWS account will be charged on an ongoing basis for these resources, even if you are not actively using them. To stop accruing charges you must delete all of these resources. To do this, see [Manage related AWS account costs](#manage-related-aws-account-costs).</Warning>
+<Warning>
+    This article describes how to create several interrelated resources in your AWS account. Your AWS account will be charged on an ongoing basis for these resources, even if you are not actively using them.<br/><br/>
+    To control some (but not all) of the related ongoing charges to your AWS account, you should stop any associated Amazon EC2 instances whenever you are not using them. 
+    You can [manually stop an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html), or you can for example 
+    [create a CloudWatch alarm to stop an instance](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/UsingAlarmActions.html).<br/><br/>
+    To stop accruing all related ongoing charges, you must delete all of these resources. To do this, see [Manage related AWS account costs](#manage-related-aws-account-costs).
+</Warning>
 
 _Estimated time to complete: 30 minutes_
 

--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -4,11 +4,11 @@ description: Follow these steps to deploy the Unstructured API service into your
 ---
 
 <Warning>
-    This article describes how to create several interrelated resources in your AWS account. Your AWS account will be charged on an ongoing basis for these resources, even if you are not actively using them.<br/><br/>
-    To control some (but not all) of the related ongoing charges to your AWS account, you should stop any associated Amazon EC2 instances whenever you are not using them. 
-    You can [manually stop an instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html), or you can for example 
-    [create a CloudWatch alarm to stop an instance](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/UsingAlarmActions.html).<br/><br/>
-    To stop accruing all related ongoing charges, you must delete all of these resources. To do this, see [Manage related AWS account costs](#manage-related-aws-account-costs).
+    This article describes how to create several interrelated resources in your AWS account. 
+    Your AWS account will be charged on an ongoing basis for these resources, even if you are not actively using them.<br/><br/>
+    Manually stopping or terminating the associated Amazon EC2 instance alone will not reduce these ongoing charges.<br/><br/>
+    To stop accruing all related ongoing charges, you must delete all of the associated AWS resources. 
+    To do this, see [Manage related AWS account costs](#manage-related-aws-account-costs).
 </Warning>
 
 _Estimated time to complete: 30 minutes_
@@ -332,10 +332,10 @@ If you need to access the Amazon EC2 instance that hosts the Unstructured API, d
 
 After you run the CloudFormation stack, costs will begin accruing to your AWS account on an ongoing basis for related AWS resources. 
 These costs vary based on where these resource are located, which resources are covered by AWS Free Tier offerings, the extent to 
-which you customize these resources' settings, how much you use these resources, and other factors. Even if you stop or terminate 
-the related EC2 instance and delete the related application load balancer, costs might continue to accrue for other related AWS sources. 
+which you customize these resources' settings, how much you use these resources, and other factors. Stopping or terminating 
+the related Amazon EC2 instance alone will not reduce these costs.
 
-To stop these costs from accruing, you can delete the CloudFormation stack. This stops and deletes all of the related AWS resources. 
+To stop these costs from accruing, delete the CloudFormation stack. This stops and deletes all of the related AWS resources. 
 To delete the CloudFormation stack, do the following:
 
 1. In the CloudFormation console, open the details page for the stack from Part II. If you do not see it, on the CloudFormation console's sidebar, click **Stacks**, and then click the name of your stack.

--- a/api-reference/api-services/azure.mdx
+++ b/api-reference/api-services/azure.mdx
@@ -4,7 +4,7 @@ title: Unstructured API on Azure
 
 Follow these steps to deploy the Unstructured API service into your Azure account.
 
-<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to shut down the virtual machine when not in use.</Warning>
+<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to [shut down the virtual machine](https://learn.microsoft.com/azure/virtual-machines/auto-shutdown-vm?tabs=portal) when not in use.</Warning>
 
 <Steps>
     <Step title=" Log in to the Azure Portal">

--- a/api-reference/api-services/azure.mdx
+++ b/api-reference/api-services/azure.mdx
@@ -4,7 +4,12 @@ title: Unstructured API on Azure
 
 Follow these steps to deploy the Unstructured API service into your Azure account.
 
-<Warning>This deployment will create a virtual machine with its own instance of the Unstructured API. To avoid unexpected charges, be sure to [shut down the virtual machine](https://learn.microsoft.com/azure/virtual-machines/auto-shutdown-vm?tabs=portal) when not in use.</Warning>
+<Warning>
+    This article describes how to create several interrelated resources in your Azure account. 
+    Your Azure account will be charged on an ongoing basis for these resources, even if you are not actively using them.<br/><br/>
+    Manually shutting down the associated Azure virtual machine when you are not using it can help reduce&mdash;but not fully eliminate&mdash;these ongoing charges.<br/><br/>
+    To stop accruing all related ongoing charges, you must delete all of the associated Azure resources.
+</Warning>
 
 <Steps>
     <Step title=" Log in to the Azure Portal">


### PR DESCRIPTION
Addresses a request to add "how to shut down instances" info/links to these articles.

See the top/beginning of:

- https://unstructured-53-mktplace-mgmt-2024-10-29.mintlify.app/api-reference/api-services/aws
- https://unstructured-53-mktplace-mgmt-2024-10-29.mintlify.app/api-reference/api-services/azure

