### PR TITLE
Astra DB connectors: switch out video embed link

### DIFF
--- a/snippets/general-shared-text/astradb.mdx
+++ b/snippets/general-shared-text/astradb.mdx
@@ -1,7 +1,7 @@
 <iframe
 width="560"
 height="315"
-src="https://www.youtube.com/embed/kupQrnCQjPw"
+src="https://www.youtube.com/embed/PMs1iwL52aM"
 title="YouTube video player"
 frameborder="0"
 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
The old video showed how to get the number of dimensions. This is no longer needed. The new video removes these instructions.

See for example: https://unstructured-53-astradb-video-link-2024-12-10.mintlify.app/platform/destinations/astradb