### PR TITLE
Temporarily remove link to SharePoint video

### DIFF
--- a/snippets/general-shared-text/sharepoint.mdx
+++ b/snippets/general-shared-text/sharepoint.mdx
@@ -1,13 +1,3 @@
-<iframe
-width="560"
-height="315"
-src="https://www.youtube.com/embed/r4BLhGgpAWQ"
-title="YouTube video player"
-frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-allowfullscreen
-></iframe>
-
 - The SharePoint site URL.
 
   - Site URLs typically have the format `https://<tenant>.sharepoint.com`.


### PR DESCRIPTION
See for example a page with the video removed: https://unstructured-53-sharepoint-video-2024-12-13.mintlify.app/platform/sources/sharepoint