### PR TITLE
Kafka connectors: new group ID field

### DIFF
--- a/snippets/general-shared-text/kafka-cli-api.mdx
+++ b/snippets/general-shared-text/kafka-cli-api.mdx
@@ -22,5 +22,8 @@ If you use Kafka API keys and secrets for authentication:
 Additional settings include:
 
 - `--confluent` (CLI) or `confluent` (Python): True to indicate that the cluster is running Confluent Kafka.
-- `--num-messages-to-consume` (CLI) or `num_messages_to_consume` (Python): The maximum number of messages to get from the topic. The default is `1`.
-- `--timeout` (CLI) or `timeout` (Python): The maximum amount of time to wait for the response of a request to the topic, expressed in seconds. The default is `1.0`.
+- `--num-messages-to-consume` (CLI) or `num_messages_to_consume` (Python): The maximum number of messages to get from the topic. The default is `1` if not otherwise specified.
+- `--timeout` (CLI) or `timeout` (Python): The maximum amount of time to wait for the response of a request to the topic, expressed in seconds. The default is `1.0` if not otherwise specified.
+- `--group-id` (CLI) or `group_id` (Python): The ID of the consumer group, if any, that is associated with the target Kafka cluser. 
+  (A consumer group is a way to allow a pool of consumers to divide the consumption of data 
+  over topics and partitions.) The default is `default_group_id` if not otherwise specified.


### PR DESCRIPTION
See for example https://unstructured-53-docs-116-kafka.mintlify.app/api-reference/ingest/source-connectors/kafka

Search for "--group-id" or "group_id"