### PR TITLE
[WIP] Quick fixes for broken syntax in workflows.mdx

### DIFF
--- a/platform/api/workflows.mdx
+++ b/platform/api/workflows.mdx
@@ -31,7 +31,7 @@ specify the settings for the workflow, as follows:
 
 <AccordionGroup>
     <Accordion title="Python SDK">
-        ```pythongit push --set-upstream origin quickfixes-2025-02-14
+        ```python
         import os
 
         from unstructured_client import UnstructuredClient

--- a/platform/api/workflows.mdx
+++ b/platform/api/workflows.mdx
@@ -31,7 +31,7 @@ specify the settings for the workflow, as follows:
 
 <AccordionGroup>
     <Accordion title="Python SDK">
-        ```python
+        ```pythongit push --set-upstream origin quickfixes-2025-02-14
         import os
 
         from unstructured_client import UnstructuredClient

--- a/platform/workflows.mdx
+++ b/platform/workflows.mdx
@@ -296,7 +296,7 @@ To create an automatic workflow:
           - **Overlap**: Apply a prefix of this many trailing characters from the prior text-split chunk to second and later chunks formed from oversized elements by text-splitting. The default is **160**.
           - **Overlap all**: Check this box to apply overlap to "normal" chunks formed by combining whole elements. Use with caution as this can introduce noise into otherwise clean semantic units. By default, this box is unchecked.
 
-        - **Chunk by character** (also known as _basic_ chunking): Combine sequential elements to maximally fill each chunk. Also, specify the following:
+        - **Chunk by character** (also known as `_basic_` chunking): Combine sequential elements to maximally fill each chunk. Also, specify the following:
 
           - **Include original elements**: Check this box to output the elements that were used to form a chunk, to appear in the `metadata` field's `orig_elements` field for that chunk. By default, this box is unchecked.
           - **Max characters**: Cut off new sections after reaching a length of this many characters. The default is **2048**.

--- a/platform/workflows.mdx
+++ b/platform/workflows.mdx
@@ -134,7 +134,7 @@ To create an automatic workflow:
                - **Combine Text Under N Characters**: 0
                - **Include Original Elements**: No
                - **Max Characters**: 2048
-               = **Multipage Sections**: No
+               - **Multipage Sections**: No
                - **New After N Characters**: 1500
                - **Overlap**: 160
                - **Overlap All**: No
@@ -300,7 +300,7 @@ To create an automatic workflow:
 
           - **Include original elements**: Check this box to output the elements that were used to form a chunk, to appear in the `metadata` field's `orig_elements` field for that chunk. By default, this box is unchecked.
           - **Max characters**: Cut off new sections after reaching a length of this many characters. The default is **2048**.
-          - **New after n chars**: Cut off new sections after reaching a length of this many characters. This is an approximate limit. The default is **1500*.
+          - **New after n chars**: Cut off new sections after reaching a length of this many characters. This is an approximate limit. The default is **1500**.
           - **Overlap**: Apply a prefix of this many trailing characters from the prior text-split chunk to second and later chunks formed from oversized elements by text-splitting. The default is **160**.
           - **Overlap All**: Check this box to apply overlap to "normal" chunks formed by combining whole elements. Use with caution as this can introduce noise into otherwise clean semantic units. By default, this box is unchecked.
         

--- a/platform/workflows.mdx
+++ b/platform/workflows.mdx
@@ -292,7 +292,7 @@ To create an automatic workflow:
           - **Include original elements**: Check this box to output the elements that were used to form a chunk, to appear in the `metadata` field's `orig_elements` field for that chunk. By default, this box is unchecked.
           - **Max characters**: Cut off new sections after reaching a length of this many characters. This is a strict limit. The default is **2048**.
           - **Multipage sections**: Check this box to allow sections to span multiple pages. By default, this box is unchecked.
-          - **New after n chars**: Cut off new sections after reaching a length of this many characters. This is an approximate limit. The default is **1500*.
+          - **New after n chars**: Cut off new sections after reaching a length of this many characters. This is an approximate limit. The default is **1500**.
           - **Overlap**: Apply a prefix of this many trailing characters from the prior text-split chunk to second and later chunks formed from oversized elements by text-splitting. The default is **160**.
           - **Overlap all**: Check this box to apply overlap to "normal" chunks formed by combining whole elements. Use with caution as this can introduce noise into otherwise clean semantic units. By default, this box is unchecked.
 


### PR DESCRIPTION
[EDIT] Closing the doc PR, as I found another version of the docs that worked for these three pages and used it to overwrite what was on our site.

The following 3 customer-facing pages across the docs website seem to be broken:

- https://docs.unstructured.io/platform/workflows
- https://docs.unstructured.io/platform/api/overview
- https://docs.unstructured.io/platform/api/workflows

I have been working with the Mintlify team to try to figure out how to fix them. This doc PR is being raised to try whatever fixes they recommend. With each push to this doc PR, the accompanying staging site is rebuilt and redeployed, so we can check to see if anything works. So far, nothing has seemed to work yet. 😢 