### PR TITLE
UI/API: Getting started note for first-time users who enter the docs by dropping directly into a connector setup page

### DIFF
--- a/api-reference/workflow/destinations/astradb.mdx
+++ b/api-reference/workflow/destinations/astradb.mdx
@@ -2,6 +2,10 @@
 title: Astra DB
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Astra DB.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/azure-ai-search.mdx
+++ b/api-reference/workflow/destinations/azure-ai-search.mdx
@@ -2,6 +2,10 @@
 title: Azure AI Search
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Azure AI Search.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/couchbase.mdx
+++ b/api-reference/workflow/destinations/couchbase.mdx
@@ -2,6 +2,10 @@
 title: Couchbase
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Couchbase.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/databricks-delta-table.mdx
+++ b/api-reference/workflow/destinations/databricks-delta-table.mdx
@@ -2,7 +2,7 @@
 title: Delta Tables in Databricks
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Delta Tables in Databricks.
     
     For information about connecting Unstructured to Delta Tables in Amazon S3 instead, see 
@@ -10,7 +10,11 @@ title: Delta Tables in Databricks
 
     For information about connecting Unstructured to Databricks Volumes instead, see 
     [Databricks Volumes](/api-reference/workflow/destinations/databricks-volumes).
-</Note>
+</Tip>
+
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
 
 Send processed data from Unstructured to a Delta Table in Databricks.
 

--- a/api-reference/workflow/destinations/databricks-volumes.mdx
+++ b/api-reference/workflow/destinations/databricks-volumes.mdx
@@ -2,12 +2,16 @@
 title: Databricks Volumes
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Databricks Volumes.
     
     For information about connecting Unstructured to Delta Tables in Databricks instead, see 
     [Delta Tables in Databricks](/api-reference/workflow/destinations/databricks-delta-table).
-</Note>
+</Tip>
+
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
 
 Send processed data from Unstructured to Databricks Volumes.
 

--- a/api-reference/workflow/destinations/delta-table.mdx
+++ b/api-reference/workflow/destinations/delta-table.mdx
@@ -2,11 +2,15 @@
 title: Delta Tables in Amazon S3
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Delta Tables in Amazon S3. For information about 
     connecting Unstructured to Delta Tables in Databricks instead, see 
     [Delta Tables in Databricks](/api-reference/workflow/destinations/databricks-delta-table).
-</Note>
+</Tip>
+
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
 
 Send processed data from Unstructured to a Delta Table, stored in Amazon S3.
 

--- a/api-reference/workflow/destinations/elasticsearch.mdx
+++ b/api-reference/workflow/destinations/elasticsearch.mdx
@@ -2,6 +2,10 @@
 title: Elasticsearch
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Elasticsearch.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/google-cloud.mdx
+++ b/api-reference/workflow/destinations/google-cloud.mdx
@@ -2,6 +2,10 @@
 title: Google Cloud Storage
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Google Cloud Storage.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/kafka.mdx
+++ b/api-reference/workflow/destinations/kafka.mdx
@@ -2,6 +2,10 @@
 title: Kafka
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Kafka.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/milvus.mdx
+++ b/api-reference/workflow/destinations/milvus.mdx
@@ -2,6 +2,10 @@
 title: Milvus
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Milvus.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/mongodb.mdx
+++ b/api-reference/workflow/destinations/mongodb.mdx
@@ -2,6 +2,10 @@
 title: MongoDB
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to MongoDB.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/motherduck.mdx
+++ b/api-reference/workflow/destinations/motherduck.mdx
@@ -2,6 +2,10 @@
 title: MotherDuck
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to MotherDuck.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/neo4j.mdx
+++ b/api-reference/workflow/destinations/neo4j.mdx
@@ -2,6 +2,10 @@
 title: Neo4j
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Neo4j.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/onedrive.mdx
+++ b/api-reference/workflow/destinations/onedrive.mdx
@@ -2,6 +2,10 @@
 title: OneDrive
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to OneDrive.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/pinecone.mdx
+++ b/api-reference/workflow/destinations/pinecone.mdx
@@ -2,6 +2,10 @@
 title: Pinecone
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Pinecone.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/postgresql.mdx
+++ b/api-reference/workflow/destinations/postgresql.mdx
@@ -2,6 +2,10 @@
 title: PostgreSQL
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to PostgreSQL.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/qdrant.mdx
+++ b/api-reference/workflow/destinations/qdrant.mdx
@@ -2,6 +2,10 @@
 title: Qdrant
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Qdrant.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/redis.mdx
+++ b/api-reference/workflow/destinations/redis.mdx
@@ -2,6 +2,10 @@
 title: Redis
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Redis.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/s3.mdx
+++ b/api-reference/workflow/destinations/s3.mdx
@@ -2,6 +2,10 @@
 title: S3
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Amazon S3.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/snowflake.mdx
+++ b/api-reference/workflow/destinations/snowflake.mdx
@@ -2,6 +2,10 @@
 title: Snowflake
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Snowflake.
 
 The requirements are as follows.

