### PR TITLE
Ingest v2: Dropbox connectors - enable automatic refreshing of expired access tokens

### DIFF
--- a/snippets/destination_connectors/dropbox.sh.mdx
+++ b/snippets/destination_connectors/dropbox.sh.mdx
@@ -18,5 +18,7 @@ unstructured-ingest \
     --additional-partition-args="{\"split_pdf_page\":\"true\", \"split_pdf_allow_failed\":\"true\", \"split_pdf_concurrency_level\": 15}" \
   dropbox \
     --token $DROPBOX_ACCESS_TOKEN \
+    --refresh-token $DROPBOX_REFRESH_TOKEN \
+    --app-key $DROPBOX_APP_KEY \
+    --app-secret $DROPBOX_APP_SECRET \
     --remote-url $DROPBOX_REMOTE_URL
-```

--- a/snippets/destination_connectors/dropbox.v2.py.mdx
+++ b/snippets/destination_connectors/dropbox.v2.py.mdx
@@ -41,7 +41,10 @@ if __name__ == "__main__":
         embedder_config=EmbedderConfig(embedding_provider="huggingface"),
         destination_connection_config=DropboxConnectionConfig(
             access_config=DropboxAccessConfig(
-                token=os.getenv("DROPBOX_ACCESS_TOKEN")
+                token=os.getenv("DROPBOX_ACCESS_TOKEN"),
+                refresh_token=os.getenv("DROPBOX_REFRESH_TOKEN"),
+                app_key=os.getenv("DROPBOX_APP_KEY"),
+                app_secret=os.getenv("DROPBOX_APP_SECRET")
             )
         ),
         uploader_config=DropboxUploaderConfig(

--- a/snippets/general-shared-text/dropbox-cli-api.mdx
+++ b/snippets/general-shared-text/dropbox-cli-api.mdx
@@ -12,3 +12,9 @@ The following environment variables:
 
 - `DROPBOX_REMOTE_URL` - The remote URL to the target subfolder inside of the app folder for the Dropbox app, represented by `--remote-url` (CLI) or `remote_url` (Python).
 - `DROPBOX_ACCESS_TOKEN` - The value of the access token for the Dropbox app that is associated with the target app folder, represented by `--token` (CLI) or `token` (Python).
+
+To have Unstructured refresh expired Dropbox App access tokens on your behalf, you must also provide the following environment variables:
+
+- `DROPBOX_REFRESH_TOKEN` - The value of the refresh token for the corresponding access token, represented by `--refresh-token` (CLI) or `refresh_token` (Python).
+- `DROPBOX_APP_KEY` - The app key for the Dropbox app, represented by `--app-key` (CLI) or `app_key` (Python).
+- `DROPBOX_APP_SECRET` - The app secret for the Dropbox app, represented by `--app-secret` (CLI) or `app_secret` (Python).

--- a/snippets/general-shared-text/dropbox.mdx
+++ b/snippets/general-shared-text/dropbox.mdx
@@ -29,7 +29,17 @@ allowfullscreen
       Access tokens are valid for **only four hours** after they are created. After this four-hour period, you can no longer use the expired access token. 
       Dropbox does not allow the creation of access tokens that are valid for more than four hours.
 
-      To generate a replacement token for an expired one, see [Replace an expired access token](#replace-an-expired-access-token), later in this article.
+      To replace an expired access token, you must first generate a _refresh token_ for the corresponding access token. To learn how to generate an access token and its corresponding refresh token, 
+      see [Replace an expired access token](#replace-an-expired-access-token), later in this article.
+
+      If you do not already have the corresponding refresh token for an existing access token, or if you lose a refresh token after you generate it, 
+      you must generate a new access token and its corresponding refresh token.
+
+      For [Unstructured Ingest](/ingestion/overview), instead of continualy replacing expired access tokens yourself, you can have Unstructured do it for you as needed; just supply Unstructured 
+      with the original access token and its corresponding refresh token along with the Dropbox app's **App key** and **App secret** values. 
+      To learn how to supply these to Unstructured, look for mentions of "access token, "refresh token," "app key," and "app secret" in the connector settings later in this article.
+
+      For the [Unstructured Platform](/platform/overview), or if you want to otherwise use the refresh token to replace the expired access token yourself, currently you must manually replace expired access tokens.
    </Warning>
 
 3. The app folder that your Dropbox app will use for access can be found in your Dropbox account under the `Apps` top-level folder. For example, if the value of the **App folder name** 
@@ -96,7 +106,11 @@ To replace an old, expired access token with a new, valid one, do the following:
    - The value of `refresh_token` is the refresh token that you can use to replace this access token much faster and easier next time. 
      If you lose this refresh token, you must go back to Step 2.
 
-8. To use the refresh token to replace the expired access token, make the following REST API call, replacing the following placeholders:
+   For [Unstructured Ingest](/ingestion/overview), if you want Unstructured to use this refresh token to automatically replace the expired access token instead of replacing it yourself, then 
+   simply supply Unstructured with these `access_token` and `refresh_token` values, along with the `<app-key>` and `<app-secret>` values 
+   as described earlier in this procedure, and then stop here.
+
+8. For the [Unstructured Platform](/platform/overview), or if you want to otherwise use the refresh token to replace the expired access token yourself, make the following REST API call, replacing the following placeholders:
 
    - Replace `<refresh-token>` with the refresh token.
    - Replace `<app-key>` with the app key for your Dropbox app.
@@ -114,6 +128,6 @@ To replace an old, expired access token with a new, valid one, do the following:
 
    - The value of `access_token` (starting with the characters `sl`) is the new, valid access token. In the connector, replace the old, 
      expired access token value with this new, valid access token value.
-   - The value of `refresh_token` is the new, valid refresh token. To replace the expired access token, go back to Step 8.
+   - The value of `refresh_token` is the new, valid refresh token. To replace the expired access token yourself, go back to Step 8.
 
    

--- a/snippets/source_connectors/dropbox.sh.mdx
+++ b/snippets/source_connectors/dropbox.sh.mdx
@@ -6,6 +6,9 @@ unstructured-ingest \
     --remote-url $DROPBOX_REMOTE_URL \
     --output-dir $LOCAL_FILE_OUTPUT_DIR \
     --token $DROPBOX_ACCESS_TOKEN \
+    --refresh-token $DROPBOX_REFRESH_TOKEN \
+    --app-key $DROPBOX_APP_KEY \
+    --app-secret $DROPBOX_APP_SECRET \
     --num-processes 2 \
     --recursive \
     --verbose \

--- a/snippets/source_connectors/dropbox.v2.py.mdx
+++ b/snippets/source_connectors/dropbox.v2.py.mdx
@@ -27,7 +27,10 @@ if __name__ == "__main__":
         downloader_config=DropboxDownloaderConfig(download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")),
         source_connection_config=DropboxConnectionConfig(
             access_config=DropboxAccessConfig(
-                token=os.getenv("DROPBOX_ACCESS_TOKEN")
+                token=os.getenv("DROPBOX_ACCESS_TOKEN"),
+                refresh_token=os.getenv("DROPBOX_REFRESH_TOKEN"),
+                app_key=os.getenv("DROPBOX_APP_KEY"),
+                app_secret=os.getenv("DROPBOX_APP_SECRET")
             )
         ),
         partitioner_config=PartitionerConfig(


### PR DESCRIPTION
Available for Ingest v2. Not yet for Platform.

See: 

- https://unstructured-53-docs-221-dropbox-refresh-token.mintlify.app/ingestion/source-connectors/dropbox
- https://unstructured-53-docs-221-dropbox-refresh-token.mintlify.app/ingestion/destination-connectors/overview