### PR TITLE
Platform API ref follow-on updates, part 2

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -518,12 +518,17 @@
                   "platform/api/sources/overview",
                   "platform/api/sources/azure-blob-storage",
                   "platform/api/sources/confluence",
+                  "platform/api/sources/couchbase",
                   "platform/api/sources/databricks-volumes",
+                  "platform/api/sources/dropbox",
+                  "platform/api/sources/elasticsearch",
                   "platform/api/sources/google-cloud",
+                  "platform/api/sources/google-drive",
                   "platform/api/sources/mongodb",
                   "platform/api/sources/onedrive",
                   "platform/api/sources/outlook",
                   "platform/api/sources/s3",
+                  "platform/api/sources/salesforce",
                   "platform/api/sources/sharepoint"
                 ]
               },
@@ -533,6 +538,7 @@
                   "platform/api/destinations/overview",
                   "platform/api/destinations/astradb",
                   "platform/api/destinations/azure-ai-search",
+                  "platform/api/destinations/couchbase",
                   "platform/api/destinations/databricks-volumes",
                   "platform/api/destinations/delta-table",
                   "platform/api/destinations/elasticsearch",
@@ -541,6 +547,8 @@
                   "platform/api/destinations/mongodb",
                   "platform/api/destinations/onedrive",
                   "platform/api/destinations/pinecone",
+                  "platform/api/destinations/postgresql",
+                  "platform/api/destinations/qdrant",
                   "platform/api/destinations/s3",
                   "platform/api/destinations/weaviate"
                 ]

--- a/platform/api/destinations/couchbase.mdx
+++ b/platform/api/destinations/couchbase.mdx
@@ -1,0 +1,30 @@
+---
+title: Couchbase
+---
+
+Send processed data from Unstructured to Couchbase.
+
+The requirements are as follows.
+
+import CouchbasePrerequisites from '/snippets/general-shared-text/couchbase.mdx';
+
+<CouchbasePrerequisites />
+
+To create or change a Couchbase destination connector, see the following examples.
+
+import CouchbaseAPIRESTCreate from '/snippets/destination_connectors/couchbase_rest_create.mdx';
+import CouchbaseAPIRESTChange from '/snippets/destination_connectors/couchbase_rest_change.mdx';
+
+<CodeGroup>
+    <CouchbaseAPIRESTCreate />
+    <CouchbaseAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import CouchbaseAPIPlaceholders from '/snippets/general-shared-text/couchbase-api-placeholders.mdx';
+
+<CouchbaseAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/destinations/overview.mdx
+++ b/platform/api/destinations/overview.mdx
@@ -15,6 +15,7 @@ For the list of specific settings, see:
 
 - [Astra DB](/platform/api/destinations/astradb) (`destination_type=astradb`)
 - [Azure AI Search](/platform/api/destinations/azure-ai-search) (`destination_type=azure_ai_search`)
+- [Couchbase](/platform/api/destinations/couchbase) (`destination_type=couchbase`)
 - [Databricks Volumes](/platform/api/destinations/databricks-volumes) (`destination_type=databricks_volumes`)
 - [Delta Table](/platform/api/destinations/delta-table) (`destination_type=delta_table`)
 - [Elasticsearch](/platform/api/destinations/elasticsearch) (`destination_type=elasticsearch`)
@@ -23,6 +24,8 @@ For the list of specific settings, see:
 - [MongoDB](/platform/api/destinations/mongodb) (`destination_type=mongodb`)
 - [OneDrive](/platform/api/destinations/onedrive) (`destination_type=onedrive`)
 - [Pinecone](/platform/api/destinations/pinecone) (`destination_type=pinecone`)
+- [PostgreSQL](/platform/api/destinations/postgresql) (`destination_type=postgres`)
+- [Qdrant](/platform/api/destinations/qdrant) (`destination_type=qdrant`)
 - [S3](/platform/api/destinations/s3) (`destination_type=s3`)
 - [Weaviate](/platform/api/destinations/weaviate) (`destination_type=weaviate`)
 

