### PR TITLE
Connector requirements grammar clean up

### DIFF
--- a/api-reference/api-services/aws.mdx
+++ b/api-reference/api-services/aws.mdx
@@ -13,7 +13,7 @@ description: Follow these steps to deploy the Unstructured API service into your
 
 _Estimated time to complete: 30 minutes_
 
-You will need:
+The requirements are as follows.
 
 1.  **An AWS account**: 
 

--- a/platform/destinations/astradb.mdx
+++ b/platform/destinations/astradb.mdx
@@ -4,7 +4,7 @@ title: Astra DB
 
 Send processed data from Unstructured to Astra DB.
 
-You'll need:
+The requirements are as follows.
 
 import AstraDBPrerequisites from '/snippets/general-shared-text/astradb.mdx';
 

--- a/platform/destinations/azure-ai-search.mdx
+++ b/platform/destinations/azure-ai-search.mdx
@@ -4,7 +4,7 @@ title: Azure AI Search
 
 Send processed data from Unstructured to Azure AI Search.
 
-You'll need:
+The requirements are as follows.
 
 import AzureAISPrerequisites from '/snippets/general-shared-text/azure-ai-search.mdx';
 

--- a/platform/destinations/chroma.mdx
+++ b/platform/destinations/chroma.mdx
@@ -4,7 +4,7 @@ title: Chroma
 
 Send processed data from Unstructured to Chroma.
 
-You'll need:
+The requirements are as follows.
 
 import ChromaPrerequisites from '/snippets/general-shared-text/chroma.mdx';
 

--- a/platform/destinations/couchbase.mdx
+++ b/platform/destinations/couchbase.mdx
@@ -4,7 +4,7 @@ title: Couchbase
 
 Send processed data from Unstructured to Couchbase.
 
-You'll need:
+The requirements are as follows.
 
 import CouchbasePrerequisites from '/snippets/general-shared-text/couchbase.mdx';
 

--- a/platform/destinations/databricks-volumes.mdx
+++ b/platform/destinations/databricks-volumes.mdx
@@ -4,7 +4,7 @@ title: Databricks Volumes
 
 Send processed data from Unstructured to Databricks Volumes.
 
-You'll need:
+The requirements are as follows.
 
 import DatabricksVolumesPrerequisites from '/snippets/general-shared-text/databricks-volumes.mdx';
 

--- a/platform/destinations/delta-table.mdx
+++ b/platform/destinations/delta-table.mdx
@@ -4,7 +4,7 @@ title: Delta Table
 
 Send processed data from Unstructured to a Delta Table, stored in Amazon S3.
 
-You'll need:
+The requirements are as follows.
 
 import DeltaTablePrerequisites from '/snippets/general-shared-text/delta-table.mdx';
 

--- a/platform/destinations/elasticsearch.mdx
+++ b/platform/destinations/elasticsearch.mdx
@@ -4,7 +4,7 @@ title: Elasticsearch
 
 Send processed data from Unstructured to Elasticsearch.
 
-You'll need:
+The requirements are as follows.
 
 import ElasticsearchPrerequisites from '/snippets/general-shared-text/elasticsearch.mdx';
 

--- a/platform/destinations/google-cloud.mdx
+++ b/platform/destinations/google-cloud.mdx
@@ -4,7 +4,7 @@ title: Google Cloud Storage
 
 Send processed data from Unstructured to Google Cloud Storage.
 
-You'll need:
+The requirements are as follows.
 
 import GCSPrerequisites from '/snippets/general-shared-text/gcs.mdx';
 

--- a/platform/destinations/milvus.mdx
+++ b/platform/destinations/milvus.mdx
@@ -4,17 +4,7 @@ title: Milvus
 
 Send processed data from Unstructured to Milvus.
 
-The following video shows how to fulfill the minimum set of Milvus prerequisites, demonstrating Milvus on IBM watsonx.data.
-
-<iframe
-width="560"
-height="315"
-src="https://www.youtube.com/embed/tl9eV-_nAHI"
-title="YouTube video player"
-frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-allowfullscreen
-></iframe>
+The requirements are as follows.
 
 import MilvusPrerequisites from '/snippets/general-shared-text/milvus.mdx';
 

--- a/platform/destinations/mongodb.mdx
+++ b/platform/destinations/mongodb.mdx
@@ -4,7 +4,7 @@ title: MongoDB
 
 Send processed data from Unstructured to MongoDB.
 
-You'll need:
+The requirements are as follows.
 
 import MongoDBPrerequisites from '/snippets/general-shared-text/mongodb.mdx';
 

--- a/platform/destinations/onedrive.mdx
+++ b/platform/destinations/onedrive.mdx
@@ -4,7 +4,7 @@ title: OneDrive
 
 Send processed data from Unstructured to OneDrive.
 
-You'll need:
+The requirements are as follows.
 
 import OneDrivePrerequisites from '/snippets/general-shared-text/onedrive.mdx';
 

--- a/platform/destinations/opensearch.mdx
+++ b/platform/destinations/opensearch.mdx
@@ -4,7 +4,7 @@ title: OpenSearch
 
 Send processed data from Unstructured to OpenSearch.
 
-You'll need:
+The requirements are as follows.
 
 import OpenSearchPrerequisites from '/snippets/general-shared-text/opensearch.mdx';
 

--- a/platform/destinations/pinecone.mdx
+++ b/platform/destinations/pinecone.mdx
@@ -4,7 +4,7 @@ title: Pinecone
 
 Send processed data from Unstructured to Pinecone.
 
-The following video shows how to fulfill the minimum set of Pinecone prerequisites:
+The following video shows how to fulfill the minimum set of Pinecone requirements:
 
 <iframe
 width="560"
@@ -16,7 +16,7 @@ allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; pic
 allowfullscreen
 ></iframe>
 
-Here are some more details about the prerequisites:
+Here are some more details about the requirements:
 
 import PineconePrerequisites from '/snippets/general-shared-text/pinecone.mdx';
 

--- a/platform/destinations/s3.mdx
+++ b/platform/destinations/s3.mdx
@@ -4,7 +4,7 @@ title: S3
 
 Send processed data from Unstructured to Amazon S3.
 
-You'll need:
+The requirements are as follows.
 
 import S3Prerequisites from '/snippets/general-shared-text/s3.mdx';
 

--- a/platform/destinations/weaviate.mdx
+++ b/platform/destinations/weaviate.mdx
@@ -4,7 +4,7 @@ title: Weaviate
 
 Send processed data from Unstructured to Weaviate.
 
