### PR TITLE
Remove broken video link in vectorshift.mdx

### DIFF
--- a/examplecode/tools/vectorshift.mdx
+++ b/examplecode/tools/vectorshift.mdx
@@ -11,18 +11,6 @@ This hands-on demonstration uses the no-code interface to walk you through creat
 enables you to use GPT-4o-mini to chat in real time with a PDF document that is processed by Unstructured and has its processed data stored in a 
 [Pinecone](https://www.pinecone.io/) vector database. 
 
-This video provides a general introduction to VectorShift pipeline projects:
-
-<iframe
-width="560"
-height="315"
-src="https://www.youtube.com/embed/_ToXPwOW2bY"
-title="YouTube video player"
-frameborder="0"
-allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-allowfullscreen
-></iframe>
-
 ## Prerequisites
 
 <iframe


### PR DESCRIPTION
This link was to a third-party video that appears to no longer exist.