### PR TITLE
Qdrant destination connector: how to create a compatible collection

### DIFF
--- a/snippets/general-shared-text/qdrant.mdx
+++ b/snippets/general-shared-text/qdrant.mdx
@@ -1,5 +1,3 @@
-- The name of the target [collection](https://qdrant.tech/documentation/concepts/collections) on the Qdrant local installation, 
-  Qdrant server, or Qdrant Cloud cluster.
 - For [Qdrant local](https://github.com/qdrant/qdrant), the path to the local Qdrant installation, for example: `/qdrant/local`
 - For [Qdrant client-server](https://qdrant.tech/documentation/quickstart/), the Qdrant server URL, for example: `http://localhost:6333`
 - For [Qdrant Cloud](https://qdrant.tech/documentation/cloud-intro/):
@@ -14,3 +12,35 @@
     4. Note the value of the **Endpoint** field, for example: `https://<random-guid>.<region-id>.<cloud-provider>.cloud.qdrant.io`.
 
   - A [Qdrant API key](https://qdrant.tech/documentation/cloud/authentication/#create-api-keys).
+
+- The name of the target [collection](https://qdrant.tech/documentation/concepts/collections) on the Qdrant local installation, 
+  Qdrant server, or Qdrant Cloud cluster.
+
+  Qdrant requires the target collection to exist before Unstructured can write to the collection. 
+  The following example code demonstrates the use of the [Python Qdrant Client](https://pypi.org/project/qdrant-client/) to create 
+  a collection on a Qdrant Cloud cluster, configuring the collection for vectors with 3072 dimensions:
+
+  ```python Python
+  from qdrant_client import QdrantClient, models
+  import os
+
+  client = QdrantClient(
+      url=os.getenv("QDRANT_URL"),
+      api_key=os.getenv("QDRANT_API_KEY")
+  )
+
+  client.create_collection(
+      collection_name=os.getenv("QDRANT_COLLECTION"),
+      vectors_config=models.VectorParams(
+          size=3072,
+          distance=models.Distance.COSINE
+      )
+  )
+
+  collection = client.get_collection(
+                   collection_name=os.getenv("QDRANT_COLLECTION")
+               )
+
+  print(f"The collection named '{os.getenv("QDRANT_COLLECTION")}' exists and " +
+        f"has a status of '{collection.status}'.")
+  ```


### PR DESCRIPTION
See for example the fourth major bullet from the top/beginning of https://unstructured-53-qdrant-collection-schema-2024-12-04.mintlify.app/api-reference/ingest/destination-connector/qdrant