### PR TITLE
Ingest v2: Elasticsearch and OpenSearch connectors - namespace updates

### DIFF
--- a/snippets/destination_connectors/elasticsearch.v2.py.mdx
+++ b/snippets/destination_connectors/elasticsearch.v2.py.mdx
@@ -4,7 +4,7 @@ import os
 from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured_ingest.v2.processes.connectors.elasticsearch import (
+from unstructured_ingest.v2.processes.connectors.elasticsearch.elasticsearch.elasticsearch.elasticsearch.elasticsearch.elasticsearch.elasticsearch import (
     ElasticsearchConnectionConfig,
     ElasticsearchAccessConfig,
     ElasticsearchUploadStagerConfig,

--- a/snippets/destination_connectors/opensearch.v2.py.mdx
+++ b/snippets/destination_connectors/opensearch.v2.py.mdx
@@ -4,7 +4,7 @@ import os
 from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured_ingest.v2.processes.connectors.opensearch import (
+from unstructured_ingest.v2.processes.connectors.elasticsearch.opensearch import (
     OpenSearchConnectionConfig,
     OpenSearchAccessConfig,
     OpensearchUploadStagerConfig,

--- a/snippets/source_connectors/elasticsearch.v2.py.mdx
+++ b/snippets/source_connectors/elasticsearch.v2.py.mdx
@@ -4,7 +4,7 @@ import os
 from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured_ingest.v2.processes.connectors.elasticsearch import (
+from unstructured_ingest.v2.processes.connectors.elasticsearch.elasticsearch import (
     ElasticsearchIndexerConfig,
     ElasticsearchDownloaderConfig,
     ElasticsearchConnectionConfig,

--- a/snippets/source_connectors/opensearch.v2.py.mdx
+++ b/snippets/source_connectors/opensearch.v2.py.mdx
@@ -4,7 +4,7 @@ import os
 from unstructured_ingest.v2.pipeline.pipeline import Pipeline
 from unstructured_ingest.v2.interfaces import ProcessorConfig
 
-from unstructured_ingest.v2.processes.connectors.opensearch import (
+from unstructured_ingest.v2.processes.connectors.elasticsearch.opensearch import (
     OpensearchIndexerConfig,
     OpensearchDownloaderConfig,
     OpenSearchConnectionConfig,


### PR DESCRIPTION
- `....elasticsearch` -> `....elasticsearch.elasticsearch`
- `....opensearch` -> `....elasticsearch.opensearch`