### PR TITLE
Tools demos: use prompt engineering to limit RAG context

### DIFF
--- a/examplecode/tools/langflow.mdx
+++ b/examplecode/tools/langflow.mdx
@@ -142,6 +142,26 @@ Also:
            Answer: 
            ```
 
+           <Tip>
+               To answer the question, the preceding prompt uses the context along with general information that the text-based LLM is 
+               trained on. To use only the context to answer the question, you can change the prompt, for example to something like this:
+
+               ```text
+               {context}
+
+               ---
+
+               Given the context above, answer the question as best as possible. Use only the context to answer the question. Do not use 
+               any other sources of information. If the context does not provide enough information to answer the question, reply with 
+               'I do not have enough context to answer the question.'
+
+               Question: {question}
+
+               Answer:
+               ```
+
+           </Tip>
+
         4. Click **Check & Save**.
 
            ![Prompt component](/img/langflow/edit-prompt.png)

--- a/examplecode/tools/vectorshift.mdx
+++ b/examplecode/tools/vectorshift.mdx
@@ -103,6 +103,19 @@ Also:
            Answer the Question based on Context. Use Memory when relevant.
            ```
 
+           <Tip>
+               To answer the question, the preceding prompt uses the context along with general information that the text-based LLM is 
+               trained on. To use only the context to answer the question, you can change the prompt, for example to something like this:
+
+               ```text
+               Answer the Question based only on the Context. Do not use any other sources of
+               information. If the context does not provide enough information to answer the 
+               question, reply with 'I do not have enough context to answer the question.' 
+               Use Memory when relevant.
+               ```
+
+           </Tip>
+
         3. For **Prompt**, enter the following text:
 
            ```


### PR DESCRIPTION
For example, for Langflow:

<img width="642" alt="Screenshot 2025-01-13 at 4 36 48 PM" src="https://github.com/user-attachments/assets/612c8083-7c7e-4292-8379-2ac9f06777ee" />

And for VectorShift:

<img width="639" alt="Screenshot 2025-01-13 at 4 37 00 PM" src="https://github.com/user-attachments/assets/8c97ec2b-f9ae-4223-8191-e0608a480cbc" />
