### PR TITLE
MongoDB connectors: connection string example, how-to, and terminology

### DIFF
--- a/snippets/general-shared-text/mongodb-cli-api.mdx
+++ b/snippets/general-shared-text/mongodb-cli-api.mdx
@@ -14,7 +14,7 @@ For a MongoDB Atlas deployment, the following environment variables:
 
 - `MONGODB_COLLECTION` - The name of the collection in the database, represented by `--collection` (CLI) or `collection` (Python).
 
-- `MONGODB_URI` - The URI for the cluster, represented by `--uri` (CLI) or `uri` (Python). 
+- `MONGODB_URI` - The connection string for the cluster, represented by `--uri` (CLI) or `uri` (Python). 
 
 For a local MongoDB server, the following environment variables:
 

--- a/snippets/general-shared-text/mongodb-platform.mdx
+++ b/snippets/general-shared-text/mongodb-platform.mdx
@@ -1,6 +1,6 @@
 Fill in the following fields:
 
 - **Name** (_required_): A unique name for this connector.
-- **URI** (_required_): The MongoDB instance connection URI.
 - **Database** (_required_): The name of the database on the instance.
 - **Collection** (_required_): The name of the collection within the database.
+- **Connection String** (_required_): The MongoDB instance connection string.

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -17,4 +17,22 @@ allowfullscreen
 - The cluster must have at least one database. [Create a database](https://www.mongodb.com/docs/compass/current/databases/#create-a-database).
 - The database must have at least one user, and that user must have sufficient access to the database. [Create a database user](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users). [Give the user database access](https://www.mongodb.com/docs/manual/core/authorization/).
 - The database must have at least one collection. [Create a collection](https://www.mongodb.com/docs/compass/current/collections/#create-a-collection).
-- The URI for the cluster. This URI must include the protocol, username, password, and host. [Learn how to get this value](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).
+- The connection string for the cluster. For MongoDB Atlas, this connection string must include the protocol, username, password, host, and cluster name. For example:
+
+  ```text
+  mongodb+srv://<db_user>:<db_password>@<host>/?retryWrites=true&w=majority&appName=<cluster>
+  ```
+
+  To get the connection string in MongoDB Atlas, do the following:
+
+  1. Log in to your MongoDB Atlas console.
+  2. In the sidebar, under **Databases**, click **Clusters**.
+  3. Click on the cluster you want to connect to.
+  4. Click **Connect**, or click the **Cmd Line Tools** tab and then click **Connect Instructions**.
+  5. Click **Drivers**.
+  6. Under **Add your connection string into your application code**, copy the connection string. 
+     You can then close the **Connect** dialog in MongoDB Atlas.
+
+     Before you use this connection string, be sure to fill in any placeholders in the string, such as your MongoDB Atlas database user's password value. 
+
+  [Learn more](https://www.mongodb.com/resources/products/fundamentals/mongodb-connection-string).


### PR DESCRIPTION
Provides more clarity about what a connection string needs to look like and how to get one. 

Also, "URI" changed to "connection string."

See (same target content in all of these pages):

- https://unstructured-53-mongodb-connection-string-2024-11-05.mintlify.app/platform/destinations/mongodb
- https://unstructured-53-mongodb-connection-string-2024-11-05.mintlify.app/api-reference/ingest/source-connectors/mongodb
- https://unstructured-53-mongodb-connection-string-2024-11-05.mintlify.app/api-reference/ingest/destination-connector/mongodb
- https://unstructured-53-mongodb-connection-string-2024-11-05.mintlify.app/open-source/ingest/source-connectors/mongodb
- https://unstructured-53-mongodb-connection-string-2024-11-05.mintlify.app/open-source/ingest/destination-connectors/mongodb
