### PR TITLE
Milvus destination connector: update how-to video embed links

### DIFF
--- a/snippets/general-shared-text/milvus.mdx
+++ b/snippets/general-shared-text/milvus.mdx
@@ -3,17 +3,17 @@
 
 The following video shows how to fulfill the minimum set of requirements for Milvus cloud-based instances, demonstrating Milvus on IBM watsonx.data:
 
-<iframe
-width="560"
-height="315"
-src="https://www.youtube.com/embed/tl9eV-_nAHI"
-title="YouTube video player"
-frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-allowfullscreen
-></iframe>
-
 - For Zilliz Cloud, you will need:
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/ASEmYryJpkU"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
 
   - A [Zilliz Cloud account](https://cloud.zilliz.com/signup).
   - A [Zilliz Cloud cluster](https://docs.zilliz.com/docs/create-cluster).
@@ -34,6 +34,16 @@ allowfullscreen
     | `record_id` | **VARCHAR** | `200` | -- | -- | -- |
 
 - For Milvus on IBM watsonx.data, you will need:
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/hLCwoe2fCnc"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>
 
   - An [IBM Cloud account](https://cloud.ibm.com/registration).
   - The [IBM watsonx.data subscription plan](https://cloud.ibm.com/docs/watsonxdata?topic=watsonxdata-getting-started).


### PR DESCRIPTION
The existing Milvus setup how-to video is being replaced with a new one that is branded "Milvus on IBM watsonx.data." Also, a new video is being added to that one that is branded "Milvus on Zilliz Cloud." This is to more cleanly separate the distinct setup steps for each vendor. 

See for example https://unstructured-53-milvus-zilliz-video-2024-12-11.mintlify.app/platform/destinations/milvus