### PR TITLE
Change field data type in databricks-delta-table.mdx

### DIFF
--- a/snippets/general-shared-text/databricks-delta-table.mdx
+++ b/snippets/general-shared-text/databricks-delta-table.mdx
@@ -96,7 +96,7 @@
       url STRING,
       version STRING,
       record_locator STRING,
-      category_depth INT,
+      category_depth DOUBLE,
       parent_id STRING,
       attached_filename STRING,
       filetype STRING,


### PR DESCRIPTION
Change `category_depth` from `INT` to `DOUBLE` in canonical `CREATE TABLE` statement.