### PR TITLE
Update salesforce-platform.mdx

### DIFF
--- a/snippets/general-shared-text/salesforce-platform.mdx
+++ b/snippets/general-shared-text/salesforce-platform.mdx
@@ -5,4 +5,4 @@ Fill in the following fields:
 - **Salesforce categories**: A comma-separated list of the Salesforce categories to access. Available categories include 
   `Account`, `Campaign`, `Case`, `EmailMessage`, and `Lead`.
 - **Consumer key** (_required_): The consumer key (client ID) for the target Salesforce connected app.
-- **Private key (PEM)** (_required_): The private key (PEM) associated with the consumer key for the Salesforce connected app. The PEM is a string that begins with `—–BEGIN RSA PRIVATE KEY—–` and ends with `—–END RSA PRIVATE KEY—–`.
+- **Private key (PEM)** (_required_): The private key (PEM) associated with the consumer key for the Salesforce connected app. The PEM must be expressed as a single-line string.


### PR DESCRIPTION
Private key (PEM) files no longer must include `RSA`, so removing that part.