--- a/platform/api/destinations/postgresql.mdx
+++ b/platform/api/destinations/postgresql.mdx
@@ -1,0 +1,30 @@
+---
+title: PostgreSQL
+---
+
+Send processed data from Unstructured to PostgreSQL.
+
+The requirements are as follows.
+
+import PostgreSQLPrerequisites from '/snippets/general-shared-text/postgresql.mdx';
+
+<PostgreSQLPrerequisites />
+
+To create or change a PostgreSQL destination connector, see the following examples.
+
+import PostgreSQLAPIRESTCreate from '/snippets/destination_connectors/postgresql_rest_create.mdx';
+import PostgreSQLAPIRESTChange from '/snippets/destination_connectors/postgresql_rest_change.mdx';
+
+<CodeGroup>
+    <PostgreSQLAPIRESTCreate />
+    <PostgreSQLAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import PostgreSQLAPIPlaceholders from '/snippets/general-shared-text/postgresql-api-placeholders.mdx';
+
+<PostgreSQLAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/destinations/qdrant.mdx
+++ b/platform/api/destinations/qdrant.mdx
@@ -1,0 +1,30 @@
+---
+title: Qdrant
+---
+
+Send processed data from Unstructured to Qdrant.
+
+The requirements are as follows.
+
+import QdrantPrerequisites from '/snippets/general-shared-text/qdrant.mdx';
+
+<QdrantPrerequisites />
+
+To create or change a Qdrant destination connector, see the following examples.
+
+import QdrantAPIRESTCreate from '/snippets/destination_connectors/qdrant_rest_create.mdx';
+import QdrantAPIRESTChange from '/snippets/destination_connectors/qdrant_rest_change.mdx';
+
+<CodeGroup>
+    <QdrantAPIRESTCreate />
+    <QdrantAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import QdrantAPIPlaceholders from '/snippets/general-shared-text/qdrant-api-placeholders.mdx';
+
+<QdrantAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/sources/couchbase.mdx
+++ b/platform/api/sources/couchbase.mdx
@@ -1,0 +1,30 @@
+---
+title: Couchbase
+---
+
+Ingest your files into Unstructured from Couchbase.
+
+The requirements are as follows.
+
+import CouchbasePrerequisites from '/snippets/general-shared-text/couchbase.mdx';
+
+<CouchbasePrerequisites />
+
+To create or change a Couchbase source connector, see the following examples.
+
+import CouchbaseAPIRESTCreate from '/snippets/source_connectors/couchbase_rest_create.mdx';
+import CouchbaseAPIRESTChange from '/snippets/source_connectors/couchbase_rest_change.mdx';
+
+<CodeGroup>
+    <CouchbaseAPIRESTCreate />
+    <CouchbaseAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import CouchbaseAPIPlaceholders from '/snippets/general-shared-text/couchbase-api-placeholders.mdx';
+
+<CouchbaseAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/sources/dropbox.mdx
+++ b/platform/api/sources/dropbox.mdx
@@ -1,0 +1,30 @@
+---
+title: Dropbox
+---
+
+Ingest your files into Unstructured from Dropbox.
+
+The requirements are as follows.
+
+import DropboxPrerequisites from '/snippets/general-shared-text/dropbox.mdx';
+
+<DropboxPrerequisites />
+
+To create or change a Dropbox source connector, see the following examples.
+
+import DropboxAPIRESTCreate from '/snippets/source_connectors/dropbox_rest_create.mdx';
+import DropboxAPIRESTChange from '/snippets/source_connectors/dropbox_rest_change.mdx';
+
+<CodeGroup>
+    <DropboxAPIRESTCreate />
+    <DropboxAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import DropboxAPIPlaceholders from '/snippets/general-shared-text/dropbox-api-placeholders.mdx';
+
+<DropboxAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/sources/elasticsearch.mdx
+++ b/platform/api/sources/elasticsearch.mdx
@@ -1,0 +1,30 @@
+---
+title: Elasticsearch
+---
+
+Ingest your files into Unstructured from Elasticsearch.
+
+The requirements are as follows.
+
+import ElasticsearchPrerequisites from '/snippets/general-shared-text/elasticsearch.mdx';
+
+<ElasticsearchPrerequisites />
+
+To create or change a Elasticsearch source connector, see the following examples.
+
+import ElasticsearchAPIRESTCreate from '/snippets/source_connectors/elasticsearch_rest_create.mdx';
+import ElasticsearchAPIRESTChange from '/snippets/source_connectors/elasticsearch_rest_change.mdx';
+
+<CodeGroup>
+    <ElasticsearchAPIRESTCreate />
+    <ElasticsearchAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import ElasticsearchAPIPlaceholders from '/snippets/general-shared-text/elasticsearch-api-placeholders.mdx';
+
+<ElasticsearchAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/sources/google-drive.mdx
+++ b/platform/api/sources/google-drive.mdx
@@ -1,0 +1,30 @@
+---
+title: Google Drive
+---
+
+Ingest your files into Unstructured from Google Drive.
+
+The requirements are as follows.
+
+import GoogleDrivePrerequisites from '/snippets/general-shared-text/google-drive.mdx';
+
+<GoogleDrivePrerequisites />
+
+To create or change a Google Drive source connector, see the following examples.
+
+import GoogleDriveAPIRESTCreate from '/snippets/source_connectors/google_drive_rest_create.mdx';
+import GoogleDriveAPIRESTChange from '/snippets/source_connectors/google_drive_rest_change.mdx';
+
+<CodeGroup>
+    <GoogleDriveAPIRESTCreate />
+    <GoogleDriveAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import GoogleDriveAPIPlaceholders from '/snippets/general-shared-text/google-drive-api-placeholders.mdx';
+
+<GoogleDriveAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/platform/api/sources/overview.mdx
+++ b/platform/api/sources/overview.mdx
@@ -14,12 +14,17 @@ To create a source connector, you must also provide a request body that contains
 For the list of specific settings, see:
 
 - [Azure](/platform/api/sources/azure-blob-storage) (`source_type=azure`)
