### PR TITLE
[Hold] Weaviate destination connector: collection management behavior updates

### DIFF
--- a/snippets/general-shared-text/weaviate-api-placeholders.mdx
+++ b/snippets/general-shared-text/weaviate-api-placeholders.mdx
@@ -1,4 +1,5 @@
 - `<name>` (_required_) - A unique name for this connector.
 - `<host-url>` (_required_) - The URL of the Weaviate database cluster.
-- `<class-name>` (_required_) - The name of the target collection within the cluster.
+- `<class-name>` - The name of the target collection within the cluster. If no value is provided, see the beginning of this article 
+  for the behavior at run time.
 - `<api-key>` (_required_) - The API key provided by Weaviate to access the cluster.

--- a/snippets/general-shared-text/weaviate-cli-api.mdx
+++ b/snippets/general-shared-text/weaviate-cli-api.mdx
@@ -14,7 +14,8 @@ The following environment variables:
 - For Embedded Weaviate:
 
   - `WEAVIATE_HOST` - The connection URL to the instance, represented by `--hostname` (CLI) or `hostname` (Python).
-  - `WEAVIATE_COLLECTION` - The name of the target collection in the instance, represented by `--collection` (CLI) or `collection` (Python).
+  - `WEAVIATE_COLLECTION` - The name of the target collection in the instance, represented by `--collection` (CLI) or `collection` (Python). 
+    If no value is provided, see the beginning of this article for the behavior at run time.
 
 - For Weaviate Cloud:
 
@@ -23,4 +24,5 @@ The following environment variables:
 
     <Note>For the CLI, the `--api-key` option here is part of the `weaviate-cloud` command. For Python, the `api_key` parameter here is part of the `CloudWeaviateAccessConfig` object.</Note>
 
-  - `WEAVIATE_COLLECTION` - The name of the target collection in the database, represented by `--collection` (CLI) or `collection` (Python).
+  - `WEAVIATE_COLLECTION` - The name of the target collection in the database, represented by `--collection` (CLI) or `collection` (Python). 
+    If no value is provided, see the beginning of this article for the behavior at run time.

--- a/snippets/general-shared-text/weaviate-platform.mdx
+++ b/snippets/general-shared-text/weaviate-platform.mdx
@@ -2,5 +2,6 @@ Fill in the following fields:
 
 - **Name** (_required_): A unique name for the connector.
 - **Cluster URL** (_required_): The URL of the Weaviate database cluster.
-- **Collection Name** (_required_): The name of the target collection within the cluster.
+- **Collection Name**: The name of the target collection within the cluster. If no value is provided, see the beginning of this article 
+  for the behavior at run time.
 - **API Key** (_required_): The API key provided by Weaviate to access the cluster.

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -29,8 +29,8 @@
       but the number of dimensions that are generated does not match the existing collection's embedding settings, the run will fail. 
       You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again.
     - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. If Unstructured generates embeddings, 
-      the new collection's name will be `Unstructured_<random-8-digit-number>_<embedding-model-name>_<number-of-dimensions>`. 
-      If Unstructured does not generate embeddings, the new collection's name will be `Unstructured_<random-8-digit-number>`.
+      the new collection's name will be `u<short-workflow-id>_<short-embedding-model-name>_<number-of-dimensions>`. 
+      If Unstructured does not generate embeddings, the new collection's name will be `u<short-workflow-id`.
 
     For [Unstructured Ingest](/ingestion/overview):
 

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -39,6 +39,26 @@
       You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again. 
     - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. The new collection's name will be `Elements`.
 