-You'll need:
+The requirements are as follows.
 
 import WeaviatePrerequisites from '/snippets/general-shared-text/weaviate.mdx';
 

--- a/platform/sources/azure-blob-storage.mdx
+++ b/platform/sources/azure-blob-storage.mdx
@@ -4,7 +4,7 @@ title: Azure
 
 Ingest your files into Unstructured from Azure Blob Storage.
 
-You'll need:
+The requirements are as follows.
 
 import AzurePrerequisites from '/snippets/general-shared-text/azure.mdx';
 

--- a/platform/sources/confluence.mdx
+++ b/platform/sources/confluence.mdx
@@ -4,7 +4,7 @@ title: Confluence
 
 Ingest your files into Unstructured from Confluence.
 
-You'll need:
+The requirements are as follows.
 
 import ConfluencePrerequisites from '/snippets/general-shared-text/confluence.mdx';
 

--- a/platform/sources/databricks-volumes.mdx
+++ b/platform/sources/databricks-volumes.mdx
@@ -4,7 +4,7 @@ title: Databricks Volumes
 
 Ingest your files into Unstructured from Databricks Volumes.
 
-You'll need: 
+The requirements are as follows. 
 
 import DatabricksVolumesPrerequisites from '/snippets/general-shared-text/databricks-volumes.mdx';
 

--- a/platform/sources/elasticsearch.mdx
+++ b/platform/sources/elasticsearch.mdx
@@ -4,7 +4,7 @@ title: Elasticsearch
 
 Ingest your files into Unstructured from Elasticsearch.
 
-You'll need:
+The requirements are as follows.
 
 import ElasticsearchPrerequisites from '/snippets/general-shared-text/elasticsearch.mdx';
 

--- a/platform/sources/google-cloud.mdx
+++ b/platform/sources/google-cloud.mdx
@@ -4,7 +4,7 @@ title: Google Cloud Storage
 
 Ingest your files into Unstructured from Google Cloud Storage.
 
-You'll need:
+The requirements are as follows.
 
 import GCSPrerequisites from '/snippets/general-shared-text/gcs.mdx';
 

--- a/platform/sources/google-drive.mdx
+++ b/platform/sources/google-drive.mdx
@@ -4,7 +4,7 @@ title: Google Drive
 
 Ingest your files into Unstructured from Google Drive.
 
-You'll need:
+The requirements are as follows.
 
 import GoogleDrivePrerequisites from '/snippets/general-shared-text/google-drive.mdx';
 

--- a/platform/sources/mongodb.mdx
+++ b/platform/sources/mongodb.mdx
@@ -4,7 +4,7 @@ title: MongoDB
 
 Ingest your files into Unstructured from MongoDB.
 
-You'll need: 
+The requirements are as follows. 
 
 import MongoDBPrerequisites from '/snippets/general-shared-text/mongodb.mdx';
 

--- a/platform/sources/onedrive.mdx
+++ b/platform/sources/onedrive.mdx
@@ -4,7 +4,7 @@ title: OneDrive
 
 Ingest your files into Unstructured from OneDrive.
 
-You'll need:
+The requirements are as follows.
 
 import OneDrivePrerequisites from '/snippets/general-shared-text/onedrive.mdx';
 

--- a/platform/sources/opensearch.mdx
+++ b/platform/sources/opensearch.mdx
@@ -4,7 +4,7 @@ title: OpenSearch
 
 Ingest your files into Unstructured from OpenSearch.
 
-You'll need:
+The requirements are as follows.
 
 import OpenSearchPrerequisites from '/snippets/general-shared-text/opensearch.mdx';
 

--- a/platform/sources/outlook.mdx
+++ b/platform/sources/outlook.mdx
@@ -4,7 +4,7 @@ title: Outlook
 
 Ingest your files into Unstructured from Outlook.
 
-You'll need:
+The requirements are as follows.
 
 import OutlookPrerequisites from '/snippets/general-shared-text/outlook.mdx';
 

--- a/platform/sources/s3.mdx
+++ b/platform/sources/s3.mdx
@@ -4,7 +4,7 @@ title: S3
 
 Ingest your files into Unstructured from Amazon S3.
 
-You'll need: 
+The requirements are as follows. 
 
 import S3Prerequisites from '/snippets/general-shared-text/s3.mdx';
 

--- a/platform/sources/salesforce.mdx
+++ b/platform/sources/salesforce.mdx
@@ -4,7 +4,7 @@ title: Salesforce
 
 Ingest your files into Unstructured from Salesforce.
 
-You'll need: 
+The requirements are as follows. 
 
 import SalesforcePrerequisites from '/snippets/general-shared-text/salesforce.mdx';
 

--- a/platform/sources/sftp-storage.mdx
+++ b/platform/sources/sftp-storage.mdx
@@ -4,7 +4,7 @@ title: SFTP
 
 Ingest your files into Unstructured from SFTP.
 
-You'll need:
+The requirements are as follows.
 
 import SFTPPrerequisites from '/snippets/general-shared-text/sftp.mdx';
 

--- a/platform/sources/sharepoint.mdx
+++ b/platform/sources/sharepoint.mdx
@@ -4,7 +4,7 @@ title: SharePoint
 
 Ingest your files into Unstructured from SharePoint.
 
-You'll need: 
+The requirements are as follows. 
 
 import SharePointPrerequisites from '/snippets/general-shared-text/sharepoint.mdx';
 

--- a/snippets/dc-shared-text/astradb-cli-api.mdx
+++ b/snippets/dc-shared-text/astradb-cli-api.mdx
@@ -1,7 +1,7 @@
 
 Batch process all your records to store structured outputs in an Astra DB account.
 
-You will need:
+The requirements are as follows.
 
 import AstraDBShared from '/snippets/general-shared-text/astradb.mdx';
 import AstraDBSharedCLIAPI from '/snippets/general-shared-text/astradb-cli-api.mdx';

--- a/snippets/dc-shared-text/azure-ai-search-cli-api.mdx
+++ b/snippets/dc-shared-text/azure-ai-search-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in an Azure AI Search account.
 
-You will need:
+The requirements are as follows.
 
 import AzureAISShared from '/snippets/general-shared-text/azure-ai-search.mdx';
 import AzureAISSharedCLIAPI from '/snippets/general-shared-text/azure-ai-search-cli-api.mdx';

--- a/snippets/dc-shared-text/azure-cli-api.mdx
+++ b/snippets/dc-shared-text/azure-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in an Azure Storage account.
 