--- a/api-reference/workflow/destinations/weaviate.mdx
+++ b/api-reference/workflow/destinations/weaviate.mdx
@@ -2,6 +2,10 @@
 title: Weaviate
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 Send processed data from Unstructured to Weaviate.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/azure-blob-storage.mdx
+++ b/api-reference/workflow/sources/azure-blob-storage.mdx
@@ -2,6 +2,10 @@
 title: Azure
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Azure Blob Storage.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/box.mdx
+++ b/api-reference/workflow/sources/box.mdx
@@ -2,6 +2,10 @@
 title: Box
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Box.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/confluence.mdx
+++ b/api-reference/workflow/sources/confluence.mdx
@@ -2,6 +2,10 @@
 title: Confluence
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Confluence.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/couchbase.mdx
+++ b/api-reference/workflow/sources/couchbase.mdx
@@ -2,6 +2,10 @@
 title: Couchbase
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Couchbase.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/databricks-volumes.mdx
+++ b/api-reference/workflow/sources/databricks-volumes.mdx
@@ -2,6 +2,10 @@
 title: Databricks Volumes
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Databricks Volumes.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/dropbox.mdx
+++ b/api-reference/workflow/sources/dropbox.mdx
@@ -2,6 +2,10 @@
 title: Dropbox
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Dropbox.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/elasticsearch.mdx
+++ b/api-reference/workflow/sources/elasticsearch.mdx
@@ -2,6 +2,10 @@
 title: Elasticsearch
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Elasticsearch.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/google-cloud.mdx
+++ b/api-reference/workflow/sources/google-cloud.mdx
@@ -2,6 +2,10 @@
 title: Google Cloud Storage
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Google Cloud Storage.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/google-drive.mdx
+++ b/api-reference/workflow/sources/google-drive.mdx
@@ -2,6 +2,10 @@
 title: Google Drive
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Google Drive.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/kafka.mdx
+++ b/api-reference/workflow/sources/kafka.mdx
@@ -2,6 +2,10 @@
 title: Kafka
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Kafka.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/mongodb.mdx
+++ b/api-reference/workflow/sources/mongodb.mdx
@@ -2,6 +2,10 @@
 title: MongoDB
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from MongoDB.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/onedrive.mdx
+++ b/api-reference/workflow/sources/onedrive.mdx
@@ -2,6 +2,10 @@
 title: OneDrive
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from OneDrive.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/outlook.mdx
+++ b/api-reference/workflow/sources/outlook.mdx
@@ -2,6 +2,10 @@
 title: Outlook
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Outlook.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/postgresql.mdx
+++ b/api-reference/workflow/sources/postgresql.mdx
@@ -2,6 +2,10 @@
 title: PostgreSQL
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from PostgreSQL.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/s3.mdx
+++ b/api-reference/workflow/sources/s3.mdx
@@ -2,6 +2,10 @@
 title: S3
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Amazon S3.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/salesforce.mdx
+++ b/api-reference/workflow/sources/salesforce.mdx
@@ -2,6 +2,10 @@
 title: Salesforce
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Salesforce.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/sharepoint.mdx
+++ b/api-reference/workflow/sources/sharepoint.mdx
@@ -2,6 +2,10 @@
 title: SharePoint
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from SharePoint.
 
 The requirements are as follows.

