### PR TITLE
UI/API: Further updates to getting-started notes at the beginning of connector how-to pages

### DIFF
--- a/api-reference/workflow/destinations/overview.mdx
+++ b/api-reference/workflow/destinations/overview.mdx
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+import FirstTimeAPIDestinationConnector from '/snippets/general-shared-text/first-time-api-destination-connector.mdx';
+
+<FirstTimeAPIDestinationConnector />
+
 To use the [Unstructured Workflow Endpoint](/api-reference/workflow/overview) to manage destination connectors, do the following:
 
 - To get a list of available destination connectors, use the `UnstructuredClient` object's `destinations.list_destinations` function (for the Python SDK) or 

--- a/api-reference/workflow/overview.mdx
+++ b/api-reference/workflow/overview.mdx
@@ -42,7 +42,7 @@ allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; pic
 allowfullscreen
 ></iframe>
 
-Watch the following 3-minute video to learn how to use the Python SDK to call the Unstructured Workflow Endpoint to 
+Watch the following 4-minute video to learn how to use the Python SDK to call the Unstructured Workflow Endpoint to 
 create [workflows](#workflows) and [jobs](#jobs) in the Unstructured UI.
 
 <iframe

--- a/api-reference/workflow/sources/overview.mdx
+++ b/api-reference/workflow/sources/overview.mdx
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+import FirstTimeAPISourceConnector from '/snippets/general-shared-text/first-time-api-source-connector.mdx';
+
+<FirstTimeAPISourceConnector />
+
 To use the [Unstructured Workflow Endpoint](/api-reference/workflow/overview) to manage source connectors, do the following:
 
 - To get a list of available source connectors, use the `UnstructuredClient` object's `sources.list_sources` function (for the Python SDK) or 

--- a/snippets/general-shared-text/first-time-api-destination-connector.mdx
+++ b/snippets/general-shared-text/first-time-api-destination-connector.mdx
@@ -1,7 +1,7 @@
 <Note>
     If you're new to Unstructured, read this note first.
     
-    Before you can create this destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
+    Before you can create a destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
     Unstructured API key. After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to get the key. 
     To learn how, watch this 40-second [how-to video](https://www.youtube.com/watch?v=FucugLkYB6M).
 
@@ -12,6 +12,11 @@
     go directly to the [quickstart notebook](https://colab.research.google.com/drive/13f5C9WtUvIPjwJzxyOR3pNJ9K9vnF4ww), 
     or watch the two 4-minute video tutorials for the [Unstructured Python SDK](/api-reference/workflow/overview#unstructured-python-sdk).
     
+    You can also create destination connectors with the Unstructured user interface (UI). 
+    [Learn how](/ui/destinations/overview).
+
     If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
     [contact us](https://unstructured.io/contact) directly.
+
+    You are now ready to start creating a destination connector! Keep reading to learn how.
 </Note>

--- a/snippets/general-shared-text/first-time-api-source-connector.mdx
+++ b/snippets/general-shared-text/first-time-api-source-connector.mdx
@@ -1,7 +1,7 @@
 <Note>
     If you're new to Unstructured, read this note first.
     
-    Before you can create this source connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
+    Before you can create a source connector, you must first [sign up for Unstructured](https://platform.unstructured.io) and get your 
     Unstructured API key. After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to get the key. 
     To learn how, watch this 40-second [how-to video](https://www.youtube.com/watch?v=FucugLkYB6M).
 
@@ -12,6 +12,11 @@
     go directly to the [quickstart notebook](https://colab.research.google.com/drive/13f5C9WtUvIPjwJzxyOR3pNJ9K9vnF4ww), 
     or watch the two 4-minute video tutorials for the [Unstructured Python SDK](/api-reference/workflow/overview#unstructured-python-sdk).
     
+    You can also create source connectors with the Unstructured user interface (UI). 
+    [Learn how](/ui/sources/overview).
+
     If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
     [contact us](https://unstructured.io/contact) directly.
+
+    You are now ready to start creating a source connector! Keep reading to learn how.
 </Note>

--- a/snippets/general-shared-text/first-time-ui-destination-connector.mdx
+++ b/snippets/general-shared-text/first-time-ui-destination-connector.mdx
@@ -1,14 +1,19 @@
 <Note>
     If you're new to Unstructured, read this note first.
     
-    Before you can create this destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
+    Before you can create a destination connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
     After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to create the destination connector.
     
     After you create the destination connector, add it along with a 
     [source connector](/ui/sources/overview) to a [workflow](/ui/workflows). Then run the worklow as a 
     [job](/ui/jobs). To learn how, try out the [hands-on UI quickstart](/ui/quickstart) or watch the 4-minute 
     [video tutorial](https://www.youtube.com/watch?v=Wn2FfHT6H-o).
+
+    You can also create destination connectors with the Unstructured API. 
+    [Learn how](/api-reference/workflow/destinations/overview).
     
     If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
     [contact us](https://unstructured.io/contact) directly.
+
+    You are now ready to start creating a destination connector! Keep reading to learn how.
 </Note>

--- a/snippets/general-shared-text/first-time-ui-source-connector.mdx
+++ b/snippets/general-shared-text/first-time-ui-source-connector.mdx
@@ -1,14 +1,19 @@
 <Note>
     If you're new to Unstructured, read this note first.
     
-    Before you can create this source connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
+    Before you can create a source connector, you must first [sign up for Unstructured](https://platform.unstructured.io). 
     After you sign up, the [Unstructured user interface](/ui/overview) (UI) appears, which you use to create the source connector.
     
     After you create the source connector, add it along with a 
     [destination connector](/ui/destinations/overview) to a [workflow](/ui/workflows). Then run the worklow as a 
     [job](/ui/jobs). To learn how, try out the [hands-on UI quickstart](/ui/quickstart) or watch the 4-minute 
     [video tutorial](https://www.youtube.com/watch?v=Wn2FfHT6H-o).
+
+    You can also create source connectors with the Unstructured API. 
+    [Learn how](/api-reference/workflow/sources/overview).
     
     If you need help, reach out to the [community](https://short.unstructured.io/pzw05l7) on Slack, or 
     [contact us](https://unstructured.io/contact) directly.
+
+    You are now ready to start creating a source connector! Keep reading to learn how.
 </Note>

--- a/ui/destinations/overview.mdx
+++ b/ui/destinations/overview.mdx
@@ -1,7 +1,12 @@
 ---
 title: Overview
-description: Destination connectors in Unstructured are designed to specify the endpoint for data processed within the platform. These connectors ensure that the transformed and analyzed data is securely and efficiently transferred to a storage system for future use, often to a vector database for tasks that involve high-speed retrieval and advanced data analytics operations.
 ---
+
+import FirstTimeUIDestinationConnector from '/snippets/general-shared-text/first-time-ui-destination-connector.mdx';
+
+<FirstTimeUIDestinationConnector />
+
+Destination connectors in Unstructured are designed to specify the endpoint for data processed within the platform. These connectors ensure that the transformed and analyzed data is securely and efficiently transferred to a storage system for future use, often to a vector database for tasks that involve high-speed retrieval and advanced data analytics operations.
 
 ![Destinations in the sidebar](/img/ui/Destinations-Sidebar.png)
 

--- a/ui/sources/overview.mdx
+++ b/ui/sources/overview.mdx
@@ -1,8 +1,12 @@
 ---
 title: Overview
-description: Source connectors are essential components in data integration systems that establish a link between your files and the data ingestion process. They facilitate the batch processing of files, allowing for the systematic retrieval and ingestion of data stored in various file formats.
-
 ---
+
+import FirstTimeUISourceConnector from '/snippets/general-shared-text/first-time-ui-source-connector.mdx';
+
+<FirstTimeUISourceConnector />
+
+Source connectors are essential components in data integration systems that establish a link between your files and the data ingestion process. They facilitate the batch processing of files, allowing for the systematic retrieval and ingestion of data stored in various file formats.
 
 ![Sources in the sidebar](/img/ui/Sources-Sidebar.png)
 


### PR DESCRIPTION
Stef asked for a few updates:

- Add a link from UI how-to pages to their API how-to counterparts, and vice versa.
- Add a blurb at the bottom of the blue boxes to keep reading to learn how. 😉 

Plus a few minor editorial updates for consistency and a bit more extensibility. 😉 