-You will need:
+The requirements are as follows.
 
 import SharedAzure from '/snippets/general-shared-text/azure.mdx';
 import SharedAzureCLIAPI from '/snippets/general-shared-text/azure-cli-api.mdx';

--- a/snippets/dc-shared-text/box-cli-api.mdx
+++ b/snippets/dc-shared-text/box-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a Box account.
 
-You will need:
+The requirements are as follows.
 
 import SharedBox from '/snippets/general-shared-text/box.mdx';
 import SharedBoxCLIAPI from '/snippets/general-shared-text/box-cli-api.mdx';

--- a/snippets/dc-shared-text/chroma-cli-api.mdx
+++ b/snippets/dc-shared-text/chroma-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a Chroma account.
 
-You will need:
+The requirements are as follows.
 
 import SharedChroma from '/snippets/general-shared-text/chroma.mdx';
 import SharedChromaCLIAPI from '/snippets/general-shared-text/chroma-cli-api.mdx';

--- a/snippets/dc-shared-text/couchbase-cli-api.mdx
+++ b/snippets/dc-shared-text/couchbase-cli-api.mdx
@@ -2,7 +2,7 @@
 
 Batch process all your records to store structured outputs in a Couchbase database.
 
-You will need:
+The requirements are as follows.
 
 import CouchbaseShared from '/snippets/general-shared-text/couchbase.mdx';
 import CouchbaseSharedCLIAPI from '/snippets/general-shared-text/couchbase-cli-api.mdx';

--- a/snippets/dc-shared-text/databricks-volumes-cli-api.mdx
+++ b/snippets/dc-shared-text/databricks-volumes-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Databricks Volumes.
 
-You will need:
+The requirements are as follows.
 
 import SharedDatabricksVolumes from '/snippets/general-shared-text/databricks-volumes.mdx';
 import SharedDatabricksVolumesCLIAPI from '/snippets/general-shared-text/databricks-volumes-cli-api.mdx';

--- a/snippets/dc-shared-text/delta-table-cli-api.mdx
+++ b/snippets/dc-shared-text/delta-table-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a Delta Table in an Amazon S3 bucket.
 
-You will need:
+The requirements are as follows.
 
 import SharedDeltaTable from '/snippets/general-shared-text/delta-table.mdx';
 import SharedDeltaTableCLIAPI from '/snippets/general-shared-text/delta-table-cli-api.mdx';

--- a/snippets/dc-shared-text/dropbox-cli-api.mdx
+++ b/snippets/dc-shared-text/dropbox-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a Dropbox account.
 
-You will need:
+The requirements are as follows.
 
 import SharedDropbox from '/snippets/general-shared-text/dropbox.mdx';
 import SharedDropboxCLIAPI from '/snippets/general-shared-text/dropbox-cli-api.mdx';

--- a/snippets/dc-shared-text/elasticsearch-cli-api.mdx
+++ b/snippets/dc-shared-text/elasticsearch-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Elasticsearch.
 
-You will need:
+The requirements are as follows.
 
 import SharedElasticsearch from '/snippets/general-shared-text/elasticsearch.mdx';
 import SharedElasticsearchCLIAPI from '/snippets/general-shared-text/elasticsearch-cli-api.mdx';

--- a/snippets/dc-shared-text/gcs-cli-api.mdx
+++ b/snippets/dc-shared-text/gcs-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Google Cloud Service.
 
-You will need:
+The requirements are as follows.
 
 import SharedGoogleCloudStorage from '/snippets/general-shared-text/gcs.mdx';
 import SharedGoogleCloudStorageCLIAPI from '/snippets/general-shared-text/gcs-cli-api.mdx';

--- a/snippets/dc-shared-text/kafka-cli-api.mdx
+++ b/snippets/dc-shared-text/kafka-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Kafka.
 
-You will need:
+The requirements are as follows.
 
 import SharedKafka from '/snippets/general-shared-text/kafka.mdx';
 import SharedKafkaCLIAPI from '/snippets/general-shared-text/kafka-cli-api.mdx';

--- a/snippets/dc-shared-text/kdbai-cli-api.mdx
+++ b/snippets/dc-shared-text/kdbai-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in KDB.AI.
 
-You will need:
+The requirements are as follows.
 
 import SharedKDBAI from '/snippets/general-shared-text/kdbai.mdx';
 import SharedKDBAICLIAPI from '/snippets/general-shared-text/kdbai-cli-api.mdx';

--- a/snippets/dc-shared-text/lancedb-cli-api.mdx
+++ b/snippets/dc-shared-text/lancedb-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in LanceDB.
 
-You will need:
+The requirements are as follows.
 
 import SharedLanceDB from '/snippets/general-shared-text/lancedb.mdx';
 import SharedLanceDBCLIAPI from '/snippets/general-shared-text/lancedb-cli-api.mdx';

--- a/snippets/dc-shared-text/milvus-cli-api.mdx
+++ b/snippets/dc-shared-text/milvus-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Milvus.
 
-You will need:
+The requirements are as follows.
 
 import SharedMilvus from '/snippets/general-shared-text/milvus.mdx';
 import SharedMilvusCLIAPI from '/snippets/general-shared-text/milvus-cli-api.mdx';

--- a/snippets/dc-shared-text/mongodb-cli-api.mdx
+++ b/snippets/dc-shared-text/mongodb-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in MongoDB.
 
-You will need:
+The requirements are as follows.
 
 import SharedMongoDB from '/snippets/general-shared-text/mongodb.mdx';
 import SharedMongoDBCLIAPI from '/snippets/general-shared-text/mongodb-cli-api.mdx';

--- a/snippets/dc-shared-text/onedrive-cli-api.mdx
+++ b/snippets/dc-shared-text/onedrive-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a OneDrive account.
 
-You will need:
+The requirements are as follows.
 
 import SharedOneDrive from '/snippets/general-shared-text/onedrive.mdx';
 import SharedOneDriveCLIAPI from '/snippets/general-shared-text/onedrive-cli-api.mdx';

--- a/snippets/dc-shared-text/opensearch-cli-api.mdx
+++ b/snippets/dc-shared-text/opensearch-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in OpenSearch.
 
-You will need:
+The requirements are as follows.
 
 import SharedOpenSearch from '/snippets/general-shared-text/opensearch.mdx';
 import SharedOpenSearchCLIAPI from '/snippets/general-shared-text/opensearch-cli-api.mdx';

--- a/snippets/dc-shared-text/pinecone-cli-api.mdx
+++ b/snippets/dc-shared-text/pinecone-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Pinecone.
 
