### PR TITLE
Delta Tables in Databricks destination connector: add missing columns to create table statement

### DIFF
--- a/snippets/general-shared-text/databricks-delta-table.mdx
+++ b/snippets/general-shared-text/databricks-delta-table.mdx
@@ -125,7 +125,9 @@
       coordinates_system STRING,
       coordinates_layout_width FLOAT,
       coordinates_layout_height FLOAT,
-      partitioner_type STRING
+      partitioner_type STRING,
+      image_mime_type STRING,
+      image_base64 STRING
   );
   ```
 


### PR DESCRIPTION
Missing the `image_mime_type` and `image_base64` columns. 