### PR TITLE
Platform: Neo4j destination connector - add graph output coverage

### DIFF
--- a/platform/api/destinations/neo4j.mdx
+++ b/platform/api/destinations/neo4j.mdx
@@ -10,6 +10,12 @@ import Neo4jPrerequisites from '/snippets/general-shared-text/neo4j.mdx';
 
 <Neo4jPrerequisites />
 
+## Graph Output
+
+import Neo4jGraphFormat from '/snippets/general-shared-text/neo4j-graph.mdx';
+
+<Neo4jGraphFormat />
+
 To create or change a Neo4j destination connector, see the following examples.
 
 import Neo4jAPIRESTCreate from '/snippets/destination_connectors/neo4j_rest_create.mdx';

--- a/platform/destinations/neo4j.mdx
+++ b/platform/destinations/neo4j.mdx
@@ -10,6 +10,12 @@ import Neo4jPrerequisites from '/snippets/general-shared-text/neo4j.mdx';
 
 <Neo4jPrerequisites />
 
+## Graph Output
+
+import Neo4jGraphFormat from '/snippets/general-shared-text/neo4j-graph.mdx';
+
+<Neo4jGraphFormat />
+
 To create the destination connector:
 
 1. On the sidebar, click **Connectors**.


### PR DESCRIPTION
Forgot to include coverage about Neo4j graph output to the Platform docs. 

See: 

- https://unstructured-53-neo4j-graph-output-2025-01-23.mintlify.app/platform/destinations/neo4j#graph-output
- https://unstructured-53-neo4j-graph-output-2025-01-23.mintlify.app/platform/api/destinations/neo4j#graph-output