-You will need:
+The requirements are as follows.
 
 import SharedPinecone from '/snippets/general-shared-text/pinecone.mdx';
 import SharedPineconeCLIAPI from '/snippets/general-shared-text/pinecone-cli-api.mdx';

--- a/snippets/dc-shared-text/postgresql-cli-api.mdx
+++ b/snippets/dc-shared-text/postgresql-cli-api.mdx
@@ -2,7 +2,7 @@ Batch process all your records to store structured outputs in a PostgreSQL schem
 
 Insert query is currently limited to append.
 
-You will need:
+The requirements are as follows.
 
 import SharedPostgreSQL from '/snippets/general-shared-text/postgresql.mdx';
 import SharedPostgreSQLCLIAPI from '/snippets/general-shared-text/postgresql-cli-api.mdx';

--- a/snippets/dc-shared-text/qdrant-cli-api.mdx
+++ b/snippets/dc-shared-text/qdrant-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Qdrant.
 
-You will need:
+The requirements are as follows.
 
 import SharedQdrant from '/snippets/general-shared-text/qdrant.mdx';
 import SharedQdrantCLIAPI from '/snippets/general-shared-text/qdrant-cli-api.mdx';

--- a/snippets/dc-shared-text/s3-cli-api.mdx
+++ b/snippets/dc-shared-text/s3-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in an S3 bucket.
 
-You will need:
+The requirements are as follows.
 
 import SharedS3 from '/snippets/general-shared-text/s3.mdx';
 import SharedS3CLIAPI from '/snippets/general-shared-text/s3-cli-api.mdx';

--- a/snippets/dc-shared-text/sftp-cli-api.mdx
+++ b/snippets/dc-shared-text/sftp-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in SFTP.
 
-You will need:
+The requirements are as follows.
 
 import SharedSFTP from '/snippets/general-shared-text/sftp.mdx';
 import SharedSFTPCLIAPI from '/snippets/general-shared-text/sftp-cli-api.mdx';

--- a/snippets/dc-shared-text/singlestore-cli-api.mdx
+++ b/snippets/dc-shared-text/singlestore-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in a SingleStore account.
 
-You will need:
+The requirements are as follows.
 
 import SingleStoreShared from '/snippets/general-shared-text/singlestore.mdx';
 import SingleStoreSharedCLIAPI from '/snippets/general-shared-text/singlestore-cli-api.mdx';

--- a/snippets/dc-shared-text/snowflake-cli-api.mdx
+++ b/snippets/dc-shared-text/snowflake-cli-api.mdx
@@ -1,6 +1,6 @@
 Batch process all your records to store structured outputs in Snowflake.
 
-You will need:
+The requirements are as follows.
 
 import SharedSnowflake from '/snippets/general-shared-text/snowflake.mdx';
 import SharedSnowflakeCLIAPI from '/snippets/general-shared-text/snowflake-cli-api.mdx';

--- a/snippets/dc-shared-text/sqlite-cli-api.mdx
+++ b/snippets/dc-shared-text/sqlite-cli-api.mdx
@@ -2,7 +2,7 @@ Batch process all your records to store structured outputs in a SQLite schema.
 
 Insert query is currently limited to append.
 
-You will need:
+The requirements are as follows.
 
 import SharedSQLite from '/snippets/general-shared-text/sqlite.mdx';
 import SharedSQLiteCLIAPI from '/snippets/general-shared-text/sqlite-cli-api.mdx';

--- a/snippets/dc-shared-text/weaviate-cli-api.mdx
+++ b/snippets/dc-shared-text/weaviate-cli-api.mdx
@@ -10,7 +10,7 @@ allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; pic
 allowfullscreen
 ></iframe>
 
-You will need:
+The requirements are as follows.
 
 import SharedWeaviate from '/snippets/general-shared-text/weaviate.mdx';
 import SharedWeaviateCLIAPI from '/snippets/general-shared-text/weaviate-cli-api.mdx';

