### PR TITLE
API: Workflows - local sources and destinations

### DIFF
--- a/api-reference/workflow/overview.mdx
+++ b/api-reference/workflow/overview.mdx
@@ -1736,7 +1736,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         asyncio.run(run_workflow())
         ```
     </Accordion>
-    <Accordion title="curl">
+    <Accordion title="curl (remote source and remote destination)">
         ```bash
         curl --request 'POST' --location \
         "$UNSTRUCTURED_API_URL/workflows/<workflow-id>/run" \
@@ -1744,7 +1744,33 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         --header "unstructured-api-key: $UNSTRUCTURED_API_KEY"
         ```
     </Accordion>
-    <Accordion title="Postman">
+    <Accordion title="curl (local source and local destination)">
+        To run a workflow that uses a local source and local destination, the workflow must have already been created to use a local source and a local destination. Also, 
+        the workflow must have already been created as a custom worklow, and the workflow cannot have been created to run on a schedule.
+
+        The workflow's source and destination must both be local. You cannot run a workflow that specifies a local source and a remote destination, nor can you run a worklow that specifies a remote source 
+        and a local destination.
+
+        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support running workflows that use a local source 
+        and a local destination.
+
+        In the following command, replace:
+
+        - `</full/path/to/local/filename.extension>` with the full path to the local file to upload.
+        - `<filename.extension>` with the filename of the local file to upload.
+        - `<local-file-media-type>` with the local file's media type. For a list of available media types, such as `application/pdf`, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
+
+        ```bash
+        curl --request 'POST' --location \
+        "$UNSTRUCTURED_API_URL/workflows/<workflow-id>/run" \
+        --header 'accept: application/json' \
+        --header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+        --form "input_files=@</full/path/to/local/filename.extension>" \
+        --form "filename=<filename.extension>" \
+        --form "type=<local-file-media-type>" \
+        ```
+    </Accordion>
+    <Accordion title="Postman (remote source and remote destination)">
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:
 
@@ -1758,6 +1784,38 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
             - **Key**: `accept`, **Value**: `application/json`
 
         4. Click **Send**.
+    </Accordion>
+    <Accordion title="Postman (local source and local destination)">
+        To run a workflow that uses a local source and local destination, the workflow must have already been created to use a local source and a local destination. Also, 
+        the workflow must have already been created as a custom worklow, and the workflow cannot have been created to run on a schedule.
+
+        The workflow's source and destination must both be local. You cannot run a workflow that specifies a local source and a remote destination, nor can you run a worklow that specifies a remote source 
+        and a local destination.
+
+        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support running workflows that use a local source 
+        and a local destination.
+
+        1. In the method drop-down list, select **POST**.
+        2. In the address box, enter the following URL:
+
+            ```text
+            {{UNSTRUCTURED_API_URL}}/workflows/<workflow-id>/run
+            ```
+
+        3. On the **Headers** tab, enter the following headers:
+
+            - **Key**: `unstructured-api-key`, **Value**: `{{UNSTRUCTURED_API_KEY}}`
+            - **Key**: `accept`, **Value**: `application/json`
+
+        4. On the **Body** tab, select **form-data**, and specify the settings for the workflow run:
+            
+            - **Key**: `input_files`, **File**, **Value**: Click the **Value** box, then click **New file from local machine**, and select the file to upload.
+            - **Key**: `filename`, **Text**, **Value**: Type the name of the file that you just uploaded.
+            - **Key**: `type`, **Text**, **Value**: `<local-file-media-type>`
+
+            For a list of available media types, such as `application/pdf`, see [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
+
+        5. Click **Send**.
     </Accordion>
 </AccordionGroup>
 
@@ -2282,5 +2340,53 @@ the `POST` method to call the `/jobs/<job-id>/cancel` endpoint (for `curl` or Po
             - **Key**: `accept`, **Value**: `application/json`
 
         4. Click **Send**.
+    </Accordion>
+</AccordionGroup>
+
+### Download a processed local file from a job
+
+This applies only to jobs that use a workflow with a local source and a local destination. 
+
+To download a processed local file from a completed job, use `GET` to call the `/jobs/<job-id>/download` endpoint, replacing 
+`<job-id>` with the job's unique ID. To get this ID, see [List jobs](#list-jobs).
+
+You must also provide Unstructured's IDs for the file to download and the workflow's output node. To get these IDs, see [Get a job](#get-a-job). In the 
+response: 
+
+- Unstructured's IDs for the file to download and the workflow's output node are in the `output_node_files` array. 
+- The ID for the file to download is in the `output_node_files` array's `file_id` field.
+- The ID for the workflow's output node is in the `output_node_files` array's `node_id` field.
+
+Currently, you cannot use the Unstructured user interface (UI) or the Unstructured Python SDK to download a file from a job that uses a 
+workflow with a local source and a local destination.
+
+<AccordionGroup>
+    <Accordion title="curl">
+        ```bash
+        curl --request 'GET' --location \
+        "$UNSTRUCTURED_API_URL/jobs/<job-id>/download?file_id=<file-id>&node_id=<node-id>" \
+        --header 'accept: application/json' \
+        --header "unstructured-api-key: $UNSTRUCTURED_API_KEY"
+        ```
+    </Accordion>
+    <Accordion title="Postman">
+        1. In the method drop-down list, select **GET**.
+        2. In the address box, enter the following URL:
+
+            ```text
+            {{UNSTRUCTURED_API_URL}}/jobs/<job-id>/download
+            ```
+
+        3. On the **Headers** tab, enter the following headers:
+
+            - **Key**: `unstructured-api-key`, **Value**: `{{UNSTRUCTURED_API_KEY}}`
+            - **Key**: `accept`, **Value**: `application/json`
+
+        4. On the **Params** tab, enter the following query parameters:
+
+            - **Key**: `file_id`, **Value**: `<file-id>`
+            - **Key**: `node_id`, **Value**: `<node-id>`
+
+        5. Click **Send**.
     </Accordion>
 </AccordionGroup>

--- a/api-reference/workflow/workflows.mdx
+++ b/api-reference/workflow/workflows.mdx
@@ -193,7 +193,7 @@ specify the settings for the workflow, as follows:
         asyncio.run(create_workflow())
         ```
     </Accordion>
