### PR TITLE
Platform UI quickstart: updated video link

### DIFF
--- a/snippets/quickstarts/platform.mdx
+++ b/snippets/quickstarts/platform.mdx
@@ -9,7 +9,7 @@ The requirements are as follows.
 <iframe
 width="560"
 height="315"
-src="https://www.youtube.com/embed/25u3qJ_7WiA"
+src="https://www.youtube.com/embed/Wn2FfHT6H-o"
 title="YouTube video player"
 frameborder="0"
 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
The new how-to shows the new dynamic pipelines feature instead of the now-removed Basic, Advanced, and Platinum options.