+    If Unstructured creates a new collection and generates embeddings, you will not see an embeddings property in tools such as the Weaviate Cloud 
+    **Collections** user interface. To view the generated embeddings, you can run a Weaviate GraphQL query such as the following. In this query, replace `<collection-name>` with 
+    the name of the new collection, and replace `<property-name>` with the name of each additional available property that 
+    you want to return results for, such as `text`, `type`, `element_id`, `record_id`, and so on. The embeddings will be 
+    returned in the `vector` property.
+
+    ```text
+    {
+      Get {
+        <collection-name> {
+          _additional {
+            vector
+          }
+          <property-name>
+          <property-name>
+        }
+      }
+    }
+    ```
+
 Weaviate requires an existing collection to have a data schema before you add data. At minimum, this schema must contain the `record_id` property, as follows:
 
 ```json

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -19,9 +19,27 @@
   - A Weaviate database instance. The following information assumes that you have a Weaviate Cloud (WCD) account with a Weaviate database cluster in that account. 
     [Create a WCD account](https://weaviate.io/developers/wcs/quickstart#create-a-wcd-account). [Create a database cluster](https://weaviate.io/developers/wcs/quickstart#create-a-weaviate-cluster). For other database options, [learn more](https://weaviate.io/developers/weaviate/installation).
   - The URL and API key for the database cluster. [Get the URL and API key](https://weaviate.io/developers/wcs/quickstart#explore-the-details-panel).
-  - The name of the target collection in the database. [Create a collection](https://weaviate.io/developers/wcs/tools/collections-tool).
+  - The name of the target collection in the database. [Create a collection](https://weaviate.io/developers/wcs/tools/collections-tool). 
+    
+    An existing collection is not required. At runtime, the collection behavior is as follows:
 
-Weaviate requires the collection to have a data schema before you add data. At minimum, this schema must contain the `record_id` property, as follows:
+    For the [Unstructured Platform](/platform/overview):
+    
+    - If an existing collection name is specified, and Unstructured generates embeddings, 
+      but the number of dimensions that are generated do not match the existing collection's embedding settings, the run will fail. 
+      You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again.
+    - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. If Unstructured generates embeddings, 
+      the new collection's name will be `Unstructured_<random-8-digit-number>_<embedding-model-name>_<number-of-dimensions>`. 
+      If Unstructured does not generate embeddings, the new collection's name will be `Unstructured_<random-8-digit-number>`.
+
+    For [Unstructured Ingest](/ingestion/overview):
+
+    - If an existing collection name is specified, and Unstructured generates embeddings, 
+      but the number of dimensions that are generated do not match the existing collection's embedding settings, the run will fail. 
+      You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again. 
+    - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. The new collection's name will be `Elements`.
+
+Weaviate requires an existing collection to have a data schema before you add data. At minimum, this schema must contain the `record_id` property, as follows:
 
 ```json
 {

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -26,7 +26,7 @@
     For the [Unstructured Platform](/platform/overview):
     
     - If an existing collection name is specified, and Unstructured generates embeddings, 
-      but the number of dimensions that are generated do not match the existing collection's embedding settings, the run will fail. 
+      but the number of dimensions that are generated does not match the existing collection's embedding settings, the run will fail. 
       You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again.
     - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. If Unstructured generates embeddings, 
       the new collection's name will be `Unstructured_<random-8-digit-number>_<embedding-model-name>_<number-of-dimensions>`. 
@@ -35,7 +35,7 @@
     For [Unstructured Ingest](/ingestion/overview):
 
     - If an existing collection name is specified, and Unstructured generates embeddings, 
-      but the number of dimensions that are generated do not match the existing collection's embedding settings, the run will fail. 
+      but the number of dimensions that are generated does not match the existing collection's embedding settings, the run will fail. 
       You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again. 
     - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. The new collection's name will be `Elements`.
 

--- a/snippets/general-shared-text/weaviate.mdx
+++ b/snippets/general-shared-text/weaviate.mdx
@@ -29,8 +29,8 @@
       but the number of dimensions that are generated does not match the existing collection's embedding settings, the run will fail. 
       You must change your Unstructured embedding settings or your existing collection's embedding settings to match, and try the run again.
     - If a collection name is not specified, Unstructured creates a new collection in your Weaviate cluster. If Unstructured generates embeddings, 
-      the new collection's name will be `u<short-workflow-id>_<short-embedding-model-name>_<number-of-dimensions>`. 
-      If Unstructured does not generate embeddings, the new collection's name will be `u<short-workflow-id`.
+      the new collection's name will be `U<short-workflow-id>_<short-embedding-model-name>_<number-of-dimensions>`. 
+      If Unstructured does not generate embeddings, the new collection's name will be `U<short-workflow-id`.
 
     For [Unstructured Ingest](/ingestion/overview):
 


### PR DESCRIPTION
This feature is now available for all users. OK'd by Shreya to publish. 

See for example https://unstructured-53-docs-190-weaviate-create-collection.mintlify.app/platform/destinations/weaviate -> the part that talks about specifying the target collection name (or not!)