+- [Couchbase](/platform/api/sources/couchbase) (`source_type=couchbase`)
 - [Confluence](/platform/api/sources/confluence) (`source_type=confluence`)
 - [Databricks Volumes](/platform/api/sources/databricks-volumes) (`source_type=databricks_volumes`)
+- [Dropbox](/platform/api/sources/dropbox) (`source_type=dropbox`)
+- [Elasticsearch](/platform/api/sources/elasticsearch) (`source_type=elasticsearch`)
 - [Google Cloud Storage](/platform/api/sources/google-cloud) (`source_type=gcs`)
+- [Google Drive](/platform/api/sources/google-drive) (`source_type=google_drive`)
 - [MongoDB](/platform/api/sources/mongodb) (`source_type=mongodb`)
 - [OneDrive](/platform/api/sources/onedrive) (`source_type=onedrive`)
 - [Outlook](/platform/api/sources/outlook) (`source_type=outlook`)
 - [S3](/platform/api/sources/s3) (`source_type=s3`)
+- [Salesforce](/platform/api/sources/salesforce) (`source_type=salesforce`)
 - [SharePoint](/platform/api/sources/sharepoint) (`source_type=sharepoint`)
 

--- a/platform/api/sources/salesforce.mdx
+++ b/platform/api/sources/salesforce.mdx
@@ -1,0 +1,30 @@
+---
+title: Salesforce
+---
+
+Ingest your files into Unstructured from Salesforce.
+
+The requirements are as follows.
+
+import SalesforcePrerequisites from '/snippets/general-shared-text/salesforce.mdx';
+
+<SalesforcePrerequisites />
+
+To create or change a Salesforce source connector, see the following examples.
+
+import SalesforceAPIRESTCreate from '/snippets/source_connectors/salesforce_rest_create.mdx';
+import SalesforceAPIRESTChange from '/snippets/source_connectors/salesforce_rest_change.mdx';
+
+<CodeGroup>
+    <SalesforceAPIRESTCreate />
+    <SalesforceAPIRESTChange />
+</CodeGroup>
+
+Replace the preceding placeholders as follows:
+
+import SalesforceAPIPlaceholders from '/snippets/general-shared-text/salesforce-api-placeholders.mdx';
+
+<SalesforceAPIPlaceholders />
+
+To change a connector, replace `<connector-id>` with the source connector's unique ID. 
+To get this ID, see [List source connectors](/platform/api/overview#list-source-connectors).

--- a/snippets/destination_connectors/couchbase_rest_change.mdx
+++ b/snippets/destination_connectors/couchbase_rest_change.mdx
@@ -1,0 +1,20 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/destinations/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "username": "<username>",
+        "bucket": "<bucket>",
+        "connection_string": "<connection-string>",
+        "scope": "<scope>",
+        "collection": "<collection>",
+        "password": "<password>",
+        "batch_size": <batch-size>,
+        "collection_id": "<collection-id>"
+    }
+}'
+```

--- a/snippets/destination_connectors/couchbase_rest_create.mdx
+++ b/snippets/destination_connectors/couchbase_rest_create.mdx
@@ -1,0 +1,22 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/destinations" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "couchbase",
+    "config": {
+        "username": "<username>",
+        "bucket": "<bucket>",
+        "connection_string": "<connection-string>",
+        "scope": "<scope>",
+        "collection": "<collection>",
+        "password": "<password>",
+        "batch_size": <batch-size>,
+        "collection_id": "<collection-id>"
+    }
+}'
+```