-    <Accordion title="curl">
+    <Accordion title="curl (remote source and remote destination)">
         ```bash
         curl --request 'POST' --location \
         "$UNSTRUCTURED_API_URL/workflows" \
@@ -222,7 +222,41 @@ specify the settings for the workflow, as follows:
         }'
         ```
     </Accordion>
-    <Accordion title="Postman">
+    <Accordion title="curl (local source and local destination)">
+        To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
+
+        The source and destination must both be local. You cannot specify a local source and a remote destination, nor can you specify a remote source 
+        and a local destination.
+
+        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support creating a workflow with a local source 
+        and a local destination.
+
+        ```bash
+        curl --request 'POST' --location \
+        "$UNSTRUCTURED_API_URL/workflows" \
+        --header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+        --header 'accept: application/json' \
+        --data \
+        '{
+            "name": "<name>",
+            "workflow_type": "custom",
+            "workflow_nodes": [
+                {
+                    "name": "<node-name>",
+                    "type": "<node-type>",
+                    "subtype": "<node-subtype>",
+                    "settings": {
+                        "...": "..."
+                    }
+                },
+                {
+                    "...": "..." 
+                } 
+            ]
+        }'
+        ```
+    </Accordion>
+    <Accordion title="Postman (remote source and remote destination)">
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:
 
@@ -257,6 +291,51 @@ specify the settings for the workflow, as follows:
                    } 
                ],
                "schedule": "<schedule-timeframe>"
+           }
+           ```
+
+        5. Click **Send**.
+    </Accordion>
+    <Accordion title="Postman (local source and local destination)">
+        To use a local source and a local destination do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
+
+        The source and destination must both be local. You cannot specify a local source and a remote destination, nor can you specify a remote source 
+        and a local destination.
+
+        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support creating a workflow with a local source 
+        and a local destination.
+
+        1. In the method drop-down list, select **POST**.
+        2. In the address box, enter the following URL:
+
+            ```text
+            {{UNSTRUCTURED_API_URL}}/workflows
+            ```
+
+        3. On the **Headers** tab, enter the following headers:
+
+            - **Key**: `unstructured-api-key`, **Value**: `{{UNSTRUCTURED_API_KEY}}`
+            - **Key**: `accept`, **Value**: `application/json`
+
+        4. On the **Body** tab, select **raw** and **JSON**, and specify the settings for the workflow:
+
+           ```json
+           {
+               "name": "<name>",
+               "workflow_type": "custom",
+               "workflow_nodes": [
+                   {
+                       "name": "<node-name>",
+                       "type": "<node-type>",
+                       "subtype": "<node-subtype>",
+                       "settings": {
+                           "...": "..."
+                       }
+                   },
+                   {
+                       "...": "..." 
+                   } 
+               ]
            }
            ```
 


### PR DESCRIPTION
Applies only to `curl` and Postman right now.

See: 

- Create a workflow with a local source and destination:
- Run a job for a workflow with a local source and destination:
- Download a processed local file from a job based on a workflow with a local source and destination: