### PR TITLE
Astra DB connectors: remove embedding dimensions setting from Platform, Ingest

### DIFF
--- a/snippets/destination_connectors/astradb.sh.mdx
+++ b/snippets/destination_connectors/astradb.sh.mdx
@@ -18,6 +18,4 @@ unstructured-ingest \
     --api-endpoint $ASTRA_DB_API_ENDPOINT \
     --token $ASTRA_DB_APPLICATION_TOKEN \
     --keyspace $ASTRA_DB_KEYSPACE \
-    --collection-name $ASTRA_DB_COLLECTION \
-    --embedding-dimension $ASTRA_DB_EMBEDDING_DIMENSIONS
-```
+    --collection-name $ASTRA_DB_COLLECTION

--- a/snippets/destination_connectors/astradb.v1.py.mdx
+++ b/snippets/destination_connectors/astradb.v1.py.mdx
@@ -30,7 +30,6 @@ def get_writer() -> Writer:
             ),
             keyspace=os.getenv("ASTRA_DB_KEYSPACE"),
             collection_name=os.getenv("ASTRA_DB_COLLECTION"),
-            embedding_dimension=os.getenv("ASTRA_DB_EMBEDDING_DIMENSIONS"),
         ),
         write_config=AstraWriteConfig(batch_size=80),
     )

--- a/snippets/destination_connectors/astradb.v2.py.mdx
+++ b/snippets/destination_connectors/astradb.v2.py.mdx
@@ -49,8 +49,7 @@ if __name__ == "__main__":
         stager_config=AstraDBUploadStagerConfig(),
         uploader_config=AstraDBUploaderConfig(
             keyspace=os.getenv("ASTRA_DB_KEYSPACE"),
-            collection_name=os.getenv("ASTRA_DB_COLLECTION"),
-            embedding_dimension=os.getenv("ASTRA_DB_EMBEDDING_DIMENSIONS")
+            collection_name=os.getenv("ASTRA_DB_COLLECTION")
         )
     ).run()
 ```

--- a/snippets/general-shared-text/astradb-cli-api.mdx
+++ b/snippets/general-shared-text/astradb-cli-api.mdx
@@ -13,5 +13,4 @@ These environment variables:
 - `ASTRA_DB_API_ENDPOINT` - The API endpoint for the Astra DB database, represented by `--api-endpoint` (CLI) or `api_endpoint` (Python). To get the endpoint, see the **Database Details > API Endpoint** value on your database's **Overview** tab.
 - `ASTRA_DB_APPLICATION_TOKEN` - The database application token value for the database, represented by `--token` (CLI) or `token` (Python). To get the token, see the **Database Details > Application Tokens** box on your database's **Overview** tab.
 - `ASTRA_DB_KEYSPACE` - The name of the keyspace for the database, represented by `--keyspace` (CLI) or `keyspace` (Python).
-- `ASTRA_DB_COLLECTION` - The name of the collection for the keyspace, represented by `--collection-name` (CLI) or `collection_name` (Python). 
-- `ASTRA_DB_EMBEDDING_DIMENSIONS` - The number of dimensions in the collection, represented by `--embedding-dimension` (CLI) or `embedding_dimension` (Python).
+- `ASTRA_DB_COLLECTION` - The name of the collection for the keyspace, represented by `--collection-name` (CLI) or `collection_name` (Python).

--- a/snippets/general-shared-text/astradb-platform.mdx
+++ b/snippets/general-shared-text/astradb-platform.mdx
@@ -4,4 +4,3 @@ Fill in the following fields:
 - **Token** (_required_): The application token for the database.
 - **API Endpoint** (_required_): The database's associated API endpoint.
 - **Collection Name** (_required_): The name of the collection in the namespace.
-- **Embedding Dimension** (_required_): The number of dimensions in the collection.


### PR DESCRIPTION
The embedding dimensions setting was recently removed from both Platform and Ingest. This PR syncs the docs to reflect this removal.