--- a/snippets/destination_connectors/postgresql_rest_change.mdx
+++ b/snippets/destination_connectors/postgresql_rest_change.mdx
@@ -1,0 +1,19 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/destinations/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "host": "<host>",
+        "database": "<database>",
+        "port": "<port>",
+        "username": "<username>",
+        "password": "<password>",
+        "table_name": "<table-name>",
+        "batch_size": "<batch-size>"
+    }
+}'
+```

--- a/snippets/destination_connectors/postgresql_rest_create.mdx
+++ b/snippets/destination_connectors/postgresql_rest_create.mdx
@@ -1,0 +1,21 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/destinations" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "postgres",
+    "config": {
+        "host": "<host>",
+        "database": "<database>",
+        "port": "<port>",
+        "username": "<username>",
+        "password": "<password>",
+        "table_name": "<table-name>",
+        "batch_size": "<batch-size>"
+    }
+}'
+```

--- a/snippets/destination_connectors/qdrant_rest_change.mdx
+++ b/snippets/destination_connectors/qdrant_rest_change.mdx
@@ -1,0 +1,16 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/destinations/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "url": "<url>",
+        "collection_name": "<collection-name>",
+        "batch_size": "<batch-size>",
+        "api_key": "<api-key>"
+    }
+}'
+```

--- a/snippets/destination_connectors/qdrant_rest_create.mdx
+++ b/snippets/destination_connectors/qdrant_rest_create.mdx
@@ -1,0 +1,18 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/destinations" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "qdrant",
+    "config": {
+        "url": "<url>",
+        "collection_name": "<collection-name>",
+        "batch_size": "<batch-size>",
+        "api_key": "<api-key>"
+    }
+}'
+```

--- a/snippets/general-shared-text/couchbase-api-placeholders.mdx
+++ b/snippets/general-shared-text/couchbase-api-placeholders.mdx
@@ -1,0 +1,9 @@
+- `<name>` (_required_) - A unique name for this connector.
+- `<username>` (_required_) - The username for the Couchbase server.
+- `<bucket>` (_required_) - The name of the bucket in the Couchbase server.
+- `<connection-string>` (_required_) - The connection string for the Couchbase server.
+- `<scope>` - The name of the scope in the bucket. The default is `_default` if not otherwise specified.
+- `<collection>` - The name of the collection in the scope. The default is `_default` if not otherwise specified.
+- `<password>` (_required_) - The password for the Couchbase server.
+- `<batch-size>` - The maximum number of records to transmit per batch. The default is `50` if not otherwise specified.
+- `<collection-id>` - The name of the collection field that contains the document ID. The default is `id` if not otherwise specified.

