### PR TITLE
Python and JS/TS SDKs: Update usage of server_url

### DIFF
--- a/api-reference/api-services/sdk-jsts.mdx
+++ b/api-reference/api-services/sdk-jsts.mdx
@@ -55,10 +55,8 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     import * as fs from "fs";
 
     const key = process.env.UNSTRUCTURED_API_KEY;
-    const url = process.env.UNSTRUCTURED_API_URL;
 
     const client = new UnstructuredClient({
-        serverURL: url,
         security: {
             apiKeyAuth: key,
         },
@@ -107,7 +105,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     const url = process.env.UNSTRUCTURED_API_URL;
 
     const client = new UnstructuredClient({
-        serverURL: url,
         security: {
             apiKeyAuth: key,
         },
@@ -181,6 +178,22 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     ```
 
 ## Customizing the client
+    ### Changing the server URL
+        The JavaScript/TypeScript SDK will send requests to the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) by default. If you are working with a different instance of the Unstructured API, you can specify a `server_url` when initializing the Python client. This applies in the following situations:
+        - Users of the [Free Unstructured API](/api-reference/api-services/free-api) - you must specify your Free API key, and the Free API URL which is `https://api.unstructured.io`.
+        - Users of the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) offerings - you must use your custom API URL. See the corresponding pages for details.
+
+        ```typescript TypeScript
+        const key = process.env.UNSTRUCTURED_API_KEY;
+        const url = process.env.UNSTRUCTURED_API_URL;    
+
+        const client = new UnstructuredClient({
+            security: { apiKeyAuth: key },
+            serverURL: url,
+        });
+        ```
+
+
     ### Retries
         You can also change the defaults for retries through the `retryConfig`[*](#parameter-names)
         when initializing the client. If a request to the API fails, the client will retry the 
@@ -190,11 +203,9 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
         ```typescript TypeScript
         const key = process.env.UNSTRUCTURED_API_KEY;
-        const url = process.env.UNSTRUCTURED_API_URL;    
 
         const client = new UnstructuredClient({
             security: { apiKeyAuth: key },
-            serverURL: url,
             retryConfig: {
                 strategy: "backoff",
                 retryConnectionErrors: true,
@@ -284,7 +295,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
     const client = new UnstructuredClient({
         security: { apiKeyAuth: process.env.UNSTRUCTURED_API_KEY },
-        serverURL: process.env.UNSTRUCTURED_API_URL
     });
 
     processFiles(

--- a/api-reference/api-services/sdk-python.mdx
+++ b/api-reference/api-services/sdk-python.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Python SDK
 
 The [Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) client allows you to send an individual file for processing by 
 [Unstructured API services](/api-reference/api-services/overview). Whether you're using the
-Free Unstructured API, the Unstructured Serverless API, or the Unstructured API on Azure/AWS, or your local
+Free Unstructured API, the Unstructured Serverless API, the Unstructured API on Azure/AWS, or your local
 deployment of the Unstructured API, you can access the API using the Python SDK. 
 
 import UseIngestOrPlatformInstead from '/snippets/general-shared-text/use-ingest-or-platform-instead.mdx';
@@ -17,19 +17,6 @@ To use the Python SDK, you'll need:
 import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAPIKeyURL />
-
-<Warning>
-    **Important**: Beginning with Python SDK 0.30.0, note the following:
-    
-    - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.    
-    - For the Free Unstructured API URL, do not use `https://api.unstructured.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructured.io` instead. 
-    - If your Python code previously used the `server_url` parameter inside of your `UnstructuredClient` constructor to specify your Unstructured API URL, you must move this `server_url` parameter into 
-      your code's `partition` or `partition_async` function calls instead, or else calls made by the Python SDK will fail. To learn how, see the following code examples.
-
-    [Learn more](#migration-guide).
-</Warning>
 
 import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
 
@@ -81,7 +68,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     try:
         res = client.general.partition(
             request=req,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
         element_dicts = [element for element in res.elements]
 
@@ -125,7 +111,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     try:
         res = client.general.partition(
             request=req,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
         element_dicts = [element for element in res.elements]
         
@@ -172,7 +157,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         try:
             res = await client.general.partition_async(
                 request=req,
-                server_url=os.getenv("UNSTRUCTURED_API_URL")
             )
             element_dicts = [element for element in res.elements]
             json_elements = json.dumps(element_dicts, indent=2)
@@ -247,13 +231,26 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
     )
     res = client.general.partition(
         request=req,
-        server_url=os.getenv("UNSTRUCTURED_API_URL")
     )
     ```
 
 ## Customizing the client
+    ### Changing the server URL
+        The Python SDK will send requests to the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) by default. If you are working with a different instance of the Unstructured API, you can specify a `server_url` when initializing the Python client. This applies in the following situations:
+        - Users of the [Free Unstructured API](/api-reference/api-services/free-api) - you must specify your Free API key, and the Free API URL which is `https://api.unstructured.io`.
+        - Users of the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) offerings - you must use your custom API URL. See the corresponding pages for details.
+
+        ```python Python
+        import os 
+
+        client = UnstructuredClient(
+            api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
+            api_key_auth=os.getenv("UNSTRUCTURED_API_URL"),
+        )
+        ```
+
     ### Retries
-        You can also change the defaults for retries through the `retry_config`[*](#parameter-names)
+        You can change the defaults for retries through the `retry_config`[*](#parameter-names)
         when initializing the client. If a request to the API fails, the client will retry the 
         request with an exponential backoff strategy up to a maximum interval of one minute. The
         function keeps retrying until the total elapsed time exceeds `max_elapsed_time`[*](#parameter-names),
@@ -264,7 +261,6 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-            server_url=os.getenv("UNSTRUCTURED_API_URL"),
             retry_config=RetryConfig(
                 strategy="backoff",
                 retry_connection_errors=True,
@@ -322,49 +318,7 @@ the names used in the SDKs are the same across all methods.
 
 ## Migration guide
 
-There are breaking changes beginning with Python SDK version 0.26.0 and again in 0.30.0. If you encounter any errors when upgrading, please find the solution below.
-
-**If you see the error: `404 Not Found`**
-
-Before 0.30.0, you could specify the following Unstructured API URL for the `server_url` parameter:
-
-- For the Unstructured Serverless API: `https://api.unstructuredapp.io/general/v0/general`
-- For the Free Unstructured API: `https://api.unstructured.io/general/v0/general`
-
-Beginning with 0.30.0, these Unstructured API URLs have changed as follows:
-
-- For the Unstructured Serverless API: `https://api.unstructuredapp.io` (remove `/general/v0/general`)
-- For the Free Unstructured API: `https://api.unstructured.io` (remove `/general/v0/general`)
-
-Also, before 0.30.0, the `server_url` parameter was part of the `UnstructuredClient` constructor. Beginning with 0.30.0, the `server_url` 
-parameter has been moved into the `partition` and `partition_async` functions.
-
-```python
-# Instead of:
-client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-# Switch to:
-client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
-)
-
-# And...
-
-# For partition:
-res = client.general.partition(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-# For partition_async:
-res = await client.general.partition_async(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-```
+There are breaking changes beginning with Python SDK version 0.26.0. If you encounter any errors when upgrading, please find the solution below.
 
 **If you see the error: `AttributeError: 'PartitionParameters' object has no attribute 'partition_parameters'`**
 
@@ -380,7 +334,6 @@ req = shared.PartitionParameters(
 
 resp = s.general.partition(
     request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
 )
 
 # Switch to:
@@ -394,7 +347,6 @@ req = operations.PartitionRequest(
 
 resp = s.general.partition(
     request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
 )
 ```
 
@@ -429,6 +381,5 @@ resp = s.general.partition(req)
 # Switch to:
 resp = s.general.partition(
     request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
 )
 ```

--- a/platform/api/overview.mdx
+++ b/platform/api/overview.mdx
@@ -57,16 +57,11 @@ To use the Unstructured Platform API, you must have:
   4. Enter some descriptive name for the API key, and then click **Save**.
   5. Click the **Copy** icon for your new API key. The API key's value is copied to your system's clipboard.
 
-- The Unstructured **Platform API URL**. This is typically `https://platform.unstructuredapp.io`, which is unique to 
-  the Unstructured Python SDK; and `https://platform.unstructuredapp.io/api/v1` for standard REST-enabled utilities (such as `curl`), 
-  tools (such as Postman), programming languages, packages, and libraries.
+- The Unstructured **Platform API URL**. If you are working with standard REST-enabled utilities such as `curl` or Postman, you will need the API URL: `https://platform.unstructuredapp.io/api/v1`.
 
   ![Unstructured Platform API URL](/img/platform/PlatformAPIURL.png)
 
   <Warning>
-      **Important**: Do not use `https://platform.unstructuredapp.io/api/v1` with the Unstructured Python SDK, or else calls made by 
-      the Python SDK will fail. Use `https://platform.unstructuredapp.io` instead.
-
       Do not use the Unstructured **Serverless API URL**, which is separate from the Unstructured Platform API URL.      
   </Warning>
 
@@ -96,8 +91,7 @@ The Unstructured Platform API is offered as follows:
 
 - As a set of Representational State Transfer (REST) endpoints, which you can call through standard REST-enabled 
 utilities, tools, programming languages, packages, and libraries. The following sections describe how to call the Unstructured Platform API with 
-`curl` and Postman. You can adapt this information as needed for your preferred programming languages and libraries, for example by using the 
-`requests` library with Python.
+`curl` and Postman. You can adapt this information as needed for your preferred programming languages and libraries.
 
   <Tip>
       You can also use the [Unstructured Platform API - Swagger UI](https://platform.unstructuredapp.io/docs) to call the REST endpoints 
@@ -148,31 +142,12 @@ as well as `curl` and Postman for all of the supported REST endpoints.
     that are available through `https://platform.unstructuredapp.io`.
 </Tip>
 
-The following Unstructured Python SDK examples use the following environment variables, which you can set as follows:
-
-```bash
-export UNSTRUCTURED_API_URL="https://platform.unstructuredapp.io"
-export UNSTRUCTURED_API_KEY="<your-unstructured-api-key>"
-```
-
-<Warning>
-    **Important**: Do not use `https://platform.unstructuredapp.io/api/v1` with the Python SDK, or else calls made by the Python SDK will fail. 
-    Use `https://platform.unstructuredapp.io` instead.
-</Warning>
-
-The following `curl` and Postman examples use the following environment variables, which you can set as follows:
+The following Unstructured examples use the following environment variables, which you can set as follows:
 
 ```bash
 export UNSTRUCTURED_API_URL="https://platform.unstructuredapp.io/api/v1"
 export UNSTRUCTURED_API_KEY="<your-unstructured-api-key>"
 ```
-
-<Warning>
-    **Important**: For standard REST-enabled clients (such as `curl`), 
-    do not use `https://platform.unstructuredapp.io` (which is unique to the 
-    Unstructured Python SDK), or else calls made by these REST-enabled clients will fail. 
-    Use `https://platform.unstructuredapp.io/api/v1` instead.
-</Warning>
 
 These environment variables enable you to more easily run the following Unstructured Python SDK and `curl` examples and help prevent 
 you from storing scripts that contain sensitive URLs and API keys in public source code repositories.
@@ -188,10 +163,6 @@ The following Postman examples use variables, which you can set as follows:
    - **Initial value**: `https://platform.unstructuredapp.io/api/v1`
    - **Current value**: `https://platform.unstructuredapp.io/api/v1`
 
-     <Warning>
-         **Important**: Do not use `https://platform.unstructuredapp.io` (which is unique to the 
-         Unstructured Python SDK), or else calls made by Postman will fail.
-     </Warning>
    <br/>
    - **Variable**: `UNSTRUCTURED_API_URL`
    - **Type**: `secret`
@@ -245,7 +216,6 @@ To get this ID, see [Sources](/platform/api/sources/overview).
             request=ListSourcesRequest(
                 source_type="<type>" # Optional, list only for this source type.
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         # Print the list in alphabetical order by connector name.
@@ -318,7 +288,6 @@ the `GET` method to call the `/sources/<connector-id>` endpoint (for `curl` or P
             request=GetSourceRequest(
                 source_id="<connector-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.source_connector_information
@@ -390,7 +359,6 @@ specify the settings for the connector. For the specific settings to include, wh
             request=CreateSourceRequest(
                 create_source_connector=source_connector
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.source_connector_information
@@ -473,7 +441,6 @@ You can change any of the connector's settings except for its `name` and `type`.
                 source_id="<connector-id>",
                 update_source_connector=source_connector
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.source_connector_information
@@ -540,7 +507,6 @@ the `DELETE` method to call the `/sources/<connector-id>` endpoint (for `curl` o
             request=DeleteSourceRequest(
                 source_id="<connector-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         print(response.raw_response)
@@ -598,7 +564,6 @@ To get this ID, see [Destinations](/platform/api/destinations/overview).
             request=ListDestinationsRequest(
                 destination_type="<type>" # Optional, list only for this destination type.
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         # Print the list in alphabetical order by connector name.
@@ -671,7 +636,6 @@ the `GET` method to call the `/destinations/<connector-id>` endpoint (for `curl`
             request=GetDestinationRequest(
                 destination_id="<connector-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.destination_connector_information
@@ -742,7 +706,6 @@ specify the settings for the connector. For the specific settings to include, wh
             request=CreateDestinationRequest(
                 create_destination_connector=destination_connector
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.destination_connector_information
@@ -824,7 +787,6 @@ You can change any of the connector's settings except for its `name` and `type`.
                 destination_id="<connector-id>",
                 update_destination_connector=destination_connector
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.destination_connector_information
@@ -890,7 +852,6 @@ the `DELETE` method to call the `/destinations/<connector-id>` endpoint (for `cu
             request=DeleteDestinationRequest(
                 destination_id="<connector-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         print(response.raw_response)
@@ -966,7 +927,6 @@ You can specify multiple query parameters, for example `?source_id=<connector-id
                 source_id="<connector-id>", # Optional, list only for this source connector ID.
                 status="<status>" # Optional, list only for this workflow status.
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         # Print the list in alphabetical order by workflow name.
@@ -1059,7 +1019,6 @@ the `GET` method to call the `/workflows/<workflow-id>` endpoint (for `curl` or 
             request=GetWorkflowRequest(
                 workflow_id="<workflow-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.workflow_information
@@ -1140,7 +1099,6 @@ specify the settings for the workflow. For the specific settings to include, see
             request=CreateWorkflowRequest(
                 create_workflow=workflow
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.workflow_information
@@ -1219,7 +1177,6 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
             request=RunWorkflowRequest(
                 workflow_id="<workflow-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         print(response.raw_response)
@@ -1285,7 +1242,6 @@ the request body (for `curl` or Postman), specify the settings for the workflow.
                 workflow_id="<workflow-id>",
                 update_workflow=workflow
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.workflow_information
@@ -1364,7 +1320,6 @@ the `DELETE` method to call the `/workflows/<workflow-id>` endpoint (for `curl` 
             request=DeleteWorkflowRequest(
                 workflow_id="<workflow-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         print(response.raw_response)
@@ -1437,7 +1392,6 @@ For `curl` or Postman, you can specify multiple query parameters as `?workflow_i
                 workflow_id="<workflow-id>", # Optional, list only for this workflow ID.
                 status="<status>", # Optional, list only for this job status.
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         # Print the list in alphabetical order by workflow name.
@@ -1520,7 +1474,6 @@ the `GET` method to call the `/jobs/<job-id>` endpoint (for `curl` or Postman), 
             request=GetJobRequest(
                 job_id="<job-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         info = response.job_information
@@ -1578,7 +1531,6 @@ the `POST` method to call the `/jobs/<job-id>/cancel` endpoint (for `curl` or Po
             request=CancelJobRequest(
                 job_id="<job-id>"
             ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
         )
 
         print(response.raw_response)

--- a/snippets/general-shared-text/no-url-for-serverless-api.mdx
+++ b/snippets/general-shared-text/no-url-for-serverless-api.mdx
@@ -1,5 +1,5 @@
 <Info>
     If you do not specify the API URL, your [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) pay-as-you-go account will be used by default. You must always specify your Serverless API key.<br/><br/>
-    To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io` for the Python SDK beginning with 0.30.0; and `https://api.unstructured.io/general/v0/general` for all other clients.<br/><br/>
+    To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io`. <br/><br/>
     To use the pay-as-you-go Unstructured API on Azure or AWS with the SDKs, you must always specify the corresponding API URL. See the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) instructions.
 </Info>


### PR DESCRIPTION
First, we can remove the breaking change notices added in https://github.com/Unstructured-IO/docs/pull/485. This is now considered a bug that was resolved in `unstructured-client==0.30.2`. Users can pass `server_url` in the client constructor as before.

Next, let's remove the mentions of `server_url` in the platform and serverless SDK examples. We want to enable the SDK to do the right thing by default, and to provide a unified SaaS experience across our services. If the user is specifying the platform or serverless URL, they will override the default behavior, and potentially see errors when they try to mix and match functions.

The `server_url` should be a special case parameter for partitioning users who are not on Serverless, i.e. free tier or marketplace deploys. We can add a section for these users under "Customizing the client" in the partitioning section of the docs.