### PR TITLE
Add Azure OpenAI embedding provider

### DIFF
--- a/api-reference/ingest/ingest-dependencies.mdx
+++ b/api-reference/ingest/ingest-dependencies.mdx
@@ -98,7 +98,7 @@ To add support for available embedding libraries, run the following:
 | `pip install "unstructured-ingest[embed-vertexai]"` | Google Vertex AI  |
 | `pip install "unstructured-ingest[embed-voyageai]"` | Voyage AI |
 | `pip install "unstructured-ingest[embed-mixedbreadai]"` | Mixedbread |
-| `pip install "unstructured-ingest[openai]"` | OpenAI |
+| `pip install "unstructured-ingest[openai]"` | OpenAI, Azure OpenAI |
 | `pip install "unstructured-ingest[togetherai]"` | together.ai  |
 
 For details about the specific dependencies that are installed, see:

--- a/snippets/ingest-configuration-shared/embedding-configuration.mdx
+++ b/snippets/ingest-configuration-shared/embedding-configuration.mdx
@@ -10,7 +10,7 @@ A common embedding configuration is a critical component that allows for dynamic
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`aws_secret_access_key`: The AWS secret access key to be used for AWS-based embedders, such as Amazon Bedrock.
 
-*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_provider`: The embedding provider to use while doing embedding. Available values include `aws-bedrock`, `huggingface`, `mixedbread-ai`, `octoai`, `openai`, `togetherai`, `vertexai`, and `voyageai`.
+*   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_provider`: The embedding provider to use while doing embedding. Available values include `aws-bedrock`, `azure-openai`, `huggingface`, `mixedbread-ai`, `octoai`, `openai`, `togetherai`, `vertexai`, and `voyageai`.
     
 *   <Icon icon="v"/><Icon icon="2"/>&nbsp;&nbsp;`embedding_api_key`: The API key to use, if one is required to generate the embeddings through an API service, such as OpenAI.
 
@@ -24,12 +24,14 @@ A common embedding configuration is a critical component that allows for dynamic
 
 *   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`model_name`: The specific model to use for the embedding provider, if necessary.
 
-*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`provider`: The embedding provider to use while doing embedding. Available values include `aws-bedrock`, `huggingface`, `mixedbread-ai`, `octoai`, `openai`, `togetherai`, `vertexai`, and `voyageai`.
+*   <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;`provider`: The embedding provider to use while doing embedding. Available values include `aws-bedrock`, `azure-openai`, `huggingface`, `mixedbread-ai`, `octoai`, `openai`, `togetherai`, `vertexai`, and `voyageai`.
 
 
 <Icon icon="v"/><Icon icon="1"/>&nbsp;&nbsp;The default `model_name` values unless otherwise specified are:
 
 * `aws-bedrock`: None
+
+* `azure-openai`: `text-embedding-ada-002`, with 1536 dimensions
 
 * `huggingface`: `sentence-transformers/all-MiniLM-L6-v2`, with 384 dimensions
 


### PR DESCRIPTION
- Uses the same extra as OpenAI (`openai`). 
- `embedding_provider` = `azure-openai`
- Default `model_name` = `text-embedding-ada-002`

See:

- https://unstructured-53-docs-119-azure-openai.mintlify.app/api-reference/ingest/ingest-dependencies - search for "Azure OpenAI"
- https://unstructured-53-docs-119-azure-openai.mintlify.app/api-reference/ingest/ingest-configuration/embedding-configuration - search for "azure-openai"