--- a/snippets/general-shared-text/dropbox-api-placeholders.mdx
+++ b/snippets/general-shared-text/dropbox-api-placeholders.mdx
@@ -1,0 +1,4 @@
+- `<name>` (_required_) - A unique name for this connector.
+- `<token>` - The value of your access token
+- `<remote-url>` - The remote URL to the target folder
+- Set `recursive` to `true` to recursively process data from subfolders within the target folder. The default is `false` if not otherwise specified.

--- a/snippets/general-shared-text/google-drive-api-placeholders.mdx
+++ b/snippets/general-shared-text/google-drive-api-placeholders.mdx
@@ -1,0 +1,5 @@
+- `<name>` (_required_) - A unique name for this connector.
+- `<drive-id>` - The ID for the target Google Drive folder.
+- `<service-account-key>` - The contents of the `credentials.json` key file as a single-line string.
+- For `extensions`, set one or more `<extension>` values (such as `.pdf` or `.docx`) to process files with only those extensions. The default is to include all extensions.
+- Set `recursive` to `true` to recursively process data from subfolders within the target folder. The default is `false` if not otherwise specified.

--- a/snippets/general-shared-text/postgresql-api-placeholders.mdx
+++ b/snippets/general-shared-text/postgresql-api-placeholders.mdx
@@ -1,0 +1,8 @@
+- `<name>` (required) - A unique name for this connector.
+- `<host>` (required) - The host name.
+- `<database>` (required) - The name of the database.
+- `<port>` (required) - The port number.
+- `<username>` (required) - The username.
+- `<password>` (required) - The user's password.
+- `<table-name>` (required) - The name of the table in the database.
+- `<batch-size>` - The maximum number of rows to transmit at a time. The default is `100` if not otherwise specified. 

--- a/snippets/general-shared-text/qdrant-api-placeholders.mdx
+++ b/snippets/general-shared-text/qdrant-api-placeholders.mdx
@@ -1,0 +1,5 @@
+- `<name>` (required) - A unique name for this connector.
+- `<url>` (required) - The Qdrant cluster's URL.
+- `<collection-name>` (required) - The name of the target collection on the Qdrant cluster.
+- `<batch-size>` - The maximum number of records to transmit at a time. The default is `50` if not otherwise specified.
+- `<api-key>` (required) - The Qdrant API key.

--- a/snippets/general-shared-text/salesforce-api-placeholders.mdx
+++ b/snippets/general-shared-text/salesforce-api-placeholders.mdx
@@ -1,0 +1,6 @@
+- `<name>` (_required_) - A unique name for this connector.
+- `<user-name>` - The Salesforce username that has access to the required Salesforce categories.
+- `<consumer-key>` - The consumer key (client ID) for the Salesforce connected app.
+- `<private-key>` - The contents of the private key (PEM) associated with the consumer key for the Salesforce connected app, expressed as a single-line string.
+- For `categories`, set one or more `<category>` values (such as `Account`, `Campaign`, `Case`, `EmailMessage`, and `Lead`) to process only those categories. 
+  The default is to include these catagories if not otherwise specified: `Account`, `Campaign`, `Case`, `EmailMessage`, and `Lead`.

--- a/snippets/source_connectors/couchbase_rest_change.mdx
+++ b/snippets/source_connectors/couchbase_rest_change.mdx
@@ -1,0 +1,20 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/sources/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "username": "<username>",
+        "bucket": "<bucket>",
+        "connection_string": "<connection-string>",
+        "scope": "<scope>",
+        "collection": "<collection>",
+        "password": "<password>",
+        "batch_size": <batch-size>,
+        "collection_id": "<collection-id>"
+    }
+}'
+```

--- a/snippets/source_connectors/couchbase_rest_create.mdx
+++ b/snippets/source_connectors/couchbase_rest_create.mdx
@@ -1,0 +1,22 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/sources" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "couchbase",
+    "config": {
+        "username": "<username>",
+        "bucket": "<bucket>",
+        "connection_string": "<connection-string>",
+        "scope": "<scope>",
+        "collection": "<collection>",
+        "password": "<password>",
+        "batch_size": <batch-size>,
+        "collection_id": "<collection-id>"
+    }
+}'
+```

