### PR TITLE
Ingest v2: Delta Tables in Databricks destination connector: fixing misspelled namespaces

### DIFF
--- a/snippets/destination_connectors/databricks_delta_table_sql_based.v2.py.mdx
+++ b/snippets/destination_connectors/databricks_delta_table_sql_based.v2.py.mdx
@@ -5,10 +5,10 @@ from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
 from unstructured_ingest.v2.processes.connectors.sql.databricks_delta_tables import (
-    DatabrickDeltaTablesConnectionConfig,
-    DatabrickDeltaTablesAccessConfig,
-    DatabrickDeltaTablesUploadStagerConfig,
-    DatabrickDeltaTablesUploaderConfig
+    DatabricksDeltaTablesConnectionConfig,
+    DatabricksDeltaTablesAccessConfig,
+    DatabricksDeltaTablesUploadStagerConfig,
+    DatabricksDeltaTablesUploaderConfig
 )
 
 from unstructured_ingest.v2.processes.connectors.local import (
@@ -44,8 +44,8 @@ if __name__ == "__main__":
         embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         
         # For authenticating with Databricks personal access tokens.
-        destination_connection_config=DatabrickDeltaTablesConnectionConfig(
-            access_config=DatabrickDeltaTablesAccessConfig(
+        destination_connection_config=DatabricksDeltaTablesConnectionConfig(
+            access_config=DatabricksDeltaTablesAccessConfig(
                 token=os.getenv("DATABRICKS_TOKEN"),
             ),
             server_hostname=os.getenv("DATABRICKS_HOST"),
@@ -53,8 +53,8 @@ if __name__ == "__main__":
         ),
 
         # For authenticating with Databricks managed service principals.
-        # destination_connection_config=DatabrickDeltaTablesConnectionConfig(
-        #     access_config=DatabrickDeltaTablesAccessConfig(
+        # destination_connection_config=DatabricksDeltaTablesConnectionConfig(
+        #     access_config=DatabricksDeltaTablesAccessConfig(
         #         client_id=os.getenv("DATABRICKS_CLIENT_ID"),
         #         client_secret=os.getenv("DATABRICKS_CLIENT_SECRET")
         #     ),
@@ -62,8 +62,8 @@ if __name__ == "__main__":
         #     http_path=os.getenv("DATABRICKS_HTTP_PATH")
         # ),
 
-        stager_config=DatabrickDeltaTablesUploadStagerConfig(),
-        uploader_config=DatabrickDeltaTablesUploaderConfig(
+        stager_config=DatabricksDeltaTablesUploadStagerConfig(),
+        uploader_config=DatabricksDeltaTablesUploaderConfig(
             catalog=os.getenv("DATABRICKS_CATALOG"),
             database=os.getenv("DATABRICKS_DATABASE"),
             table_name=os.getenv("DATABRICKS_TABLE"),

--- a/snippets/destination_connectors/databricks_delta_table_volume_based.v2.py.mdx
+++ b/snippets/destination_connectors/databricks_delta_table_volume_based.v2.py.mdx
@@ -5,9 +5,9 @@ from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
 from unstructured_ingest.v2.processes.connectors.sql.databricks_delta_tables import (
-    DatabrickDeltaTablesConnectionConfig,
-    DatabrickDeltaTablesAccessConfig,
-    DatabrickDeltaTablesUploadStagerConfig
+    DatabricksDeltaTablesConnectionConfig,
+    DatabricksDeltaTablesAccessConfig,
+    DatabricksDeltaTablesUploadStagerConfig
 )
 
 from unstructured_ingest.v2.processes.connectors.databricks.volumes_table import (
@@ -45,8 +45,8 @@ if __name__ == "__main__":
         embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         
         # For authenticating with Databricks personal access tokens.
-        destination_connection_config=DatabrickDeltaTablesConnectionConfig(
-            access_config=DatabrickDeltaTablesAccessConfig(
+        destination_connection_config=DatabricksDeltaTablesConnectionConfig(
+            access_config=DatabricksDeltaTablesAccessConfig(
                 token=os.getenv("DATABRICKS_TOKEN"),
             ),
             server_hostname=os.getenv("DATABRICKS_HOST"),
@@ -54,8 +54,8 @@ if __name__ == "__main__":
         ),
 
         # For authenticating with Databricks managed service principals.
-        # destination_connection_config=DatabrickDeltaTablesConnectionConfig(
-        #     access_config=DatabrickDeltaTablesAccessConfig(
+        # destination_connection_config=DatabricksDeltaTablesConnectionConfig(
+        #     access_config=DatabricksDeltaTablesAccessConfig(
         #         client_id=os.getenv("DATABRICKS_CLIENT_ID"),
         #         client_secret=os.getenv("DATABRICKS_CLIENT_SECRET")
         #     ),
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         #     http_path=os.getenv("DATABRICKS_HTTP_PATH")
         # ),
 
-        stager_config=DatabrickDeltaTablesUploadStagerConfig(),
+        stager_config=DatabricksDeltaTablesUploadStagerConfig(),
         uploader_config=DatabricksVolumeDeltaTableUploaderConfig(
             catalog=os.getenv("DATABRICKS_CATALOG"),
             schema=os.getenv("DATABRICKS_SCHEMA"),


### PR DESCRIPTION
These were originally misspelled in the source code (`Databrick` instead of `Databricks`). The source code has since been fixed--so fixing it here, too.