### PR TITLE
Fix link to Unstructured Product website in mint.json

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -43,7 +43,7 @@
       {
         "name": "Product",
         "icon": "square-terminal",
-        "url": "https://unstructured.io/product"
+        "url": "https://unstructured.io/"
       },
       {
         "name": "Trust Portal",


### PR DESCRIPTION
Point to product home page. Until now, this was pointing to the "For Enterprise" home page.