### PR TITLE
Sign in URLs, API keys, and API URLs: Enterprise and self-hosted guidance differs from SaaS

### DIFF
--- a/api-reference/troubleshooting/api-key-url.mdx
+++ b/api-reference/troubleshooting/api-key-url.mdx
@@ -43,7 +43,7 @@ For the API URL, note the following:
   the default API URL that Unstructured Python SDK uses for the Partition Endpoint.
 
 <Note>
-    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a self-hosted deployment of Unstructured, your API URL 
+    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, your API URL 
     might be different. For guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
 </Note>
 
@@ -64,7 +64,7 @@ For the API key, the same API key works for both the [Unstructured Workflow Endp
    c. Click the **Copy** icon next to your new key to add the key to your system's clipboard. If you lose this key, simply return and click the **Copy** icon again.<br/>
 
 <Note>
-    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a self-hosted deployment of Unstructured, the process for getting your API key 
+    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, the process for getting your API key 
     might be different. For guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
 </Note>
   
@@ -78,7 +78,7 @@ For the API URL, note the value of the Unstructured API URL for the Endpoint tha
    [Unstructured Workflow Endpoint](/api-reference/workflow/overview) or the [Unstructured Partition Endpoint](/api-reference/partition/overview), respectively.
 
 <Note>
-    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a self-hosted deployment of Unstructured, your API URL 
+    If you signed up through the [For Enterprise](https://unstructured.io/enterprise) page, of if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, your API URL 
     might be different. For guidance, email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io). 
 </Note>
 

--- a/snippets/general-shared-text/enterprise-self-hosted-differences.mdx
+++ b/snippets/general-shared-text/enterprise-self-hosted-differences.mdx
@@ -1,4 +1,4 @@
 <Note>
-    If you signed up for Unstructured through the [For Enterprise](https://unstructured.io/enterprise) page, or if you are using a self-hosted deployment of Unstructured, the following information 
+    If you signed up for Unstructured through the [For Enterprise](https://unstructured.io/enterprise) page, or if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, the following information 
     might apply differently to you. For details, contact Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io).
 </Note>

--- a/snippets/general-shared-text/get-started-simple-api-only.mdx
+++ b/snippets/general-shared-text/get-started-simple-api-only.mdx
@@ -1,3 +1,8 @@
+<Note>
+    If you signed up for Unstructured through the [For Enterprise](https://unstructured.io/enterprise) page, or if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, the following information 
+    about signing up, signing in, and getting your Unstructured API key might apply differently to you. For details, contact Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io).
+</Note>
+
 1. Go to [https://platform.unstructured.io](https://platform.unstructured.io) and use your email address, Google account, or GitHub account to 
    sign up for an Unstructured account (if you do not already have one) and sign into the account at the same time. The 
    [Unstructured user interface (UI)](/ui/overview) appears.

--- a/snippets/general-shared-text/get-started-simple-ui-only.mdx
+++ b/snippets/general-shared-text/get-started-simple-ui-only.mdx
@@ -1,3 +1,8 @@
+<Note>
+    If you signed up for Unstructured through the [For Enterprise](https://unstructured.io/enterprise) page, or if you are using a [self-hosted](/self-hosted/overview) deployment of Unstructured, the following sign up information 
+    does not apply to you, and you can skip ahead to the next step after you sign in. If you are not sure how to sign in, contact Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io).
+</Note>
+
 Go to [https://platform.unstructured.io](https://platform.unstructured.io) and use your email address, Google account, or GitHub account to 
 sign up for an Unstructured account (if you do not already have one) and sign into the account at the same time. The 
 [Unstructured user interface (UI)](/ui/overview) appears, and you can start using it right away.

--- a/ui/account/organizations.mdx
+++ b/ui/account/organizations.mdx
@@ -144,7 +144,7 @@ sales representative, email Unstructured Sales at [sales@unstructured.io](mailto
 ## Access an organizational account
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's [self-hosted deployment of Unstructured](/self-hosted/overview).
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that you want to access.
 
    If the organizational account selector is not shown, or if the selector does not show the organizational account you want to access, then 
@@ -159,7 +159,7 @@ sales representative, email Unstructured Sales at [sales@unstructured.io](mailto
 To add a user to an organizational account as a member:
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that you want to add the member to.
 3. In the sidebar, above your user icon, click the **Settings** (gear) icon.
 4. Click **Manage Account**.
@@ -176,7 +176,7 @@ To add a user to an organizational account as a member:
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the member you want to change roles for.
 3. In the sidebar, above your user icon, click the **Settings** (gear) icon.
 4. Click **Manage Account**.
@@ -203,7 +203,7 @@ To add a user to an organizational account as a member:
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that you want to remove the member from.
 3. In the sidebar, above your user icon, click the **Settings** (gear) icon.
 4. Click **Manage Account**.

--- a/ui/account/workspaces.mdx
+++ b/ui/account/workspaces.mdx
@@ -104,7 +104,7 @@ sales representative, email Unstructured Sales at [sales@unstructured.io](mailto
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that you want to add a workspace to.
 3. In the sidebar, above your user icon, click the **Settings** (gear) icon.
 4. Click **View All Workspaces**.
@@ -122,7 +122,7 @@ sales representative, email Unstructured Sales at [sales@unstructured.io](mailto
 ## Access a workspace
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace you want to access.
 3. In the workspace selector, select the name of the workspace that you want to access.
 
@@ -146,7 +146,7 @@ To add a user to a workspace as a member:
 1. Make sure the account user that you want to add has already been added as a member of the workspace's parent organizational account. 
    [Learn how](/ui/account/organizations#add-a-member-to-an-organization).
 2. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 3. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace you want to add a member to.
 4. In the workspace selector, select the name of the workspace that you want to add a member to.
 5. In the sidebar, above your user icon, click the **Settings** (gear) icon.
@@ -165,7 +165,7 @@ To add a user to a workspace as a member:
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace for the member you want to change roles for.
 3. In the workspace selector, select the name of the workspace that contains the member you want to change roles for.
 4. In the sidebar, above your user icon, click the **Settings** (gear) icon.
@@ -194,7 +194,7 @@ To add a user to a workspace as a member:
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace you want to remove a member from.
 3. In the workspace selector, select the name of the workspace that you want to remove a member from.
 4. In the sidebar, above your user icon, click the **Settings** (gear) icon.
@@ -216,7 +216,7 @@ To make programmatic API calls to a workspace instead of using the UI, an API ke
 An API key can be used only with the workspace for which it was created.
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace you want to create an API key for.
 3. In the workspace selector, select the name of the workspace that you want to create an API key for.
 4. In the sidebar, above your user icon, click the **Settings** (gear) icon.
@@ -243,7 +243,7 @@ An API key is valid only for the workspace for which it was created.
 </Info>
 
 1. Depending on the location of the organizational account that you want to access, sign in to [https://platform.unstructured.io](https://platform.unstructured.io), 
-   or sign in by using the URL for your organization's self-hosted deployment of Unstructured.
+   or sign in by using the URL for your organization's [self-hosted](/self-hosted/overview) deployment of Unstructured.
 2. In the top navigation bar, in the organizational account selector, select the name of the organizational account that contains the workspace you want to delete an API key for.
 3. In the workspace selector, select the name of the workspace that you want to delete an API key for.
 4. In the sidebar, above your user icon, click the **Settings** (gear) icon.


### PR DESCRIPTION
Also, providing more links to self-hosted guidance where it seems to be useful. 