### PR TITLE
Langflow demo: how to work with multiple files

### DIFF
--- a/examplecode/tools/langflow.mdx
+++ b/examplecode/tools/langflow.mdx
@@ -32,14 +32,19 @@ Also:
         3. Click **Blank Flow**.
     </Step>
     <Step title="Add the Unstructured component">
-        In this step, you add a component that instructs Unstructured Serverless API services to process a local file or a local directory of files that you specify.
+        In this step, you add a component that instructs Unstructured Serverless API services to process a local file that you specify.
  
         1. On the sidebar, expand **Experimental (Beta)**, and then expand **Loaders**.
         2. Drag the **Unstructured** component onto the designer area.
-        3. In the **Unstructured** component, click the box or icon next to **File**, and then select a file or a directory of files for Unstructured to process. This component works only with the file extensions `.pdf`, `.docx`, and `.txt`.
+        3. In the **Unstructured** component, click the box or icon next to **File**, and then select a local file for Unstructured to process.
 
-           You can select any files that you want. This demonstration uses [the text of the United States Constitution in PDF format](https://constitutioncenter.org/media/files/constitution.pdf), 
+           This component works only with the file extensions `.pdf`, `.docx`, and `.txt`. Although you can use any local file with one of these extensions, 
+           this demonstration uses [the text of the United States Constitution in PDF format](https://constitutioncenter.org/media/files/constitution.pdf), 
            saved to your local development machine.
+
+           <Tip>
+               To work with multiple local files, or to work with remote files, see the suggested options in [Next steps](#next-steps).
+           </Tip>
 
         4. For **Unstructured.io Serverless API Key**, enter your Unstructured API key value.
 
@@ -92,7 +97,7 @@ Also:
     
             <Note>
                 Each time you click the play icon in the **Astra DB Ingest** component, Unstructured reprocesses the specified local 
-                file or a local directory. If neither the specified file names or directories nor the specified collection name change, this could result in multiple duplicate records 
+                file. If this file does not change, this could result in multiple duplicate records 
                 being inserted into the specified Astra DB collection. You should only click the play icon in the **Astra DB Ingest** component when you want to insert new processed data into 
                 the specified Astra DB collection.
             </Note>
@@ -202,24 +207,24 @@ Also:
 ## Next steps
 
 Now that you have your pipeline set up, here are just a few ways that you could modify it to support different requirements, 
-such as processing non-local files or using a different vector store.
+such as processing multiple files or using a different vector store.
 
-### Process non-local files
+### Process multiple files
 
-In this demonstration, you pass to Unstructured a file or a directory of files that are stored locally. To pass 
+In this demonstration, you pass to Unstructured a single local file. To pass multiple local or 
 non-local files to Unstructured instead, you can use the 
 [Unstructured Platform](/platform/overview) or 
 [Unstructured Ingest](/ingestion/overview) outside of Langflow.
 
 To do this, you can:
 
-- [Use the Unstructured Platform to create a workflow](/platform/quickstart) that relies on any available non-local 
+- [Use the Unstructured Platform to create a workflow](/platform/quickstart) that relies on any available 
   [source connector](/platform/sources/overview) to connect to 
-  [Astra DB](/platform/destinations/astradb). Run this workflow outside of Langflow anytime you have new documents in that non-local source location that 
+  [Astra DB](/platform/destinations/astradb). Run this workflow outside of Langflow anytime you have new documents in that source location that 
   you want Unstructured to process and then insert the new processed data into Astra DB. Then, back in the Langflow project, 
   use the **Playground** to ask additional questions, which will now include the new data when generating answers.
 
-- [Use Unstructured Ingest to create a pipeline](/api-reference/ingest/overview) that relies on any available non-local 
+- [Use Unstructured Ingest to create a pipeline](/api-reference/ingest/overview) that relies on any available 
   [source connector](/api-reference/ingest/source-connectors/overview) to connect to 
   [Astra DB](/api-reference/ingest/destination-connector/astradb). Run this pipeline outside of Langflow anytime you have new documents in that non-local source location that 
   you want Unstructured to process and then insert the new processed data into Astra DB. Then, back in the Langflow project, 


### PR DESCRIPTION
The Langflow demo mistakenly states that you can feed multiple local files into the **Unstructured** component in Langflow. You cannot. This PR corrects this statement.

See https://unstructured-53-langflow-single-file-2024-11-06.mintlify.app/examplecode/tools/langflow