### PR TITLE
Google Drive source connector: shared drives are now also supported

### DIFF
--- a/snippets/general-shared-text/google-drive-api-placeholders.mdx
+++ b/snippets/general-shared-text/google-drive-api-placeholders.mdx
@@ -1,5 +1,5 @@
 - `<name>` (_required_) - A unique name for this connector.
-- `<drive-id>` - The ID for the target Google Drive folder.
+- `<drive-id>` - The ID for the target Google Drive folder or drive.
 - `<service-account-key>` - The contents of the `credentials.json` key file as a single-line string.
 - For `extensions`, set one or more `<extension>` values (such as `pdf` or `docx`) to process files with only those extensions. The default is to include all extensions.
 
@@ -7,4 +7,4 @@
       Do not include the leading dot in the file extensions. For example, use `pdf` or `docx` instead of `.pdf` or `.docx`.
   </Note>
 
-- Set `recursive` to `true` to recursively process data from subfolders within the target folder. The default is `false` if not otherwise specified.
+- Set `recursive` to `true` to recursively process data from subfolders within the target folder or drive. The default is `false` if not otherwise specified.

--- a/snippets/general-shared-text/google-drive-cli-api.mdx
+++ b/snippets/general-shared-text/google-drive-cli-api.mdx
@@ -10,7 +10,7 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 The following environment variables:
 
-- `GOOGLE_DRIVE_FOLDER_ID` - The folder ID, represented by `--drive-id` (CLI) or `drive_id` (Python).
+- `GOOGLE_DRIVE_FOLDER_ID` - The folder or drive ID, represented by `--drive-id` (CLI) or `drive_id` (Python).
 - One of the following:
 
   - `GCP_SERVICE_ACCOUNT_KEY_FILEPATH` - The path to the `credentials.json` key file, represented by `--service-account-key-path` (CLI) or `service_account_key_path` (Python).

--- a/snippets/general-shared-text/google-drive-platform.mdx
+++ b/snippets/general-shared-text/google-drive-platform.mdx
@@ -1,7 +1,7 @@
 Fill in the following fields:
 
 - **Name** (_required_): A unique name for this connector.
-- **Drive ID** (_required_): The target folder's ID.
+- **Drive ID** (_required_): The target folder's or drive's ID.
 - **Extensions**: A comma-separated list of any file extensions to be included in the ingestion process (such as `jpg,pdf`), if filtering is needed. 
   The default is to include all files, if not otherwise specified.
 
@@ -9,5 +9,5 @@ Fill in the following fields:
       Do not include the leading dot in the file extensions. For example, use `jpg` or `pdf` instead of `.jpg` or `.pdf`.
   </Note>
 
-- **Recursive**: Check this box to also access files from all subfolders within the folder.
+- **Recursive**: Check this box to also access files from all subfolders within the folder or drive.
 - **Account Key** (_required_): The contents of the `credentials.json` key file for the target service account. These contents must be expressed as a single-line string without line breaks.

--- a/snippets/general-shared-text/google-drive.mdx
+++ b/snippets/general-shared-text/google-drive.mdx
@@ -32,8 +32,8 @@ allowfullscreen
     (Get-Content -Path "<path-to-downloaded-key-file>" -Raw).Replace("`r`n", "").Replace("`n", "")
     ```
 
-- A [Google Drive folder](https://support.google.com/drive/answer/2375091).
-- Give the service account access to the folder. To do this, share the folder with the service account's email address. 
+- A Google Drive [shared folder](https://support.google.com/drive/answer/2375091) or [shared drive](https://support.google.com/a/users/answer/7212025).
+- Give the service account access to the shared folder or shared drive. To do this, share the folder or drive with the service account's email address. 
   [Learn how](https://support.google.com/drive/answer/7166529). 
   [Learn more](https://www.googlecloudcommunity.com/gc/Workspace-Q-A/Can-i-give-access-to-document-of-google-drive-to-service-account/m-p/530106).  
-- Get the folder's ID. This is a part of the URL for your Google Drive folder represented in the following URL as `{folder_id}`: `https://drive.google.com/drive/folders/{folder-id}`.
+- Get the shared folder's ID or shared drive's ID. This is a part of the URL for your Google Drive shared folder or shared drive, represented in the following URL as `{folder_id}`: `https://drive.google.com/drive/folders/{folder-id}`.


### PR DESCRIPTION
Very minor updates to indicate that shared drives are now also supported in addition to shared folders that were already supported.