--- a/api-reference/workflow/sources/snowflake.mdx
+++ b/api-reference/workflow/sources/snowflake.mdx
@@ -2,6 +2,10 @@
 title: Snowflake
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 Ingest your files into Unstructured from Snowflake.
 
 The requirements are as follows.

--- a/snippets/general-shared-text/first-time-api-destination-connector.mdx
+++ b/snippets/general-shared-text/first-time-api-destination-connector.mdx
@@ -1,0 +1,17 @@
+<Note>
+    If you're new to Unstructured, read this note first.
+    
+    Before you can create this destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
+    Unstructured API key. After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to get the key. 
+    To learn how, watch this 40-second [how-to video](https://www.youtube.com/watch?v=FucugLkYB6M).
+
+    After you create the destination connector, add it along with a 
+    [source connector](/api-reference/workflow/sources/overview) to a [workflow](/api-reference/workflow/overview#workflows). 
+    Then run the worklow as a [job](/api-reference/workflow/overview#jobs). To learn how, try out the 
+    [hands-on Workflow Endpoint quickstart](/api-reference/workflow/overview#quickstart), 
+    go directly to the [quickstart notebook](https://colab.research.google.com/drive/13f5C9WtUvIPjwJzxyOR3pNJ9K9vnF4ww), 
+    or watch the two 4-minute video tutorials for the [Unstructured Python SDK](/api-reference/workflow/overview#unstructured-python-sdk).
+    
+    If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
+    [contact us](https://unstructured.io/contact) directly.
+</Note>

--- a/snippets/general-shared-text/first-time-api-source-connector.mdx
+++ b/snippets/general-shared-text/first-time-api-source-connector.mdx
@@ -1,0 +1,17 @@
+<Note>
+    If you're new to Unstructured, read this note first.
+    
+    Before you can create this source connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
+    Unstructured API key. After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to get the key. 
+    To learn how, watch this 40-second [how-to video](https://www.youtube.com/watch?v=FucugLkYB6M).
+
+    After you create the source connector, add it along with a 
+    [destination connector](/api-reference/workflow/destinations/overview) to a [workflow](/api-reference/workflow/overview#workflows). 
+    Then run the worklow as a [job](/api-reference/workflow/overview#jobs). To learn how, try out the 
+    [hands-on Workflow Endpoint quickstart](/api-reference/workflow/overview#quickstart), 
+    go directly to the [quickstart notebook](https://colab.research.google.com/drive/13f5C9WtUvIPjwJzxyOR3pNJ9K9vnF4ww), 
+    or watch the two 4-minute video tutorials for the [Unstructured Python SDK](/api-reference/workflow/overview#unstructured-python-sdk).
+    
+    If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
+    [contact us](https://unstructured.io/contact) directly.
+</Note>

--- a/snippets/general-shared-text/first-time-ui-destination-connector.mdx
+++ b/snippets/general-shared-text/first-time-ui-destination-connector.mdx
@@ -1,0 +1,14 @@
+<Note>
+    If you're new to Unstructured, read this note first.
+    
+    Before you can create this destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
+    After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to create the destination connector.
+    
+    After you create the destination connector, add it along with a 
+    [source connector](/ui/sources/overview) to a [workflow](/ui/workflows). Then run the worklow as a 
+    [job](/ui/jobs). To learn how, try out the [hands-on UI quickstart](/ui/quickstart) or watch the 4-minute 
+    [video tutorial](https://www.youtube.com/watch?v=Wn2FfHT6H-o).
+    
+    If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
+    [contact us](https://unstructured.io/contact) directly.
+</Note>

--- a/snippets/general-shared-text/first-time-ui-source-connector.mdx
+++ b/snippets/general-shared-text/first-time-ui-source-connector.mdx
@@ -1,0 +1,14 @@
+<Note>
+    If you're new to Unstructured, read this note first.
+    
+    Before you can create this source connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
+    After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to create the source connector.
+    
+    After you create the source connector, add it along with a 
+    [destination connector](/ui/destinations/overview) to a [workflow](/ui/workflows). Then run the worklow as a 
+    [job](/ui/jobs). To learn how, try out the [hands-on UI quickstart](/ui/quickstart) or watch the 4-minute 
+    [video tutorial](https://www.youtube.com/watch?v=Wn2FfHT6H-o).
+    
+    If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
+    [contact us](https://unstructured.io/contact) directly.
+</Note>

--- a/ui/destinations/astradb.mdx
+++ b/ui/destinations/astradb.mdx
@@ -2,6 +2,10 @@
 title: Astra DB 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Astra DB.
 
 The requirements are as follows.

--- a/ui/destinations/azure-ai-search.mdx
+++ b/ui/destinations/azure-ai-search.mdx
@@ -2,6 +2,10 @@
 title: Azure AI Search 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Azure AI Search.
 
 The requirements are as follows.

--- a/ui/destinations/chroma.mdx
+++ b/ui/destinations/chroma.mdx
@@ -2,6 +2,10 @@
 title: Chroma 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Chroma.
 
 The requirements are as follows.

--- a/ui/destinations/couchbase.mdx
+++ b/ui/destinations/couchbase.mdx
@@ -2,6 +2,10 @@
 title: Couchbase 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Couchbase.
 
 The requirements are as follows.

--- a/ui/destinations/databricks-delta-table.mdx
+++ b/ui/destinations/databricks-delta-table.mdx
@@ -2,7 +2,7 @@
 title: Delta Tables in Databricks
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Delta Tables in Databricks.
     
     For information about connecting Unstructured to Delta Tables in Amazon S3 instead, see 
@@ -10,7 +10,11 @@ title: Delta Tables in Databricks
 
     For information about connecting Unstructured to Databricks Volumes instead, see 
     [Databricks Volumes](/ui/destinations/databricks-volumes).
-</Note>
+</Tip>
+
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
 
 Send processed data from Unstructured to a Delta Table in Databricks.
 

--- a/ui/destinations/databricks-volumes.mdx
+++ b/ui/destinations/databricks-volumes.mdx
@@ -2,12 +2,16 @@
 title: Databricks Volumes
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Databricks Volumes.
     
     For information about connecting Unstructured to Delta Tables in Databricks instead, see 
     [Delta Tables in Databricks](/ui/destinations/databricks-delta-table).
-</Note>
+</Tip>
+
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
 
 Send processed data from Unstructured to Databricks Volumes.
 

--- a/ui/destinations/delta-table.mdx
+++ b/ui/destinations/delta-table.mdx
@@ -2,11 +2,15 @@
 title: Delta Tables in Amazon S3
 ---
 
-<Note>
+<Tip>
     This article covers connecting Unstructured to Delta Tables in Amazon S3. For information about 
     connecting Unstructured to Delta Tables in Databricks instead, see 
     [Delta Tables in Databricks](/ui/destinations/databricks-delta-table).
-</Note>
+</Tip>
+
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
 
 Send processed data from Unstructured to a Delta Table, stored in Amazon S3.
 

--- a/ui/destinations/elasticsearch.mdx
+++ b/ui/destinations/elasticsearch.mdx
@@ -2,6 +2,10 @@
 title: Elasticsearch 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Elasticsearch.
 
 The requirements are as follows.

--- a/ui/destinations/google-cloud.mdx
+++ b/ui/destinations/google-cloud.mdx
@@ -2,6 +2,10 @@
 title: Google Cloud Storage
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Google Cloud Storage.
 
 The requirements are as follows.

--- a/ui/destinations/kafka.mdx
+++ b/ui/destinations/kafka.mdx
@@ -2,6 +2,10 @@
 title: Kafka
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Kafka.
 
 The requirements are as follows.

--- a/ui/destinations/milvus.mdx
+++ b/ui/destinations/milvus.mdx
@@ -2,6 +2,10 @@
 title: Milvus
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Milvus.
 
 The requirements are as follows.

--- a/ui/destinations/mongodb.mdx
+++ b/ui/destinations/mongodb.mdx
@@ -2,6 +2,10 @@
 title: MongoDB
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to MongoDB.
 
 The requirements are as follows.

--- a/ui/destinations/motherduck.mdx
+++ b/ui/destinations/motherduck.mdx
@@ -2,6 +2,10 @@
 title: MotherDuck
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to MotherDuck.
 
 The requirements are as follows.

--- a/ui/destinations/neo4j.mdx
+++ b/ui/destinations/neo4j.mdx
@@ -2,6 +2,10 @@
 title: Neo4j
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Neo4j.
 
 The requirements are as follows.

--- a/ui/destinations/onedrive.mdx
+++ b/ui/destinations/onedrive.mdx
@@ -2,6 +2,10 @@
 title: OneDrive
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to OneDrive.
 
 The requirements are as follows.

--- a/ui/destinations/opensearch.mdx
+++ b/ui/destinations/opensearch.mdx
@@ -2,6 +2,10 @@
 title: OpenSearch 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to OpenSearch.
 
 The requirements are as follows.

--- a/ui/destinations/pinecone.mdx
+++ b/ui/destinations/pinecone.mdx
@@ -2,6 +2,10 @@
 title: Pinecone
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Pinecone.
 
 The following video shows how to fulfill the minimum set of Pinecone requirements:

--- a/ui/destinations/postgresql.mdx
+++ b/ui/destinations/postgresql.mdx
@@ -2,6 +2,10 @@
 title: PostgreSQL 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to PostgreSQL.
 
 The requirements are as follows.

--- a/ui/destinations/qdrant.mdx
+++ b/ui/destinations/qdrant.mdx
@@ -2,6 +2,10 @@
 title: Qdrant 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Qdrant.
 
 The requirements are as follows.

--- a/ui/destinations/redis.mdx
+++ b/ui/destinations/redis.mdx
@@ -2,6 +2,10 @@
 title: Redis 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Redis.
 
 The requirements are as follows.

--- a/ui/destinations/s3.mdx
+++ b/ui/destinations/s3.mdx
@@ -2,6 +2,10 @@
 title: S3 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Amazon S3.
 
 The requirements are as follows.

--- a/ui/destinations/snowflake.mdx
+++ b/ui/destinations/snowflake.mdx
@@ -2,6 +2,10 @@
 title: Snowflake
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Snowflake.
 
 The requirements are as follows.

--- a/ui/destinations/weaviate.mdx
+++ b/ui/destinations/weaviate.mdx
@@ -2,6 +2,10 @@
 title: Weaviate 
 ---
 
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
 Send processed data from Unstructured to Weaviate.
 
 The requirements are as follows.

--- a/ui/sources/azure-blob-storage.mdx
+++ b/ui/sources/azure-blob-storage.mdx
@@ -2,6 +2,10 @@
 title: Azure
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Azure Blob Storage.
 
 The requirements are as follows.

--- a/ui/sources/box.mdx
+++ b/ui/sources/box.mdx
@@ -2,6 +2,10 @@
 title: Box
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Box.
 
 The requirements are as follows. 

--- a/ui/sources/confluence.mdx
+++ b/ui/sources/confluence.mdx
@@ -2,6 +2,10 @@
 title: Confluence
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Confluence.
 
 The requirements are as follows.

--- a/ui/sources/couchbase.mdx
+++ b/ui/sources/couchbase.mdx
@@ -2,6 +2,10 @@
 title: Couchbase
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Couchbase.
 
 The requirements are as follows.

--- a/ui/sources/databricks-volumes.mdx
+++ b/ui/sources/databricks-volumes.mdx
@@ -2,6 +2,10 @@
 title: Databricks Volumes 
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Databricks Volumes.
 
 The requirements are as follows. 

--- a/ui/sources/dropbox.mdx
+++ b/ui/sources/dropbox.mdx
@@ -2,6 +2,10 @@
 title: Dropbox
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Dropbox.
 
 The requirements are as follows.

--- a/ui/sources/elasticsearch.mdx
+++ b/ui/sources/elasticsearch.mdx
@@ -2,6 +2,10 @@
 title: Elasticsearch 
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Elasticsearch.
 
 The requirements are as follows.

--- a/ui/sources/google-cloud.mdx
+++ b/ui/sources/google-cloud.mdx
@@ -2,6 +2,10 @@
 title: Google Cloud Storage
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Google Cloud Storage.
 
 The requirements are as follows.

--- a/ui/sources/google-drive.mdx
+++ b/ui/sources/google-drive.mdx
@@ -2,6 +2,10 @@
 title: Google Drive 
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Google Drive.
 
 The requirements are as follows.

--- a/ui/sources/kafka.mdx
+++ b/ui/sources/kafka.mdx
@@ -2,6 +2,10 @@
 title: Kafka
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Kafka.
 
 The requirements are as follows. 

--- a/ui/sources/mongodb.mdx
+++ b/ui/sources/mongodb.mdx
@@ -2,6 +2,10 @@
 title: MongoDB
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from MongoDB.
 
 The requirements are as follows. 

--- a/ui/sources/onedrive.mdx
+++ b/ui/sources/onedrive.mdx
@@ -2,6 +2,10 @@
 title: OneDrive
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from OneDrive.
 
 The requirements are as follows.

--- a/ui/sources/opensearch.mdx
+++ b/ui/sources/opensearch.mdx
@@ -2,6 +2,10 @@
 title: OpenSearch
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from OpenSearch.
 
 The requirements are as follows.

--- a/ui/sources/outlook.mdx
+++ b/ui/sources/outlook.mdx
@@ -2,6 +2,10 @@
 title: Outlook
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Outlook.
 
 The requirements are as follows.

--- a/ui/sources/postgresql.mdx
+++ b/ui/sources/postgresql.mdx
@@ -2,6 +2,10 @@
 title: PostgreSQL
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from PostgreSQL.
 
 The requirements are as follows.

--- a/ui/sources/s3.mdx
+++ b/ui/sources/s3.mdx
@@ -2,6 +2,10 @@
 title: S3
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Amazon S3.
 
 The requirements are as follows. 

--- a/ui/sources/salesforce.mdx
+++ b/ui/sources/salesforce.mdx
@@ -2,6 +2,10 @@
 title: Salesforce
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Salesforce.
 
 The requirements are as follows. 

--- a/ui/sources/sftp-storage.mdx
+++ b/ui/sources/sftp-storage.mdx
@@ -2,6 +2,10 @@
 title: SFTP 
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from SFTP.
 
 The requirements are as follows.

--- a/ui/sources/sharepoint.mdx
+++ b/ui/sources/sharepoint.mdx
@@ -2,6 +2,10 @@
 title: SharePoint 
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from SharePoint.
 
 The requirements are as follows. 

--- a/ui/sources/snowflake.mdx
+++ b/ui/sources/snowflake.mdx
@@ -2,6 +2,10 @@
 title: Snowflake
 ---
 
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
 Ingest your files into Unstructured from Snowflake.
 
 The requirements are as follows.


### PR DESCRIPTION
We want to link from our product site to the tech docs site for setup docs for a particular partner. The closest we have right now are the individual source and destination connector docs. Until we have a more robust approach, this PR adds a getting started note at the top/beginning of each of these pages, giving new users some brief guidance to be more successful here faster. 

See for example:

- UI source connector page: https://unstructured-53-first-use-2025-03-13.mintlify.app/ui/sources/azure-blob-storage
- UI destination connector page: https://unstructured-53-first-use-2025-03-13.mintlify.app/ui/destinations/astradb
- API source connector page: https://unstructured-53-first-use-2025-03-13.mintlify.app/api-reference/workflow/sources/azure-blob-storage
- API destination connector page: https://unstructured-53-first-use-2025-03-13.mintlify.app/api-reference/workflow/destinations/astradb

