### PR TITLE
Partition Endpoint: extracting images and block types requires hi-res

### DIFF
--- a/snippets/how-to-api/extract_image_block_types.py.mdx
+++ b/snippets/how-to-api/extract_image_block_types.py.mdx
@@ -28,9 +28,7 @@ if __name__ == "__main__":
     request = operations.PartitionRequest(
         shared.PartitionParameters(
             files=files,
-            strategy=shared.Strategy.VLM,
-            vlm_model="gpt-4o",
-            vlm_model_provider="openai",
+            strategy=shared.Strategy.HI_RES,
             split_pdf_page=True,
             split_pdf_allow_failed=True,
             split_pdf_concurrency_level=15,


### PR DESCRIPTION
See the updated code example in https://unstructured-53-extract-images-and-tables-no-vlm-2025-03-18.mintlify.app/api-reference/partition/extract-image-block-types