### PR TITLE
PostgreSQL and Couchbase connectors: fix up third-party links

### DIFF
--- a/snippets/general-shared-text/couchbase.mdx
+++ b/snippets/general-shared-text/couchbase.mdx
@@ -15,18 +15,21 @@ import AllowIPAddressRanges from '/snippets/general-shared-text/ip-address-range
 
 For Couchbase Capella, you will need:
 
-- A Couchbase Capella account. [Create an account](https://docs.couchbase.com/cloud/get-started/create-account.html).
-- A Couchbase Capella cluster. [Create a cluster](https://docs.couchbase.com/cloud/clusters/create-database.html).
-- A [bucket, scope, and collection](https://docs.couchbase.com/cloud/clusters/data-service/about-buckets-scopes-collections.html).  
-- A cluster connection string. [Learn how](https://docs.couchbase.com/cloud/get-started/connect.html).
-- A username and password. [Learn how](https://docs.couchbase.com/cloud/clusters/manage-database-users.html).
-- Incoming IP address allowance. [Learn how](https://docs.couchbase.com/cloud/clusters/allow-ip-address.html).
+- A [Couchbase Capella account](https://docs.couchbase.com/cloud/get-started/create-account.html#sign-up-free-tier).
+- A [Couchbase Capella cluster](https://docs.couchbase.com/cloud/get-started/create-account.html#getting-started).
+- A [bucket](https://docs.couchbase.com/cloud/clusters/data-service/manage-buckets.html#add-bucket), 
+  [scope](https://docs.couchbase.com/cloud/clusters/data-service/scopes-collections.html#create-scope), 
+  and [collection](https://docs.couchbase.com/cloud/clusters/data-service/scopes-collections.html#create-collection) 
+  on the cluster.  
+- The cluster's [public connection string](https://docs.couchbase.com/cloud/get-started/connect.html#connect-from-sdk-cbsh-cli-or-ide).
+- The [cluster access name (username) and secret (password)](https://docs.couchbase.com/cloud/clusters/manage-database-users.html#create-database-credentials).
+- [Incoming IP address allowance](https://docs.couchbase.com/cloud/clusters/allow-ip-address.html) for the cluster.
 
   <AllowIPAddressRanges />
 
 For a local Couchbase server, you will need:
 
-- Installation of a local Couchbase server. [Learn how](https://docs.couchbase.com/server/current/getting-started/start-here.html).
-- Connection details to the local Couchbase server. [Learn how](https://docs.couchbase.com/server/current/guides/connect.html).
+- [Installation of a local Couchbase server](https://docs.couchbase.com/server/current/getting-started/start-here.html).
+- [Connection details](https://docs.couchbase.com/server/current/guides/connect.html) to the local Couchbase server.
 
 To learn more about how to set up a Couchbase cluster and play with data, refer to this [tutorial](https://developer.couchbase.com/tutorial-quickstart-flask-python).

--- a/snippets/general-shared-text/postgresql.mdx
+++ b/snippets/general-shared-text/postgresql.mdx
@@ -36,7 +36,7 @@ import AllowIPAddressRanges from '/snippets/general-shared-text/ip-address-range
 - The host name and port number for the instance. 
 
   - For Amazon RDS for PostgreSQL, learn how to [get the host name and port number](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToPostgreSQLInstance.html#postgresql-endpoint).
-  - For Azure Database for PostgreSQL, learn how to [get the host](https://learn.microsoft.com/azure/postgresql/flexible-server/quickstart-create-server-portal#connect-to-the-azure-database-for-postgresql-flexible-server-database-using-psql). The port number is `5432`.
+  - For Azure Database for PostgreSQL, learn how to [get the host](https://learn.microsoft.com/azure/postgresql/flexible-server/quickstart-create-server#get-the-connection-information). The port number is `5432`.
   - For local PostgreSQL installations, these values are in the `postgresql.conf` file's `listen_addresses` and `port` settings. This file should be on the same machine as the instance. These values might also already be set as environment variables named `PGHOST` and `PGPORT` on the same machine as the instance. 
   - For other installation types, see your PostgreSQL provider's documentation.
 


### PR DESCRIPTION
Reducing some visual clutter for links, and fixing one link target.

See for example:

- https://unstructured-53-postgresql-connect-links-2025-01-21.mintlify.app/platform/sources/couchbase
- https://unstructured-53-postgresql-connect-links-2025-01-21.mintlify.app/platform/sources/postgresql