--- a/snippets/source_connectors/dropbox_rest_change.mdx
+++ b/snippets/source_connectors/dropbox_rest_change.mdx
@@ -1,0 +1,15 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/sources/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "token": "<token>",
+        "remote_url": "<remote-url>",
+        "recursive": <true|false>
+    }
+}'
+```

--- a/snippets/source_connectors/dropbox_rest_create.mdx
+++ b/snippets/source_connectors/dropbox_rest_create.mdx
@@ -1,0 +1,17 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/sources" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "dropbox",
+    "config": {
+        "token": "<token>",
+        "remote_url": "<remote-url>",
+        "recursive": <true|false>
+    }
+}'
+```

--- a/snippets/source_connectors/elasticsearch_rest_change.mdx
+++ b/snippets/source_connectors/elasticsearch_rest_change.mdx
@@ -1,0 +1,15 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/sources/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "hosts": ["<host-url>"],
+        "es_api_key": "<es-api-key>",
+        "index_name": "<index-name>"
+    }
+}'
+```

--- a/snippets/source_connectors/elasticsearch_rest_create.mdx
+++ b/snippets/source_connectors/elasticsearch_rest_create.mdx
@@ -1,0 +1,17 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/sources" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "elasticsearch",
+    "config": {
+        "hosts": ["<host-url>"],
+        "es_api_key": "<es-api-key>",
+        "index_name": "<index-name>"
+    }
+}'
+```

--- a/snippets/source_connectors/google_drive_rest_change.mdx
+++ b/snippets/source_connectors/google_drive_rest_change.mdx
@@ -1,0 +1,19 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/sources/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "drive_id": "<drive-id>",
+        "service_account_key": "<service-account-key>",
+        "extensions": [
+            "<extension>",
+            "<extension>"
+        ],
+        "recursive": <true|false>
+    }
+}'
+```

--- a/snippets/source_connectors/google_drive_rest_create.mdx
+++ b/snippets/source_connectors/google_drive_rest_create.mdx
@@ -1,0 +1,21 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/sources" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "google_drive",
+    "config": {
+        "drive_id": "<drive-id>",
+        "service_account_key": "<service-account-key>",
+        "extensions": [
+            "<extension>",
+            "<extension>"
+        ],
+        "recursive": <true|false>
+    }
+}'
+```

--- a/snippets/source_connectors/salesforce_rest_change.mdx
+++ b/snippets/source_connectors/salesforce_rest_change.mdx
@@ -1,0 +1,19 @@
+```bash REST (Change)
+curl --request 'PUT' --location \
+"$UNSTRUCTURED_API_URL/sources/<connector-id>" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "config": {
+        "username": "<user-name>",
+        "consumer_key": "<consumer-key>",
+        "private_key": "<private-key>",
+        "categories": [
+            "<category>",
+            "<category>"
+        ]
+    }
+}'
+```

--- a/snippets/source_connectors/salesforce_rest_create.mdx
+++ b/snippets/source_connectors/salesforce_rest_create.mdx
@@ -1,0 +1,21 @@
+```bash REST (Create)
+curl --request 'POST' --location \
+"$UNSTRUCTURED_API_URL/sources" \
+--header 'accept: application/json' \
+--header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+--header 'content-type: application/json' \
+--data \
+'{
+    "name": "<name>",
+    "type": "salesforce",
+    "config": {
+        "username": "<user-name>",
+        "consumer_key": "<consumer-key>",
+        "private_key": "<private-key>",
+        "categories": [
+            "<category>",
+            "<category>"
+        ]
+    }
+}'
+```


### PR DESCRIPTION
There were several errors in the Platform API reference docs that were published earlier today, now that I'm able to actually fully test the production endpoints. This is the second of two follow-on PRs to address these errors. 

Specifically, this PR is to backfill instructions for creating some of the source and destination connectors that are missing, as these connectors were brought online just a few days ago. The field names for these connectors do not match 1:1 with the related labels in the UI, and they are not exposed in the Swagger UI either, so without these docs it is almost impossible to figure them out. These are:

- Sources: 

  - Couchbase
  - Dropbox
  - Elasticsearch
  - Google Drive
  - Salesforce
  
- Destinations: 

  - Couchbase
  - PostgreSQL
  - Qdrant