### PR TITLE
Box connectors: now also accepts a single-line string containing the related app's private key file contents

### DIFF
--- a/snippets/destination_connectors/box.sh.mdx
+++ b/snippets/destination_connectors/box.sh.mdx
@@ -14,6 +14,6 @@ unstructured-ingest \
     --verbose \
     --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}" \
   box \
-    --box-app-config $BOX_APP_CONFIG_PATH \
+    --box-app-config $BOX_APP_CONFIG \
     --remote-url $BOX_REMOTE_URL
 ```

--- a/snippets/destination_connectors/box.v1.py.mdx
+++ b/snippets/destination_connectors/box.v1.py.mdx
@@ -24,7 +24,7 @@ from unstructured_ingest.runner.writers.fsspec.box import (
 def get_writer() -> Writer:
     return BoxWriter(
         connector_config=SimpleBoxConfig(
-            access_config=BoxAccessConfig(box_app_config=os.getenv("BOX_APP_CONFIG_PATH")),
+            access_config=BoxAccessConfig(box_app_config=os.getenv("BOX_APP_CONFIG")),
             remote_url=os.getenv("BOX_REMOTE_URL"),
         ),
         write_config=BoxWriteConfig(),

--- a/snippets/destination_connectors/box.v2.py.mdx
+++ b/snippets/destination_connectors/box.v2.py.mdx
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         destination_connection_config=BoxConnectionConfig(
             access_config=BoxAccessConfig(
-                box_app_config=os.getenv("BOX_APP_CONFIG_PATH")
+                box_app_config=os.getenv("BOX_APP_CONFIG")
             )
         ),
         uploader_config=BoxUploaderConfig(

--- a/snippets/general-shared-text/box-cli-api.mdx
+++ b/snippets/general-shared-text/box-cli-api.mdx
@@ -10,5 +10,6 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 The following environment variables:
 
-- `BOX_APP_CONFIG_PATH` - The local path to the downloaded private key configuration JSON file for the Box Custom App, represented by `--box-app-config` (CLI) or `box_app_config` (Python).
+- `BOX_APP_CONFIG` - The local path to the downloaded private key configuration JSON file for the Box Custom App, 
+   or a single-line string that contains the contents of this file, represented by `--box-app-config` (CLI) or `box_app_config` (Python).
 - `BOX_REMOTE_URL` - The remote URL to the target folder, represented by `--remote-url` (CLI) or `remote_url` (Python).

--- a/snippets/general-shared-text/box.mdx
+++ b/snippets/general-shared-text/box.mdx
@@ -16,4 +16,22 @@
    - **Share** your Box account's target folder with the copied service account's email address as a **Co-owner** or **Editor**. 
    - Note the remote URL to the target folder, which takes the format `box://<path/to/folder/in/account>`.
 
-6. The private key configuration JSON file for the Box Custom App. To download this file, in the Box Custom App, on the **Configuration** tab, under **Add and Manage Public Keys**, click **Generate a Public/Private Keypair**. Store the downloaded private key configuration JSON file in a secure location. Do not share it with others.
+6. The private key configuration JSON file for the Box Custom App, or a string that contains this file's contents.
+
+   - To download this file, in the Box Custom App, on the **Configuration** tab, under **Add and Manage Public Keys**, click **Generate a Public/Private Keypair**. Store the downloaded private key configuration JSON file in a secure location.
+   - To ensure maximum compatibility across Unstructured service offerings, you should give the private key configuration JSON file information to Unstructured as 
+   a single-line string that contains the contents of the downloaded private key configuration JSON file (and not the file itself). 
+   To print this single-line string, suitable for copying, you can run one of the following commands from your Terminal or Command Prompt. 
+   In this command, replace `<path-to-downloaded-key-file>` with the path to the private key configuration JSON file that you downloaded by following the preceding instructions.
+
+     - For macOS or Linux: 
+
+       ```text
+       tr -d '\n' < <path-to-downloaded-key-file>
+       ```
+
+     - For Windows:
+
+       ```text
+       (Get-Content -Path "<path-to-downloaded-key-file>" -Raw).Replace("`r`n", "").Replace("`n", "")
+       ```

--- a/snippets/source_connectors/box.sh.mdx
+++ b/snippets/source_connectors/box.sh.mdx
@@ -3,7 +3,7 @@
 
 unstructured-ingest \
   box \
-    --box-app-config $BOX_APP_CONFIG_PATH \
+    --box-app-config $BOX_APP_CONFIG \
     --remote-url $BOX_REMOTE_URL \
     --output-dir $LOCAL_FILE_OUTPUT_DIR \
     --num-processes 2 \

--- a/snippets/source_connectors/box.v1.py.mdx
+++ b/snippets/source_connectors/box.v1.py.mdx
@@ -27,7 +27,7 @@ if __name__ == "__main__":
             remote_url=os.getenv("BOX_REMOTE_URL"),
             recursive=True,
             access_config=BoxAccessConfig(
-                box_app_config=os.getenv("BOX_APP_CONFIG_PATH")
+                box_app_config=os.getenv("BOX_APP_CONFIG")
             ),
         ),
     )

--- a/snippets/source_connectors/box.v2.py.mdx
+++ b/snippets/source_connectors/box.v2.py.mdx
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         downloader_config=BoxDownloaderConfig(download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")),
         source_connection_config=BoxConnectionConfig(
             access_config=BoxAccessConfig(
-                box_app_config=os.getenv("BOX_APP_CONFIG_PATH")
+                box_app_config=os.getenv("BOX_APP_CONFIG")
             )
         ),
         partitioner_config=PartitionerConfig(


### PR DESCRIPTION
See: 

- https://unstructured-53-docs-115-box-ingest.mintlify.app/api-reference/ingest/source-connectors/box
- https://unstructured-53-docs-115-box-ingest.mintlify.app/api-reference/ingest/destination-connector/box
- https://unstructured-53-docs-115-box-ingest.mintlify.app/open-source/ingest/source-connectors/box
- https://unstructured-53-docs-115-box-ingest.mintlify.app/open-source/ingest/destination-connectors/box