### PR TITLE
Update overview.mdx

### DIFF
--- a/platform/api/overview.mdx
+++ b/platform/api/overview.mdx
@@ -191,7 +191,7 @@ The following Postman examples use variables, which you can set as follows:
    - **Initial value**: `https://platform.unstructuredapp.io/api/v1`
    - **Current value**: `https://platform.unstructuredapp.io/api/v1`
    <br/>
-   - **Variable**: `UNSTRUCTURED_API_URL`
+   - **Variable**: `UNSTRUCTURED_API_KEY`
    - **Type**: `secret`
    - **Initial value**: `<your-unstructured-api-key>`
    - **Current value**: `<your-unstructured-api-key>`


### PR DESCRIPTION
I corrected the mistake in the documentation where the API key was incorrectly labeled as UNSTRUCTURED_API_URL instead of UNSTRUCTURED_API_KEY. The correct global variable settings are now:

Variable: UNSTRUCTURED_API_URL

Type: Default
Value: https://platform.unstructuredapp.io/api/v1
Variable: UNSTRUCTURED_API_KEY

Type: Secret