--- a/snippets/general-shared-text/airtable.mdx
+++ b/snippets/general-shared-text/airtable.mdx
@@ -1,5 +1,3 @@
-The Airtable connector prerequisites:
-
 - An [Airtable](https://www.airtable.com/) account. [Create a free Airtable account](https://airtable.com/signup). 
 - An Airtable personal access token. [Create a personal access token](https://support.airtable.com/docs/creating-and-using-api-keys-and-access-tokens).
 

--- a/snippets/general-shared-text/astradb.mdx
+++ b/snippets/general-shared-text/astradb.mdx
@@ -1,5 +1,3 @@
-The Astra DB connector prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/azure-ai-search.mdx
+++ b/snippets/general-shared-text/azure-ai-search.mdx
@@ -1,5 +1,3 @@
-The Azure AI Search prerequisites:
-
 The following video shows how to fulfill the minimum set of Azure AI Search prerequisites:
 
 <iframe

--- a/snippets/general-shared-text/azure-ai-search.mdx
+++ b/snippets/general-shared-text/azure-ai-search.mdx
@@ -1,4 +1,4 @@
-The following video shows how to fulfill the minimum set of Azure AI Search prerequisites:
+The following video shows how to fulfill the minimum set of Azure AI Search requirements:
 
 <iframe
 width="560"
@@ -10,7 +10,7 @@ allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; pic
 allowfullscreen
 ></iframe>
 
-Here are some more details about these prerequisites:
+Here are some more details about these requirements:
 
 - The endpoint and API key for Azure AI Search. [Create an endpoint and API key](https://learn.microsoft.com/azure/search/search-create-service-portal).
 - The name of the index in Azure AI Search. [Create an index](https://learn.microsoft.com/rest/api/searchservice/create-index).

--- a/snippets/general-shared-text/azure.mdx
+++ b/snippets/general-shared-text/azure.mdx
@@ -1,5 +1,3 @@
-The Azure Storage account prerequisites.
-
 The following video shows how to fulfill the minimum set of Azure Storage account prerequisites:
 
 <iframe

--- a/snippets/general-shared-text/azure.mdx
+++ b/snippets/general-shared-text/azure.mdx
@@ -1,4 +1,4 @@
-The following video shows how to fulfill the minimum set of Azure Storage account prerequisites:
+The following video shows how to fulfill the minimum set of Azure Storage account requirements:
 
 <iframe
 width="560"
@@ -18,7 +18,7 @@ allowfullscreen
   - **Read**, **Write**, and **List** for both reading from and writing to the container.
 </Note>
 
-Here are some more details about these prerequisites:
+Here are some more details about these requirements:
 
 - An Azure account. To create one, [learn how](https://azure.microsoft.com/pricing/purchase-options/azure-account).
 

--- a/snippets/general-shared-text/box.mdx
+++ b/snippets/general-shared-text/box.mdx
@@ -1,5 +1,3 @@
-The Box prerequisites:
-
 1. Access to the [Developer Console](https://app.box.com/developers/console) from your [Box enterprise account](https://account.box.com/signup/enterprise-plan) or [Box developer account](https://account.box.com/signup/developer).
 
 2. A Box Custom App in your Box account, set up to use **Server Authentication (with JWT)**. See [Setup with JWT](https://developer.box.com/guides/authentication/jwt/jwt-setup/).

--- a/snippets/general-shared-text/chroma.mdx
+++ b/snippets/general-shared-text/chroma.mdx
@@ -1,5 +1,3 @@
-The Chroma prerequisites:
-
 - A Chroma server. See [Deployment](https://docs.trychroma.com/deployment).
 
   For example, here is a video about how to deploy a Chroma server to AWS:

--- a/snippets/general-shared-text/confluence.mdx
+++ b/snippets/general-shared-text/confluence.mdx
@@ -1,5 +1,3 @@
-The Confluence prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/couchbase.mdx
+++ b/snippets/general-shared-text/couchbase.mdx
@@ -1,5 +1,3 @@
-The Couchbase database prerequisites. 
-
 - For the [Unstructured Platform](/platform/overview), only Couchbase Capella clusters are supported.
 - For [Unstructured Ingest](/ingestion/overview), Couchbase Capella clusters and local Couchbase server deployments are supported.
 

--- a/snippets/general-shared-text/databricks-volumes.mdx
+++ b/snippets/general-shared-text/databricks-volumes.mdx
@@ -1,5 +1,3 @@
-The Databricks Volumes prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/delta-table.mdx
+++ b/snippets/general-shared-text/delta-table.mdx
@@ -12,7 +12,7 @@ allowfullscreen
 
 The preceding video does not show how to create an AWS account or an S3 bucket. 
 
-For more information about prerequisites, see the following:
+For more information about requirements, see the following:
 
 - An AWS account. [Create an AWS account](https://aws.amazon.com/free).
 

--- a/snippets/general-shared-text/delta-table.mdx
+++ b/snippets/general-shared-text/delta-table.mdx
@@ -1,6 +1,4 @@
-The Delta Table prerequisites for Amazon S3:
-
-The following video shows how to fulfill the minimum set of S3 prerequisites:
+The following video shows how to fulfill the minimum set of Amazon S3 requirements to store Delta Tables:
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/dropbox.mdx
+++ b/snippets/general-shared-text/dropbox.mdx
@@ -1,5 +1,3 @@
-The Dropbox prerequisites:
-
 1. A Dropbox account. [Get an account](https://www.dropbox.com/try/teams).
 
 2. A target source or destination folder in your Dropbox account. [Create a folder](https://help.dropbox.com/create-upload/creating-using-folders-on-dropbox).

--- a/snippets/general-shared-text/elasticsearch.mdx
+++ b/snippets/general-shared-text/elasticsearch.mdx
@@ -1,5 +1,3 @@
-The Elasticsearch prerequisites.
-
 - For the [Unstructured Platform](/platform/overview), only Elastic Cloud instances are supported.
 - For [Unstructured Ingest](/ingestion/overview), Elastic Cloud instances and self-manged Elasticsearch instances are supported.
 - For Elastic Cloud, you will need an [Elastic Cloud service instance](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#hosted-elasticsearch-service).

--- a/snippets/general-shared-text/gcs.mdx
+++ b/snippets/general-shared-text/gcs.mdx
@@ -1,5 +1,3 @@
-The Google Cloud Storage prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/gitlab.mdx
+++ b/snippets/general-shared-text/gitlab.mdx
@@ -1,5 +1,3 @@
-The GitLab prerequisites:
-
 - A [GitLab account](https://gitlab.com/users/sign_up).
 - The URL for the target [GitLab repository](https://docs.gitlab.com/ee/user/project/repository/).
 - A [GitLab access token](https://docs.gitlab.com/ee/security/tokens/) that allows access to the repository.

--- a/snippets/general-shared-text/google-drive.mdx
+++ b/snippets/general-shared-text/google-drive.mdx
@@ -1,5 +1,3 @@
-The Google Drive prerequisites:
-
 1. A Google Cloud service account and its related `credentials.json` key file or its contents in JSON format. [Learn how](https://developers.google.com/workspace/guides/create-credentials#service-account).
 
    <iframe

--- a/snippets/general-shared-text/hubspot.mdx
+++ b/snippets/general-shared-text/hubspot.mdx
@@ -1,5 +1,3 @@
-The HubSpot prerequisites:
-
 - A [HubSpot private app and its related access token](https://developers.hubspot.com/docs/api/private-apps). 
 - The HubSpot [object types](https://developers.hubspot.com/docs/api/crm/understanding-the-crm#objects) and any of their built-in properties that you want to access. Supported object types include tickets, emails, notes, calls, products, and communications.
 - Any HubSpot params and [custom properties](https://knowledge.hubspot.com/properties/create-and-edit-properties) that you want to access for any of the supported object types.

--- a/snippets/general-shared-text/kafka.mdx
+++ b/snippets/general-shared-text/kafka.mdx
@@ -1,5 +1,3 @@
-The Kafka prerequisites:
-
 - A Kafka cluster, such as ones provided by [Confluent Cloud](https://www.confluent.io/confluent-cloud), [Amazon Managed Streaming for Apache Kafka (Amazon MSK)](https://aws.amazon.com/msk/), or [Google Cloud Managed Service for Apache Kafka](https://cloud.google.com/products/managed-service-for-apache-kafka).
 - The hostname of the bootstrap Kafka cluster to connect to.  
 - The port number of the cluster.

--- a/snippets/general-shared-text/kdbai.mdx
+++ b/snippets/general-shared-text/kdbai.mdx
@@ -1,5 +1,3 @@
-The KDB.AI prerequisites:
-
 - A KDB.AI Cloud or server instance. [Sign Up for KDB.AI Cloud: Starter Edition](https://trykdb.kx.com/kdbai/signup/). [Set up KDB.AI Server](https://code.kx.com/kdbai/latest/gettingStarted/kdb-ai-server-setup.html).
 - The instance's endpoint URL. [Get the KDB.AI Cloud endpoint URL](https://code.kx.com/kdbai/latest/gettingStarted/kdb-ai-cloud-setup.html#connect-to-your-database). [Get the KDB.AI Server endpoint URL](https://code.kx.com/kdbai/latest/gettingStarted/kdb-ai-server-setup.html).
 - An API key. [Create the API key](https://code.kx.com/kdbai/latest/gettingStarted/kdb-ai-cloud-setup.html#create-an-api-key).

--- a/snippets/general-shared-text/lancedb.mdx
+++ b/snippets/general-shared-text/lancedb.mdx
@@ -1,5 +1,3 @@
-The LanceDB prerequisites:
-
 - A [LanceDB open source software (OSS) installation](https://lancedb.github.io/lancedb/basic/#installation) on a local machine, a server, or a virtual machine. 
   (LanceDB Cloud is not supported.)
 - For LanceDB OSS with local data storage:

--- a/snippets/general-shared-text/milvus.mdx
+++ b/snippets/general-shared-text/milvus.mdx
@@ -1,4 +1,4 @@
-The following video shows how to fulfill the minimum set of Milvus prerequisites, demonstrating Milvus on IBM watsonx.data:
+The following video shows how to fulfill the minimum set of Milvus requirements, demonstrating Milvus on IBM watsonx.data:
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/milvus.mdx
+++ b/snippets/general-shared-text/milvus.mdx
@@ -1,10 +1,4 @@
-The Milvus prerequisites:
-
-- A [Milvus instance](https://milvus.io/docs/install-overview.md).
-- The [URI](https://milvus.io/api-reference/pymilvus/v2.4.x/MilvusClient/Client/MilvusClient.md) of the instance.
-- The [username and password, or token](https://milvus.io/docs/authenticate.md) to access the instance.
-- The name of the [database](https://milvus.io/docs/manage_databases.md) in the instance.
-- The name of the [collection](https://milvus.io/docs/manage-collections.md) in the database.
+The following video shows how to fulfill the minimum set of Milvus prerequisites, demonstrating Milvus on IBM watsonx.data:
 
 <iframe
 width="560"
@@ -15,3 +9,10 @@ frameborder="0"
 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 allowfullscreen
 ></iframe>
+
+- A [Milvus instance](https://milvus.io/docs/install-overview.md).
+- The [URI](https://milvus.io/api-reference/pymilvus/v2.4.x/MilvusClient/Client/MilvusClient.md) of the instance.
+- The [username and password, or token](https://milvus.io/docs/authenticate.md) to access the instance.
+- The name of the [database](https://milvus.io/docs/manage_databases.md) in the instance.
+- The name of the [collection](https://milvus.io/docs/manage-collections.md) in the database.
+

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,4 +1,4 @@
-The MongoDB prerequisites for a MongoDB Atlas deployment:
+The MongoDB prerequisites for a MongoDB Atlas deployment include:
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,4 +1,4 @@
-The MongoDB prerequisites for a MongoDB Atlas deployment include:
+The MongoDB requirements for a MongoDB Atlas deployment include:
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/onedrive.mdx
+++ b/snippets/general-shared-text/onedrive.mdx
@@ -1,5 +1,3 @@
-The OneDrive prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/opensearch.mdx
+++ b/snippets/general-shared-text/opensearch.mdx
@@ -1,5 +1,3 @@
-The OpenSearch prerequisites:
-
 - An OpenSearch instance, such as an [AWS OpenSearch](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/setting-up.html) instance...
 
   <iframe

--- a/snippets/general-shared-text/outlook.mdx
+++ b/snippets/general-shared-text/outlook.mdx
@@ -1,5 +1,3 @@
-The Outlook prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/pinecone.mdx
+++ b/snippets/general-shared-text/pinecone.mdx
@@ -1,5 +1,3 @@
-The Pinecone prerequisites:
-
 - A Pinecone account. [Get an account](https://app.pinecone.io/).
 
   <iframe

--- a/snippets/general-shared-text/postgresql.mdx
+++ b/snippets/general-shared-text/postgresql.mdx
@@ -1,6 +1,4 @@
-The PostgreSQL prerequisites, which include the following settings.
-
-The following video shows for example how to get these settings by using [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/).
+The following video shows for example how to get these settings by using [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/):
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/qdrant.mdx
+++ b/snippets/general-shared-text/qdrant.mdx
@@ -1,5 +1,3 @@
-The Qdrant prerequisites are as follows.
-
 - The name of the target [collection](https://qdrant.tech/documentation/concepts/collections) on the Qdrant local installation, 
   Qdrant server, or Qdrant Cloud cluster.
 - For [Qdrant local](https://github.com/qdrant/qdrant), the path to the local Qdrant installation, for example: `/qdrant/local`

--- a/snippets/general-shared-text/s3.mdx
+++ b/snippets/general-shared-text/s3.mdx
@@ -1,4 +1,4 @@
-The following video shows how to fulfill the minimum set of Amazon S3 prerequisites:
+The following video shows how to fulfill the minimum set of Amazon S3 requirements:
 
 <iframe
 width="560"
@@ -12,7 +12,7 @@ allowfullscreen
 
 The preceding video does not show how to create an AWS account; enable anonymous access to the bucket (which is supported but 
 not recommended); or generate an AWS STS session token for temporary access, if required by your organization's security 
-requirements. For more information about prerequisites, see the following:
+requirements. For more information about requirements, see the following:
 
 - An AWS account. [Create an AWS account](https://aws.amazon.com/free).
 

--- a/snippets/general-shared-text/s3.mdx
+++ b/snippets/general-shared-text/s3.mdx
@@ -1,6 +1,4 @@
-The Amazon S3 prerequisites:
-
-The following video shows how to fulfill the minimum set of S3 prerequisites:
+The following video shows how to fulfill the minimum set of Amazon S3 prerequisites:
 
 <iframe
 width="560"

--- a/snippets/general-shared-text/salesforce.mdx
+++ b/snippets/general-shared-text/salesforce.mdx
@@ -1,5 +1,3 @@
-The Salesforce prerequisites:
-
 - A Salesforce account. [Create an account](https://developer.salesforce.com/signup).
 
   <iframe

--- a/snippets/general-shared-text/sftp.mdx
+++ b/snippets/general-shared-text/sftp.mdx
@@ -1,5 +1,3 @@
-The SFTP prerequisites:
-
 - The SFTP server hostname, port, username, and password.
 
   SFTP servers are offered by several vendors. For example, the following video shows how to create and set up an SFTP server by using AWS Transfer Family:

--- a/snippets/general-shared-text/sharepoint.mdx
+++ b/snippets/general-shared-text/sharepoint.mdx
@@ -1,5 +1,3 @@
-The SharePoint prerequisites, which include the following settings.
-
 <iframe
 width="560"
 height="315"

--- a/snippets/general-shared-text/singlestore.mdx
+++ b/snippets/general-shared-text/singlestore.mdx
@@ -1,5 +1,3 @@
-The SingleStore prerequisites:
-
 - A SingleStore deployment, database, and table. [Learn how](https://www.singlestore.com/blog/how-to-get-started-with-singlestore/).
 - The hostname for the SingleStore deployment.
 - The port for the host.

--- a/snippets/general-shared-text/slack.mdx
+++ b/snippets/general-shared-text/slack.mdx
@@ -1,5 +1,3 @@
-The Slack prerequisites:
-
 - A Slack app. Create a Slack app by following [Step 1: Creating an app](https://api.slack.com/quickstart#creating).
 - The app must have the `channels:history` OAuth scope. Give the app this scope by following [Step 2: Requesting scopes](https://api.slack.com/quickstart#scopes).
 - The app must be installed and authorized for the target Slack workspace. Install and authorize the app by following [Step 3: Installing and authorizing the app](https://api.slack.com/quickstart#installing).

--- a/snippets/general-shared-text/snowflake.mdx
+++ b/snippets/general-shared-text/snowflake.mdx
@@ -1,5 +1,3 @@
-The Snowflake prerequisites:
-
 - A Snowflake [account](https://signup.snowflake.com/) and its [identifier](https://docs.snowflake.com/user-guide/admin-account-identifier).
 
   <iframe

--- a/snippets/general-shared-text/sqlite.mdx
+++ b/snippets/general-shared-text/sqlite.mdx
@@ -1,5 +1,3 @@
-The SQLite prerequisites:
-
 - A SQLite instance. [Download and install SQLite](https://www.sqlitetutorial.net/download-install-sqlite/).
 - A SQLite database. [Create a database](https://www.sqlite.org/quickstart.html).
 - The path to the database's `.db` file.

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -1,5 +1,3 @@
-The Weaviate prerequisites:
-
 <iframe
 width="560"
 height="315"

--- a/snippets/quickstarts/platform.mdx
+++ b/snippets/quickstarts/platform.mdx
@@ -1,6 +1,6 @@
 This quickstart uses a no-code, point-and-click user interface in your web browser to get all of your data RAG-ready. Data is processed on Unstructured-hosted compute resources.
 
-You will need:
+The requirements are as follows.
 
 - A compatible source (input) location in cloud storage that contains your documents for Unstructured to process. [See the list of supported source types](/platform/connectors#sources).
 - Compatible files in your source location. [See the list of supported file types](/platform/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.

--- a/snippets/sc-shared-text/airtable-cli-api.mdx
+++ b/snippets/sc-shared-text/airtable-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Airtable to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your data and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import AirtableShared from '/snippets/general-shared-text/airtable.mdx';
 import AirtableSharedCLIAPI from '/snippets/general-shared-text/airtable-cli-api.mdx';

--- a/snippets/sc-shared-text/astradb-cli-api.mdx
+++ b/snippets/sc-shared-text/astradb-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Astra DB to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import AstraDBShared from '/snippets/general-shared-text/astradb.mdx';
 import AstraDBSharedCLIAPI from '/snippets/general-shared-text/astradb-cli-api.mdx';

--- a/snippets/sc-shared-text/azure-cli-api.mdx
+++ b/snippets/sc-shared-text/azure-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Azure Storage to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedAzure from '/snippets/general-shared-text/azure.mdx';
 import SharedAzureCLIAPI from '/snippets/general-shared-text/azure-cli-api.mdx';

--- a/snippets/sc-shared-text/box-cli-api.mdx
+++ b/snippets/sc-shared-text/box-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Box to your preprocessing pipeline, and use the Unstructured CLI or Python to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedBox from '/snippets/general-shared-text/box.mdx';
 import SharedBoxCLIAPI from '/snippets/general-shared-text/box-cli-api.mdx';

--- a/snippets/sc-shared-text/confluence-cli-api.mdx
+++ b/snippets/sc-shared-text/confluence-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Confluence to your preprocessing pipeline, and use the Unstructured CLI or Python to batch process all your spaces and pages and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedConfluence from '/snippets/general-shared-text/confluence.mdx';
 import SharedConfluenceCLIAPI from '/snippets/general-shared-text/confluence-cli-api.mdx';

--- a/snippets/sc-shared-text/couchbase-cli-api.mdx
+++ b/snippets/sc-shared-text/couchbase-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Couchbase Database to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need:
+The requirements are as follows.
 
 import SharedCouchbaseDB from '/snippets/general-shared-text/couchbase.mdx';
 import SharedCouchbaseDBCLIAPI from '/snippets/general-shared-text/couchbase-cli-api.mdx';

--- a/snippets/sc-shared-text/databricks-volumes-cli-api.mdx
+++ b/snippets/sc-shared-text/databricks-volumes-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Databricks Volumes to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedDatabricksVolumes from '/snippets/general-shared-text/databricks-volumes.mdx';
 import SharedDatabricksVolumesCLIAPI from '/snippets/general-shared-text/databricks-volumes-cli-api.mdx';

--- a/snippets/sc-shared-text/dropbox-cli-api.mdx
+++ b/snippets/sc-shared-text/dropbox-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Dropbox to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedDropbox from '/snippets/general-shared-text/dropbox.mdx';
 import SharedDropboxCLIAPI from '/snippets/general-shared-text/dropbox-cli-api.mdx';

--- a/snippets/sc-shared-text/elasticsearch-cli-api.mdx
+++ b/snippets/sc-shared-text/elasticsearch-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Elasticsearch to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedElasticsearch from '/snippets/general-shared-text/elasticsearch.mdx';
 import SharedElasticsearchCLIAPI from '/snippets/general-shared-text/elasticsearch-cli-api.mdx';

--- a/snippets/sc-shared-text/gcs-cli-api.mdx
+++ b/snippets/sc-shared-text/gcs-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Google Cloud Storage to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need:
+The requirements are as follows.
 
 import SharedGoogleCloudStorage from '/snippets/general-shared-text/gcs.mdx';
 import SharedGoogleCloudStorageCLIAPI from '/snippets/general-shared-text/gcs-cli-api.mdx';

--- a/snippets/sc-shared-text/gitlab-cli-api.mdx
+++ b/snippets/sc-shared-text/gitlab-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect GitLab to your preprocessing pipeline, and use the Unstructured CLI or Python to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedGitLab from '/snippets/general-shared-text/gitlab.mdx';
 import SharedGitLabCLIAPI from '/snippets/general-shared-text/gitlab-cli-api.mdx';

--- a/snippets/sc-shared-text/google-drive-cli-api.mdx
+++ b/snippets/sc-shared-text/google-drive-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Google Drive to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need:
+The requirements are as follows.
 
 import SharedGoogleDrive from '/snippets/general-shared-text/google-drive.mdx';
 import SharedGoogleDriveCLIAPI from '/snippets/general-shared-text/google-drive-cli-api.mdx';

--- a/snippets/sc-shared-text/hubspot-cli-api.mdx
+++ b/snippets/sc-shared-text/hubspot-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect HubSpot to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need:
+The requirements are as follows.
 
 import SharedHubSpot from '/snippets/general-shared-text/hubspot.mdx';
 import SharedHubSpotCLIAPI from '/snippets/general-shared-text/hubspot-cli-api.mdx';

--- a/snippets/sc-shared-text/kafka-cli-api.mdx
+++ b/snippets/sc-shared-text/kafka-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Kafka to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedKafka from '/snippets/general-shared-text/kafka.mdx';
 import SharedKafkaCLIAPI from '/snippets/general-shared-text/kafka-cli-api.mdx';

--- a/snippets/sc-shared-text/mongodb-cli-api.mdx
+++ b/snippets/sc-shared-text/mongodb-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect MongoDB to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedMongoDB from '/snippets/general-shared-text/mongodb.mdx';
 import SharedMongoDBCLIAPI from '/snippets/general-shared-text/mongodb-cli-api.mdx';

--- a/snippets/sc-shared-text/onedrive-cli-api.mdx
+++ b/snippets/sc-shared-text/onedrive-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect OneDrive to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedOneDrive from '/snippets/general-shared-text/onedrive.mdx';
 import SharedOneDriveCLIAPI from '/snippets/general-shared-text/onedrive-cli-api.mdx';

--- a/snippets/sc-shared-text/opensearch-cli-api.mdx
+++ b/snippets/sc-shared-text/opensearch-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect OpenSearch to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedOpenSearch from '/snippets/general-shared-text/opensearch.mdx';
 import SharedOpenSearchCLIAPI from '/snippets/general-shared-text/opensearch-cli-api.mdx';

--- a/snippets/sc-shared-text/outlook-cli-api.mdx
+++ b/snippets/sc-shared-text/outlook-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Outlook to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedOutlook from '/snippets/general-shared-text/outlook.mdx';
 import SharedOutlookCLIAPI from '/snippets/general-shared-text/outlook-cli-api.mdx';

--- a/snippets/sc-shared-text/postgresql-cli-api.mdx
+++ b/snippets/sc-shared-text/postgresql-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect PostgreSQL to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedPostgreSQL from '/snippets/general-shared-text/postgresql.mdx';
 import SharedPostgreSQLCLIAPI from '/snippets/general-shared-text/postgresql-cli-api.mdx';

--- a/snippets/sc-shared-text/s3-cli-api.mdx
+++ b/snippets/sc-shared-text/s3-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect S3 to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedS3 from '/snippets/general-shared-text/s3.mdx';
 import SharedS3CLIAPI from '/snippets/general-shared-text/s3-cli-api.mdx';

--- a/snippets/sc-shared-text/salesforce-cli-api.mdx
+++ b/snippets/sc-shared-text/salesforce-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Salesforce to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSalesforce from '/snippets/general-shared-text/salesforce.mdx';
 import SharedSalesforceCLIAPI from '/snippets/general-shared-text/salesforce-cli-api.mdx';

--- a/snippets/sc-shared-text/sftp-cli-api.mdx
+++ b/snippets/sc-shared-text/sftp-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect SFTP to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSFTP from '/snippets/general-shared-text/sftp.mdx';
 import SharedSFTPCLIAPI from '/snippets/general-shared-text/sftp-cli-api.mdx';

--- a/snippets/sc-shared-text/sharepoint-cli-api.mdx
+++ b/snippets/sc-shared-text/sharepoint-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect SharePoint to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSharePoint from '/snippets/general-shared-text/sharepoint.mdx';
 import SharedSharePointCLIAPI from '/snippets/general-shared-text/sharepoint-cli-api.mdx';

--- a/snippets/sc-shared-text/singlestore-cli-api.mdx
+++ b/snippets/sc-shared-text/singlestore-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect SingleStore to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSingleStore from '/snippets/general-shared-text/singlestore.mdx';
 import SharedSingleStoreCLIAPI from '/snippets/general-shared-text/singlestore-cli-api.mdx';

--- a/snippets/sc-shared-text/slack-cli-api.mdx
+++ b/snippets/sc-shared-text/slack-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Slack to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSlack from '/snippets/general-shared-text/slack.mdx';
 import SharedSlackCLIAPI from '/snippets/general-shared-text/slack-cli-api.mdx';

--- a/snippets/sc-shared-text/snowflake-cli-api.mdx
+++ b/snippets/sc-shared-text/snowflake-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect Snowflake to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSnowflake from '/snippets/general-shared-text/snowflake.mdx';
 import SharedSnowflakeCLIAPI from '/snippets/general-shared-text/snowflake-cli-api.mdx';

--- a/snippets/sc-shared-text/sqlite-cli-api.mdx
+++ b/snippets/sc-shared-text/sqlite-cli-api.mdx
@@ -1,6 +1,6 @@
 Connect SQLite to your preprocessing pipeline, and use the Unstructured Ingest CLI or the Unstructured Ingest Python library to batch process all your documents and store structured outputs locally on your filesystem.
 
-You will need: 
+The requirements are as follows. 
 
 import SharedSQLite from '/snippets/general-shared-text/sqlite.mdx';
 import SharedSQLiteCLIAPI from '/snippets/general-shared-text/sqlite-cli-api.mdx';

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -88,7 +88,7 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 This quickstart uses your local machine, with the [Unstructured Ingest Python library](/ingestion/overview#unstructured-ingest-python-library) installed. It preprocesses source (input) files on your local machine, and it uses the Unstructured Serverless API to deliver the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
-You will need:
+The requirements are as follows.
 
 - Python installed on your local machine.
 - Compatible files on your local machine to be processed. [See the list of supported file types](#supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.


### PR DESCRIPTION
We have a lot of page introductions that are something like this construction:

> You'll need:
>
> The `<connector-name>` requirements:

This is somewhat sloppy and hinders readability a bit, making it seem that there might be some missing information at worst. This PR seeks to clean this up. 