### PR TITLE
Revert back to original API behavior for default API URLs, server_url need and placement

### DIFF
--- a/api-reference/api-services/examples.mdx
+++ b/api-reference/api-services/examples.mdx
@@ -11,19 +11,6 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
 
-<Warning>
-    **Important**: Beginning with Python SDK 0.30.0, note the following:
-    
-    - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.    
-    - For the Free Unstructured API URL, do not use `https://api.unstructured.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructured.io` instead. 
-    - If your Python code previously used the `server_url` parameter inside of your `UnstructuredClient` constructor to specify your Unstructured API URL, you must move this `server_url` parameter into 
-      your code's `partition` or `partition_async` function calls instead, or else calls made by the Python SDK will fail. To learn how, see the following code examples.
-
-    [Learn more](/api-reference/api-services/sdk-python#migration-guide).
-</Warning>
-
 <NoURLForServerlessAPI/>
 
 import UseIngestOrPlatformInstead from '/snippets/general-shared-text/use-ingest-or-platform-instead.mdx';
@@ -136,8 +123,7 @@ The `hi_res` strategy supports different models, and the default is `layout_v1.1
 
             try:
                 res = await client.general.partition_async(
-                    request=req,
-                    server_url=os.getenv("UNSTRUCTURED_API_URL")
+                    request=req
                 )
                 element_dicts = [element for element in res.elements]
                 json_elements = json.dumps(element_dicts, indent=2)
@@ -356,8 +342,7 @@ For better OCR results, you can specify what languages your document is in using
 
             try:
                 res = await client.general.partition_async(
-                    request=req, 
-                    server_url=os.getenv("UNSTRUCTURED_API_URL")
+                    request=req
                 )
                 element_dicts = [element for element in res.elements]
                 json_elements = json.dumps(element_dicts, indent=2)
@@ -573,8 +558,7 @@ Set the `coordinates` parameter to `true` to add this field to the elements in t
 
             try:
                 res = await client.general.partition_async(
-                    request=req,
-                    server_url=os.getenv("UNSTRUCTURED_API_URL")
+                    request=req
                 )
                 element_dicts = [element for element in res.elements]
                 json_elements = json.dumps(element_dicts, indent=2)
@@ -793,8 +777,7 @@ This can be helpful if you'd like to use the IDs as a primary key in a database,
 
             try:
                 res = await client.general.partition_async(
-                    request=req,
-                    server_url=os.getenv("UNSTRUCTURED_API_URL")
+                    request=req
                 )
                 element_dicts = [element for element in res.elements]
                 json_elements = json.dumps(element_dicts, indent=2)
@@ -1020,8 +1003,7 @@ By default, the `chunking_strategy` is set to `None`, and no chunking is perform
 
             try:
                 res = await client.general.partition_async(
-                    request=req,
-                    server_url=os.getenv("UNSTRUCTURED_API_URL")
+                    request=req
                 )
                 element_dicts = [element for element in res.elements]
                 json_elements = json.dumps(element_dicts, indent=2)

--- a/api-reference/api-services/free-api.mdx
+++ b/api-reference/api-services/free-api.mdx
@@ -19,17 +19,6 @@ The Free Unstructured API requires authentication via an API key. Here's how you
 5.  Click **Submit**. You will receive a Free Unstructured API key at the **Email** you provided. Store your API key in a secure location. Do not share it with others.
 6.  For the Free Unstructured API, the API URL is `https://api.unstructured.io/general/v0/general`
 
-<Warning>
-    **Important**: This article shows how to use Free Unstructured API with the Unstructured CLI and the 
-    Unstructured Ingest Python library. While you can also use this API URL with the Unstructured Python SDK, 
-    beginning with Python SDK 0.30.0, note the following:
-    
-    - Do not use https://api.unstructured.io/general/v0/general, or else calls made by 
-      the Python SDK will fail. Use https://api.unstructured.io` instead.    
-    - If your Python code uses the `server_url` parameter inside of your `UnstructuredClient` constructor to specify this URL, you must move this `server_url` parameter into 
-      your code's `partition` or `partition_async` function calls instead, or else calls made by the Python SDK will fail.
-</Warning>
-
 import FreeKeyNoServerlessURL from '/snippets/general-shared-text/free-api-key-no-serverless-access.mdx';
 
 <FreeKeyNoServerlessURL />

--- a/api-reference/api-services/saas-api-development-guide.mdx
+++ b/api-reference/api-services/saas-api-development-guide.mdx
@@ -13,7 +13,7 @@ This page describes how to get started with the Unstructured Serverless API. Lea
 
 ## Get started
 
-To call the Unstructured Serverless API, you need an Unstructured account, API key, and API URL:
+To call the Unstructured Serverless API, you need an Unstructured account and an Unstructured API key:
 
 <Steps>
     <Step title="Sign up">
@@ -64,7 +64,7 @@ To call the Unstructured Serverless API, you need an Unstructured account, API k
         </Tip>
 
     </Step> 
-    <Step title="Get your API key and API URL">
+    <Step title="Get your API key">
 
         <img src="https://unstructured-tech-docs.s3.amazonaws.com/Unstructured-Platform-APIKeyURL.gif" alt="Unstructured API key how-to" width="500" />
 
@@ -76,26 +76,8 @@ To call the Unstructured Serverless API, you need an Unstructured account, API k
         2. On the **API Keys** tab, click **Generate New Key**.
         3. Enter some descriptive name for the API key, and then click **Save**.
         4. Click the **Copy** icon for your new API key. The API key's value is copied to your system's clipboard.
-        5. Note the Unstructured **Serverless API URL**, which is `https://api.unstructuredapp.io/general/v0/general`
-
-        ![Unstructured Serverless API URL](/img/platform/ServerlessAPIURL.png)
-
-        <Warning>
-            Do not use the Unstructured **Platform API URL**, which is separate from the Unstructured Serverless API URL.
-        </Warning>
-
-        <Note>
-            If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, your API URL 
-            might be different. For API URL guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
-            If your API URL is different, be sure to substitute `https://api.unstructuredapp.io/general/v0/general` for your 
-            API URL throughout the following examples.
-        </Note>    
     </Step>
 </Steps>
-
-import ServerlessKeyNoFreeURL from '/snippets/general-shared-text/serverless-api-key-no-free-access.mdx';
-
-<ServerlessKeyNoFreeURL />
 
 [Try the quickstart](#quickstart).
 
@@ -137,6 +119,10 @@ import SharedPagesBilling from '/snippets/general-shared-text/pages-billing.mdx'
 
 These examples use your local machine. They send source (input) files from your local machine to the Unstructured Serverless API which delivers the processed data to a destination (output) location, also on your local machine. Data is processed on Unstructured-hosted compute resources.
 
+import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
+
+<NoURLForServerlessAPI/>
+
 ### Unstructured Ingest CLI
 
 To work with the Unstructured Serverless API by using the [Unstructured Ingest CLI](/ingestion/overview#unstructured-ingest-cli), you will need to:
@@ -147,12 +133,11 @@ To work with the Unstructured Serverless API by using the [Unstructured Ingest C
   pip install unstructured-ingest
   ```
 
-- Set the following environment variables:
+- Set the following environment variable:
 
   - Set `UNSTRUCTURED_API_KEY` to your API key.
-  - Set `UNSTRUCTURED_API_URL` to your API URL.
   
-  [Get your API key and API URL](#get-started).
+  [Get your API key](#get-started).
 
 - Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
@@ -168,7 +153,6 @@ unstructured-ingest \
     --output-dir <path/to/output> \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
-    --partition-endpoint $UNSTRUCTURED_API_URL \
     --strategy hi_res \
     --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}"
 ```
@@ -188,9 +172,8 @@ To work with the Unstructured Serverless API by using the [Unstructured Python l
 - Set the following environment variables:
 
   - Set `UNSTRUCTURED_API_KEY` to your API key.
-  - Set `UNSTRUCTURED_API_URL` to your API URL.
   
-  [Get your API key and API URL](#get-started).
+  [Get your API key](#get-started).
 
 - Have some compatible files on your local machine to be processed. [See the list of supported file types](/api-reference/api-services/supported-file-types). If you do not have any files available, you can download some from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 

--- a/api-reference/api-services/sdk-python.mdx
+++ b/api-reference/api-services/sdk-python.mdx
@@ -18,19 +18,6 @@ import SharedAPIKeyURL from '/snippets/general-shared-text/api-key-url.mdx';
 
 <SharedAPIKeyURL />
 
-<Warning>
-    **Important**: Beginning with Python SDK 0.30.0, note the following:
-    
-    - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.    
-    - For the Free Unstructured API URL, do not use `https://api.unstructured.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructured.io` instead. 
-    - If your Python code previously used the `server_url` parameter inside of your `UnstructuredClient` constructor to specify your Unstructured API URL, you must move this `server_url` parameter into 
-      your code's `partition` or `partition_async` function calls instead, or else calls made by the Python SDK will fail. To learn how, see the following code examples.
-
-    [Learn more](#migration-guide).
-</Warning>
-
 import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serverless-api.mdx';
 
 <NoURLForServerlessAPI/>
@@ -80,8 +67,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
     try:
         res = client.general.partition(
-            request=req,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            request=req
         )
         element_dicts = [element for element in res.elements]
 
@@ -124,8 +110,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
     try:
         res = client.general.partition(
-            request=req,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            request=req
         )
         element_dicts = [element for element in res.elements]
         
@@ -171,8 +156,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
 
         try:
             res = await client.general.partition_async(
-                request=req,
-                server_url=os.getenv("UNSTRUCTURED_API_URL")
+                request=req
             )
             element_dicts = [element for element in res.elements]
             json_elements = json.dumps(element_dicts, indent=2)
@@ -246,8 +230,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         )
     )
     res = client.general.partition(
-        request=req,
-        server_url=os.getenv("UNSTRUCTURED_API_URL")
+        request=req
     )
     ```
 
@@ -263,8 +246,7 @@ import NoURLForServerlessAPI from '/snippets/general-shared-text/no-url-for-serv
         import os 
 
         client = UnstructuredClient(
-            api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-            server_url=os.getenv("UNSTRUCTURED_API_URL"),
+            api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
             retry_config=RetryConfig(
                 strategy="backoff",
                 retry_connection_errors=True,
@@ -322,49 +304,7 @@ the names used in the SDKs are the same across all methods.
 
 ## Migration guide
 
-There are breaking changes beginning with Python SDK version 0.26.0 and again in 0.30.0. If you encounter any errors when upgrading, please find the solution below.
-
-**If you see the error: `404 Not Found`**
-
-Before 0.30.0, you could specify the following Unstructured API URL for the `server_url` parameter:
-
-- For the Unstructured Serverless API: `https://api.unstructuredapp.io/general/v0/general`
-- For the Free Unstructured API: `https://api.unstructured.io/general/v0/general`
-
-Beginning with 0.30.0, these Unstructured API URLs have changed as follows:
-
-- For the Unstructured Serverless API: `https://api.unstructuredapp.io` (remove `/general/v0/general`)
-- For the Free Unstructured API: `https://api.unstructured.io` (remove `/general/v0/general`)
-
-Also, before 0.30.0, the `server_url` parameter was part of the `UnstructuredClient` constructor. Beginning with 0.30.0, the `server_url` 
-parameter has been moved into the `partition` and `partition_async` functions.
-
-```python
-# Instead of:
-client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-# Switch to:
-client = unstructured_client.UnstructuredClient(
-    api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
-)
-
-# And...
-
-# For partition:
-res = client.general.partition(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-
-# For partition_async:
-res = await client.general.partition_async(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL")
-)
-```
+There are breaking changes beginning with Python SDK version 0.26.0. If you encounter any errors when upgrading, please find the solution below.
 
 **If you see the error: `AttributeError: 'PartitionParameters' object has no attribute 'partition_parameters'`**
 
@@ -379,8 +319,7 @@ req = shared.PartitionParameters(
 )
 
 resp = s.general.partition(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
+    request=req
 )
 
 # Switch to:
@@ -393,8 +332,7 @@ req = operations.PartitionRequest(
 )
 
 resp = s.general.partition(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
+    request=req
 )
 ```
 
@@ -428,7 +366,6 @@ resp = s.general.partition(req)
 
 # Switch to:
 resp = s.general.partition(
-    request=req,
-    server_url=os.getenv("UNSTRUCTURED_API_URL") # Beginning with 0.30.0
+    request=req
 )
 ```

--- a/api-reference/troubleshooting/api-key-url.mdx
+++ b/api-reference/troubleshooting/api-key-url.mdx
@@ -37,15 +37,12 @@ API error occurred: Status 404
 
 For the API URL, note the following:
 
-- For the [Unstructured Platform API](/platform/api/overview), the API URL is typically `https://platform.unstructuredapp.io`, which is unique to 
-  the Unstructured Python SDK; and `https://platform.unstructuredapp.io/api/v1` for standard REST-enabled utilities (such as `curl`), 
-  tools (such as Postman), programming languages, packages, and libraries.
-- For the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide), the API URL is typically `https://api.unstructuredapp.io`, which is unique to 
-  the Unstructured Python SDK, beginning with 0.30.0; and `https://api.unstructuredapp.io/general/v0/general` for the Unstructured Python SDK before 0.30.0 and for standard REST-enabled utilities (such as `curl`), 
-  tools (such as Postman), programming languages, packages, and libraries. Be aware of the inclusion of `app` in this API URL.
-- For the [Free Unstructured API](/api-reference/api-services/free-api), the API URL is typically https://api.unstructured.io`, which is unique to 
-  the Unstructured Python SDK, beginning with 0.30.0; and `https://api.unstructured.io/general/v0/general` for the Unstructured Python SDK before 0.30.0 and for standard REST-enabled utilities (such as `curl`), 
-  tools (such as Postman), programming languages, packages, and libraries. Be aware that there is no `app` in this API URL.
+- For the [Unstructured Platform API](/platform/api/overview), the API URL is typically `https://platform.unstructuredapp.io/api/v1`.
+- For the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide), the API URL is typically `https://api.unstructuredapp.io/general/v0/general`. 
+  Be aware of the inclusion of `app` in this API URL.
+- For the [Free Unstructured API](/api-reference/api-services/free-api), the API URL is typically https://api.unstructured.io/general/v0/general`. 
+  Be aware that there is no `app` in this API URL.
+- For the Unstructured API on AWS and the Unstructured API on Azure, the API URLs are unique per deployment. See the [AWS](/api-reference/api-services/aws) or [Azure](/api-reference/api-services/azure) instructions.
 
 <Note>The free 14-day trial of the Unstructured Serverless API or Unstructured Platform API is different than the Free Unstructured API.</Note>
 
@@ -61,24 +58,7 @@ For the API key, note the following:
 
   ![Unstructured Serverless and Platform API URLs](/img/platform/ServerlessPlatformAPIURL.png)
 
-  <Warning>
-      **Important**: For the Unstructured Python SDK beginning with 0.30.0:
-      
-      - For the Unstructured Platform API URL, do not use `https://platform.unstructuredapp.io/api/v1`, or else calls made by 
-      the Python SDK will fail. Use `https://platform.unstructuredapp.io` instead.
-      - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-      the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.  
-      - For the Free Unstructured API URL, do not use https://api.unstructured.io/general/v0/general, or else calls made by 
-      the Python SDK will fail. Use https://api.unstructured.io` instead.   
-  </Warning>
-
 - For the [Free Unstructured API](/api-reference/api-services/free-api), the API key is in your original email from Unstructured. If you cannot find the original email, you can regenerate it by going to [https://unstructured.io/api-key-free](https://unstructured.io/api-key-free).
-
-  <Warning>
-      **Important**: For the Unstructured Python SDK beginning with 0.30.0,   
-      for the Free Unstructured API URL, do not use https://api.unstructured.io/general/v0/general, or else calls made by 
-      the Python SDK will fail. Use https://api.unstructured.io` instead.   
-  </Warning>
 
 <Note>The free 14-day trial of the Unstructured Serverless API or Unstructured Platform API is different than the Free Unstructured API.</Note>
 
@@ -93,49 +73,7 @@ If you still believe you have the correct API URL and API key, try the following
 
    **For the Unstructured Python SDK** (Unstructured Platform API, Unstructured Serverless API, and Free Unstructured API only)
 
-   - For the Unstructured Python SDK beginning with 0.30.0, if the `server_url` parameter is in your `UnstructuredClient` constructor, move it into 
-     your operational calling function such as `partition` or `partition_asyc` for Unstructured API services or `list_*`, `get_*`, `create_*`, `update_*`, or `delete_*` for the Unstructured Platform API. For example:
-
-     ```python
-     # Instead of this (before Python SDK 0.30.0):
-     client = unstructured_client.UnstructuredClient(
-         api_key_auth=os.getenv("UNSTRUCTURED_API_KEY"),
-         server_url=os.getenv("UNSTRUCTURED_API_URL")
-     )
-
-     # Switch to this (beginning with Python SDK 0.30.0):
-     client = unstructured_client.UnstructuredClient(
-         api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
-     )
-
-     # And then...
-
-     # For Unstructured API services:
-     res = client.general.<partition|partition_async>(
-         request=req,
-         server_url=os.getenv("UNSTRUCTURED_API_URL")
-     )
-
-     # Or for the Unstructured Platform API:
-     res = client.<sources-destinations-workflows-jobs>.<list-get-create-delete-operation>(
-         request=req,
-         server_url=os.getenv("UNSTRUCTURED_API_URL")
-     )
-     ```
-
    - Check the value of the `server_url` parameter. Make sure it is set to the right API URL, or an environment variable representing the right API URL.
-
-     <Warning>
-         **Important**: For the Unstructured Python SDK beginning with 0.30.0:
-      
-         - For the Unstructured Platform API URL, do not use `https://platform.unstructuredapp.io/api/v1`, or else calls made by 
-           the Python SDK will fail. Use `https://platform.unstructuredapp.io` instead.
-         - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-           the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.  
-         - For the Free Unstructured API URL, do not use https://api.unstructured.io/general/v0/general, or else calls made by 
-           the Python SDK will fail. Use https://api.unstructured.io` instead.     
-     </Warning>
-
    - Check the value of the `api_key_auth` parameter. Make sure it is set to the right API key, or an environment variable representing the right API key.
 
    **For the Unstructured JavaScript/TypeScript SDK** (Unstructured Serverless API and Free Unstructured API only)
@@ -194,24 +132,10 @@ If you still believe you have the correct API URL and API key, try the following
    
    ![Unstructured Serverless and Platform API URLs](/img/platform/ServerlessPlatformAPIURL.png)
 
-   <Warning>
-       **Important**: For the Unstructured Python SDK beginning with 0.30.0:
-      
-       - For the Unstructured Platform API URL, do not use `https://platform.unstructuredapp.io/api/v1`, or else calls made by 
-         the Python SDK will fail. Use `https://platform.unstructuredapp.io` instead.
-       - For the Unstructured Serverless API URL, do not use `https://api.unstructuredapp.io/general/v0/general`, or else calls made by 
-         the Python SDK will fail. Use `https://api.unstructuredapp.io` instead.   
-   </Warning>
-   
    **For the Free Unstructured API**
 
    - Open your original email from Unstructured that contains your API key. Make sure it matches the one in your script, code, or environment variable. If you cannot find the original email, you can regenerate it by going to [https://unstructured.io/api-key-free](https://unstructured.io/api-key-free).
    - Make sure that you are using `https://api.unstructured.io/general/v0/general` (not `platform.unstructuredapp.io` or `api.unstructuredapp.io`) for the API URL. 
-
-   <Warning>
-       **Important**: For the Unstructured Python SDK beginning with 0.30.0 for the Free Unstructured API URL, do not use https://api.unstructured.io/general/v0/general, or else calls made by 
-       the Python SDK will fail. Use https://api.unstructured.io` instead.    
-   </Warning>
 
 4. If you are still getting this issue, [contact us directly](https://unstructured.io/contact).
 

--- a/platform/api/overview.mdx
+++ b/platform/api/overview.mdx
@@ -57,72 +57,71 @@ To use the Unstructured Platform API, you must have:
   4. Enter some descriptive name for the API key, and then click **Save**.
   5. Click the **Copy** icon for your new API key. The API key's value is copied to your system's clipboard.
 
-- The Unstructured **Platform API URL**. This is typically `https://platform.unstructuredapp.io`, which is unique to 
-  the Unstructured Python SDK; and `https://platform.unstructuredapp.io/api/v1` for standard REST-enabled utilities (such as `curl`), 
-  tools (such as Postman), programming languages, packages, and libraries.
+The Unstructured Platform API is offered as part of the Unstructured Python SDK and as a set of Representational State Transfer (REST) endpoints.
 
-  ![Unstructured Platform API URL](/img/platform/PlatformAPIURL.png)
+### Unstructured Python SDK
 
-  <Warning>
-      **Important**: Do not use `https://platform.unstructuredapp.io/api/v1` with the Unstructured Python SDK, or else calls made by 
-      the Python SDK will fail. Use `https://platform.unstructuredapp.io` instead.
+The [Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client), beginning with version 0.30.2, 
+allows you to call the Unstructured Platform API through standard Python code.
 
-      Do not use the Unstructured **Serverless API URL**, which is separate from the Unstructured Platform API URL.      
-  </Warning>
+To install the Unstructured Python SDK, run the following command from within your Python virtual environment:
 
-  <Note>
-      If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, your API URL 
-      might be different. For API URL guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
-      If your API URL is different, be sure to substitute `https://platform.unstructuredapp.io/api/v1` for your 
-      API URL throughout the following examples.
-  </Note>
+```bash
+pip install "unstructured-client>=0.30.2"
+```
 
-The Unstructured Platform API is offered as follows:
+If you already have the Unstructured Python SDK installed, upgrade to at least version 0.30.2 by running the following command instead:
 
-- As part of the [Unstructured Python SDK](https://github.com/Unstructured-IO/unstructured-python-client) beginning with version 0.30.0, 
-  which you can call through standard Python code.
+```bash
+pip install --upgrade "unstructured-client>=0.30.2"
+```
 
-  To install the Unstructured Python SDK, run the following command from within your Python virtual environment:
+### REST endpoints
 
-  ```bash
-  pip install "unstructured-client>=0.30.0"
-  ```
-
-  If you already have the Unstructured Python SDK installed, upgrade to at least version 0.30.0 by running the following command instead:
-
-  ```bash
-  pip install --upgrade "unstructured-client>=0.30.0"
-  ```
-
-- As a set of Representational State Transfer (REST) endpoints, which you can call through standard REST-enabled 
+The Unstructured Platform API is also callable from a set of Representational State Transfer (REST) endpoints, which you can call through standard REST-enabled 
 utilities, tools, programming languages, packages, and libraries. The following sections describe how to call the Unstructured Platform API with 
 `curl` and Postman. You can adapt this information as needed for your preferred programming languages and libraries, for example by using the 
 `requests` library with Python.
 
-  <Tip>
-      You can also use the [Unstructured Platform API - Swagger UI](https://platform.unstructuredapp.io/docs) to call the REST endpoints 
-      that are available through `https://platform.unstructuredapp.io`.
-  </Tip>
+<Tip>
+    You can also use the [Unstructured Platform API - Swagger UI](https://platform.unstructuredapp.io/docs) to call the REST endpoints 
+    that are available through `https://platform.unstructuredapp.io`.
+</Tip>
+
+To call the REST endpoints, you must specify the Unstructured **Platform API URL**. This is typically `https://platform.unstructuredapp.io/api/v1`.
+
+![Unstructured Platform API URL](/img/platform/PlatformAPIURL.png)
+
+<Warning>
+    Do not use the Unstructured **Serverless API URL**, which is separate from the Unstructured Platform API URL.      
+</Warning>
 
 <Note>
-    The Unstructured Platform API is separate from [Unstructured Serverless API services](/api-reference/api-services/overview) and 
-    [Unstructured Ingest](/api-reference/ingest/overview). 
-
-    Because of this separation, the following Unstructured SDKs, tools, and libraries do _not_ work with the Unstructured Platform API:
-
-    - The [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts)
-    - [Local single-file POST requests](/api-reference/api-services/post-requests) to Unstructured Serverless API services
-    - The [Unstructured open source Python library](/api-reference/api-services/partition-via-api)
-    - The [Unstructued Ingest CLI](/api-reference/ingest/ingest-cli)
-    - The [Unstructured Ingest Python library](/api-reference/ingest/python-ingest)
-
-    [Free Unstructured API](/api-reference/api-services/free-api) accounts are also _not_ supported.
-
-    The following Unstructured API URLs are also _not_ supported:
-
-    - `https://api.unstructuredapp.io/general/v0/general` (the Unstructured Serverless API URL)
-    - `https://api.unstructured.io/general/v0/general` (the Free Unstructured API URL)
+    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, your API URL 
+    might be different. For API URL guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
+    If your API URL is different, be sure to substitute `https://platform.unstructuredapp.io/api/v1` for your 
+    API URL throughout the following examples.
 </Note>
+
+### Restrictions
+
+The Unstructured Platform API is separate from [Unstructured Serverless API services](/api-reference/api-services/overview) and 
+[Unstructured Ingest](/api-reference/ingest/overview). 
+
+Because of this separation, the following Unstructured SDKs, tools, and libraries do _not_ work with the Unstructured Platform API:
+
+- The [Unstructured JavaScript/TypeScript SDK](/api-reference/api-services/sdk-jsts)
+- [Local single-file POST requests](/api-reference/api-services/post-requests) to Unstructured Serverless API services
+- The [Unstructured open source Python library](/api-reference/api-services/partition-via-api)
+- The [Unstructued Ingest CLI](/api-reference/ingest/ingest-cli)
+- The [Unstructured Ingest Python library](/api-reference/ingest/python-ingest)
+
+[Free Unstructured API](/api-reference/api-services/free-api) accounts are also _not_ supported.
+
+The following Unstructured API URLs are also _not_ supported:
+
+- `https://api.unstructuredapp.io/general/v0/general` (the Unstructured Serverless API URL)
+- `https://api.unstructured.io/general/v0/general` (the Free Unstructured API URL)
 
 ## Basics
 
@@ -148,17 +147,28 @@ as well as `curl` and Postman for all of the supported REST endpoints.
     that are available through `https://platform.unstructuredapp.io`.
 </Tip>
 
-The following Unstructured Python SDK examples use the following environment variables, which you can set as follows:
+### Python SDK
+
+The following Unstructured Python SDK examples use the following environment variable, which you can set as follows:
 
 ```bash
-export UNSTRUCTURED_API_URL="https://platform.unstructuredapp.io"
 export UNSTRUCTURED_API_KEY="<your-unstructured-api-key>"
 ```
 
-<Warning>
-    **Important**: Do not use `https://platform.unstructuredapp.io/api/v1` with the Python SDK, or else calls made by the Python SDK will fail. 
-    Use `https://platform.unstructuredapp.io` instead.
-</Warning>
+Calls made by the Unstructured Python SDK's `unstructured_client` functions for creating, listing, updating, 
+and deleting connectors, workflows, and jobs in the Unstructured Platform all use the Unstrucutured Platform API URL (`https://platform.unstructuredapp.io/api/v1`) by default. You do not need to 
+use the `server_url` parameter to specify this API URL in your Python code for these particular functions.
+
+<Note>
+    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, your API URL 
+    might be different. For API URL guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
+    If your API URL is different, be sure to substitute `https://platform.unstructuredapp.io/api/v1` for your 
+    API URL throughout the following examples.
+
+    To specify an API URL in your code, set the `server_url` parameter in the `UnstructuredClient` constructor to the target API URL.
+</Note>
+
+### curl and Postman
 
 The following `curl` and Postman examples use the following environment variables, which you can set as follows:
 
@@ -166,13 +176,6 @@ The following `curl` and Postman examples use the following environment variable
 export UNSTRUCTURED_API_URL="https://platform.unstructuredapp.io/api/v1"
 export UNSTRUCTURED_API_KEY="<your-unstructured-api-key>"
 ```
-
-<Warning>
-    **Important**: For standard REST-enabled clients (such as `curl`), 
-    do not use `https://platform.unstructuredapp.io` (which is unique to the 
-    Unstructured Python SDK), or else calls made by these REST-enabled clients will fail. 
-    Use `https://platform.unstructuredapp.io/api/v1` instead.
-</Warning>
 
 These environment variables enable you to more easily run the following Unstructured Python SDK and `curl` examples and help prevent 
 you from storing scripts that contain sensitive URLs and API keys in public source code repositories.
@@ -187,11 +190,6 @@ The following Postman examples use variables, which you can set as follows:
    - **Type**: `default`
    - **Initial value**: `https://platform.unstructuredapp.io/api/v1`
    - **Current value**: `https://platform.unstructuredapp.io/api/v1`
-
-     <Warning>
-         **Important**: Do not use `https://platform.unstructuredapp.io` (which is unique to the 
-         Unstructured Python SDK), or else calls made by Postman will fail.
-     </Warning>
    <br/>
    - **Variable**: `UNSTRUCTURED_API_URL`
    - **Type**: `secret`
@@ -244,8 +242,7 @@ To get this ID, see [Sources](/platform/api/sources/overview).
         response = client.sources.list_sources(
             request=ListSourcesRequest(
                 source_type="<type>" # Optional, list only for this source type.
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         # Print the list in alphabetical order by connector name.
@@ -317,8 +314,7 @@ the `GET` method to call the `/sources/<connector-id>` endpoint (for `curl` or P
         response = client.sources.get_source(
             request=GetSourceRequest(
                 source_id="<connector-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.source_connector_information
@@ -389,8 +385,7 @@ specify the settings for the connector. For the specific settings to include, wh
         response = client.sources.create_source(
             request=CreateSourceRequest(
                 create_source_connector=source_connector
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.source_connector_information
@@ -472,8 +467,7 @@ You can change any of the connector's settings except for its `name` and `type`.
             request=UpdateSourceRequest(
                 source_id="<connector-id>",
                 update_source_connector=source_connector
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.source_connector_information
@@ -539,8 +533,7 @@ the `DELETE` method to call the `/sources/<connector-id>` endpoint (for `curl` o
         response = client.sources.delete_source(
             request=DeleteSourceRequest(
                 source_id="<connector-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         print(response.raw_response)
@@ -597,8 +590,7 @@ To get this ID, see [Destinations](/platform/api/destinations/overview).
         response = client.destinations.list_destinations(
             request=ListDestinationsRequest(
                 destination_type="<type>" # Optional, list only for this destination type.
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         # Print the list in alphabetical order by connector name.
@@ -670,8 +662,7 @@ the `GET` method to call the `/destinations/<connector-id>` endpoint (for `curl`
         response = client.destinations.get_destination(
             request=GetDestinationRequest(
                 destination_id="<connector-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.destination_connector_information
@@ -741,8 +732,7 @@ specify the settings for the connector. For the specific settings to include, wh
         response = client.destinations.create_destination(
             request=CreateDestinationRequest(
                 create_destination_connector=destination_connector
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.destination_connector_information
@@ -823,8 +813,7 @@ You can change any of the connector's settings except for its `name` and `type`.
             request=UpdateDestinationRequest(
                 destination_id="<connector-id>",
                 update_destination_connector=destination_connector
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.destination_connector_information
@@ -889,8 +878,7 @@ the `DELETE` method to call the `/destinations/<connector-id>` endpoint (for `cu
         response = client.destinations.delete_destination(
             request=DeleteDestinationRequest(
                 destination_id="<connector-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         print(response.raw_response)
@@ -965,8 +953,7 @@ You can specify multiple query parameters, for example `?source_id=<connector-id
                 destination_id="<connector-id>", # Optional, list only for this destination connector ID.
                 source_id="<connector-id>", # Optional, list only for this source connector ID.
                 status="<status>" # Optional, list only for this workflow status.
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         # Print the list in alphabetical order by workflow name.
@@ -1058,8 +1045,7 @@ the `GET` method to call the `/workflows/<workflow-id>` endpoint (for `curl` or 
         response = client.workflows.get_workflow(
             request=GetWorkflowRequest(
                 workflow_id="<workflow-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.workflow_information
@@ -1139,8 +1125,7 @@ specify the settings for the workflow. For the specific settings to include, see
         response = client.workflows.create_workflow(
             request=CreateWorkflowRequest(
                 create_workflow=workflow
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.workflow_information
@@ -1218,8 +1203,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         response = client.workflows.run_workflow(
             request=RunWorkflowRequest(
                 workflow_id="<workflow-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         print(response.raw_response)
@@ -1284,8 +1268,7 @@ the request body (for `curl` or Postman), specify the settings for the workflow.
             request=UpdateWorkflowRequest(
                 workflow_id="<workflow-id>",
                 update_workflow=workflow
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.workflow_information
@@ -1363,8 +1346,7 @@ the `DELETE` method to call the `/workflows/<workflow-id>` endpoint (for `curl` 
         response = client.workflows.delete_workflow(
             request=DeleteWorkflowRequest(
                 workflow_id="<workflow-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         print(response.raw_response)
@@ -1436,8 +1418,7 @@ For `curl` or Postman, you can specify multiple query parameters as `?workflow_i
             request=ListJobsRequest(
                 workflow_id="<workflow-id>", # Optional, list only for this workflow ID.
                 status="<status>", # Optional, list only for this job status.
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         # Print the list in alphabetical order by workflow name.
@@ -1519,8 +1500,7 @@ the `GET` method to call the `/jobs/<job-id>` endpoint (for `curl` or Postman), 
         response = client.jobs.get_job(
             request=GetJobRequest(
                 job_id="<job-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.job_information
@@ -1577,8 +1557,7 @@ the `POST` method to call the `/jobs/<job-id>/cancel` endpoint (for `curl` or Po
         response = client.jobs.cancel_job(
             request=CancelJobRequest(
                 job_id="<job-id>"
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         print(response.raw_response)

--- a/platform/api/workflows.mdx
+++ b/platform/api/workflows.mdx
@@ -73,8 +73,7 @@ specify the settings for the workflow, as follows:
         response = client.workflows.create_workflow(
             request=CreateWorkflowRequest(
                 create_workflow=workflow
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.workflow_information
@@ -236,8 +235,7 @@ In the request body, specify the settings for the workflow. For the specific set
             request=UpdateWorkflowRequest(
                 workflow_id="<workflow-id>",
                 update_workflow=workflow
-            ),
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            )
         )
 
         info = response.workflow_information

--- a/snippets/general-shared-text/no-url-for-serverless-api.mdx
+++ b/snippets/general-shared-text/no-url-for-serverless-api.mdx
@@ -1,5 +1,5 @@
 <Info>
-    If you do not specify the API URL, the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) URL of `https://platform.unstructuredapp.io/api/v1` is used by default. You must always specify your Serverless API key.<br/><br/>
+    If you do not specify the API URL, the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) URL of `https://api.unstructuredapp.io/general/v0/general` is used by default. You must always specify your Serverless API key.<br/><br/>
     
     To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io/general/v0/general`<br/><br/>
     

--- a/snippets/general-shared-text/no-url-for-serverless-api.mdx
+++ b/snippets/general-shared-text/no-url-for-serverless-api.mdx
@@ -1,5 +1,13 @@
 <Info>
-    If you do not specify the API URL, your [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) pay-as-you-go account will be used by default. You must always specify your Serverless API key.<br/><br/>
-    To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io` for the Python SDK beginning with 0.30.0; and `https://api.unstructured.io/general/v0/general` for all other clients.<br/><br/>
-    To use the pay-as-you-go Unstructured API on Azure or AWS with the SDKs, you must always specify the corresponding API URL. See the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) instructions.
+    If you do not specify the API URL, the [Unstructured Serverless API](/api-reference/api-services/saas-api-development-guide) URL of `https://platform.unstructuredapp.io/api/v1` is used by default. You must always specify your Serverless API key.<br/><br/>
+    
+    To use the [Free Unstructured API](/api-reference/api-services/free-api), you must always specify your Free API key, and the Free API URL which is `https://api.unstructured.io/general/v0/general`<br/><br/>
+    
+    To use the pay-as-you-go Unstructured API on Azure or AWS with the SDKs, you must always specify the corresponding API URL. See the [Azure](/api-reference/api-services/azure) or [AWS](/api-reference/api-services/aws) instructions.<br/><br/>
+    
+    To specify the API URL in your code if needed:
+    
+    - For the Unstructured Python SDK and the Unstructured JavaScript/TypeScript SDK, set the `server_url` parameter in the `UnstructuredClient` constructor to the target API URL.
+    - For Unstructured Ingest, set `partition_endpoint` (for Python) or `--partition-endpoint` (for the CLI) to the target API URL.
+    - For the Unstructured open source library, set `api_url` to the target API URL.
 </Info>

--- a/snippets/how-to-api/extract_image_block_types.py.mdx
+++ b/snippets/how-to-api/extract_image_block_types.py.mdx
@@ -45,8 +45,7 @@ if __name__ == "__main__":
 
     try:
         result = await client.general.partition_async(
-            request=request,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            request=request
         )
 
         for element in result.elements:

--- a/snippets/how-to-api/extract_text_as_html.py.mdx
+++ b/snippets/how-to-api/extract_text_as_html.py.mdx
@@ -36,8 +36,7 @@ if __name__ == "__main__":
 
     try:
         result = await client.general.partition_async(
-            request=request,
-            server_url=os.getenv("UNSTRUCTURED_API_URL")
+            request=request
         )
 
         # Provide some minimal CSS for better table readability.

--- a/snippets/how-to-api/get_chunked_elements.py.mdx
+++ b/snippets/how-to-api/get_chunked_elements.py.mdx
@@ -44,8 +44,7 @@ req = operations.PartitionRequest(
 
 try:
     res = await client.general.partition_async(
-        request=req,
-        server_url=os.getenv("UNSTRUCTURED_API_URL")
+        request=req
     )
 
     # Create a dictionary that will hold only

--- a/snippets/ingestion/local-to-local.v2.py.mdx
+++ b/snippets/ingestion/local-to-local.v2.py.mdx
@@ -20,7 +20,6 @@ if __name__ == "__main__":
         partitioner_config=PartitionerConfig(
             partition_by_api=True,
             api_key=os.getenv("UNSTRUCTURED_API_KEY"),
-            partition_endpoint=os.getenv("UNSTRUCTURED_API_URL"),
             strategy="hi_res",
             additional_partition_args={
                 "split_pdf_page": True,


### PR DESCRIPTION
- Removed `server_url=os.getenv("UNSTRUCTURED_API_URL")` from code examples.
- Removed old notes about `0.30.0` Python SDK behaviors.
- Removed various references to setting `UNSTRUCTURED_API_URL` to your API URL.

Etc. 
