### PR TITLE
Platform: OneDrive connector - path for source, but remote URL for destination

### DIFF
--- a/snippets/general-shared-text/onedrive-platform.mdx
+++ b/snippets/general-shared-text/onedrive-platform.mdx
@@ -5,9 +5,7 @@ Fill in the following fields:
 - **Tenant ID** (_required_): The directory (tenant) ID of the Entra ID app registration.
 - **Authority URL** (_required_): The authentication token provider URL for the Entra ID app registration. The default is `https://login.microsoftonline.com`.
 - **Principal Name** (_required_): The User Principal Name (UPN) for the OneDrive user account in Entra ID. This is typically the user's email address.
-- **Path**: The path to the target folder in the OneDrive account, starting with the account's root folder, for example `my-folder/my-subfolder`.
-- **Recursive**: Check this box to recursively access files from subfolders within the specified OneDrive path.
 - **Client Credential** (_required_): The client secret for the Entra ID app registration.
-
-
-
+- **Path** (source connector only): The path to the target folder in the OneDrive account, starting with the account's root folder, for example `my-folder/my-subfolder`.
+- **Recursive** (source connector only): Check this box to recursively access files from subfolders within the specified OneDrive path.
+- **Remote URL** (destination connector only): `onedrive://`, followed by the path to the target folder in the OneDrive account, starting with the account's root folder, for example `onedrive://my-folder/my-subfolder`.


### PR DESCRIPTION
For the OneDrive source connector, there's a **Path** field, which we describe in the docs. However, for the OneDrive destination connector, there is no **Path** field; instead, it's the **Remote URL** field, which we don't describe in the docs. This PR corrects this. 

See for example the very end/bottom of https://unstructured-53-onedrive-remote-url-2024-12-06.mintlify.app/platform/destinations/onedrive

