### PR TITLE
API: Local-to-local workflows for Python, local-to-remote workflows for REST and Python

### DIFF
--- a/api-reference/workflow/overview.mdx
+++ b/api-reference/workflow/overview.mdx
@@ -1822,7 +1822,14 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
 `<workflow-id>` with the workflow's unique ID. To get this ID, see [List workflows](#list-workflows).
 
 <AccordionGroup>
-    <Accordion title="Python SDK">
+    <Accordion title="Python SDK (remote source and remote destination)">
+        <Note>
+            If the target workflow was originally created programmatically by the Unstructured Python SDK or with a REST API client such as `curl` or Postman, 
+            and the workflow uses a local source connector, you can run the workflow only with a REST API client such as `curl` or Postman, 
+            as described later in this section. 
+            You cannot run the workflow with the Python SDK or the Unstructured user interface (UI), even though the workflow is visible in the UI.
+        </Note>
+
         ```python
         import os
 
@@ -1842,7 +1849,14 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         print(response.raw_response)
         ```
     </Accordion>
-    <Accordion title="Python SDK (async)">
+    <Accordion title="Python SDK (async) (remote source and remote destination)">
+        <Note>
+            If the target workflow was originally created programmatically by the Unstructured Python SDK or with a REST API client such as `curl` or Postman, 
+            and the workflow uses a local source connector, you can run the workflow only with a REST API client such as `curl` or Postman, 
+            as described later in this section. 
+            You cannot run the workflow with the Python SDK or the Unstructured user interface (UI), even though the workflow is visible in the UI.
+        </Note>
+
         ```python
         import os
         import asyncio
@@ -1874,16 +1888,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         --header "unstructured-api-key: $UNSTRUCTURED_API_KEY"
         ```
     </Accordion>
-    <Accordion title="curl (local source and local destination)">
-        To run a workflow that uses a local source and local destination, the workflow must have already been created to use a local source and a local destination. Also, 
-        the workflow must have already been created as a custom worklow, and the workflow cannot have been created to run on a schedule.
-
-        The workflow's source and destination must both be local. You cannot run a workflow that specifies a local source and a remote destination, nor can you run a worklow that specifies a remote source 
-        and a local destination.
-
-        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support running workflows that use a local source 
-        and a local destination.
-
+    <Accordion title="curl (local source and local or remote destination)">
         In the following command, replace:
 
         - `</full/path/to/local/filename.extension>` with the full path to the local file to upload.
@@ -1901,7 +1906,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
         --form "input_files=@</full/path/to/local/filename.extension>;filename=<filename.extension>;type=<local-file-media-type>" # For each additional file to be uploaded.
         ```
 
-        To access the processed files' data, [download a processed local file](#download-a-processed-local-file-from-a-job) from the workflow's job run.
+        For a local destination, to access the processed files' data, [download a processed local file](#download-a-processed-local-file-from-a-job) from the workflow's job run.
     </Accordion>
     <Accordion title="Postman (remote source and remote destination)">
         1. In the method drop-down list, select **POST**.
@@ -1918,16 +1923,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
 
         4. Click **Send**.
     </Accordion>
-    <Accordion title="Postman (local source and local destination)">
-        To run a workflow that uses a local source and local destination, the workflow must have already been created to use a local source and a local destination. Also, 
-        the workflow must have already been created as a custom worklow, and the workflow cannot have been created to run on a schedule.
-
-        The workflow's source and destination must both be local. You cannot run a workflow that specifies a local source and a remote destination, nor can you run a worklow that specifies a remote source 
-        and a local destination.
-
-        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support running workflows that use a local source 
-        and a local destination.
-
+    <Accordion title="Postman (local source and local or remote destination)">
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:
 
@@ -1960,7 +1956,7 @@ the `POST` method to call the `/workflows/<workflow-id>/run` endpoint (for `curl
 
         5. Click **Send**.
 
-        To access the processed files' data, [download a processed local file](#download-a-processed-local-file-from-a-job) from the workflow's job run.
+        For a local destination, to access the processed files' data, [download a processed local file](#download-a-processed-local-file-from-a-job) from the workflow's job run.
     </Accordion>
 </AccordionGroup>
 

--- a/api-reference/workflow/workflows.mdx
+++ b/api-reference/workflow/workflows.mdx
@@ -112,8 +112,15 @@ specify the settings for the workflow, as follows:
     <Accordion title="Python SDK (local source and local destination)">
         To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
 
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` or Postman. [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
+        
         ```python
         import os
 
@@ -187,7 +194,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="Python SDK (local source and remote destination)">
         To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` or Postman. [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         ```python
         import os
@@ -345,7 +359,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="Python SDK (async) (local source and local destination)">
         To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` or Postman. [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         ```python
         import os
@@ -424,7 +445,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="Python SDK (async) (local source and remote destination)">
         To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` or Postman. [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         ```python
         import os
@@ -533,7 +561,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="curl (local source and local destination)">
         To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` (or Postman). [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         ```bash
         curl --request 'POST' --location \
@@ -563,7 +598,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="curl (local source and remote destination)">
         To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as `curl` (or Postman). [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         ```bash
         curl --request 'POST' --location \
@@ -634,7 +676,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="Postman (local source and local destination)">
         To use a local source and a local destination do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as Postman (or `curl`). [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:
@@ -675,7 +724,14 @@ specify the settings for the workflow, as follows:
     <Accordion title="Postman (local source and remote destination)">
         To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        Workflows with a local source cannot be set to run on a repeating schedule.
+        <Note>
+            A workflow with a local source has the following limitations:
+
+            - The workflow cannot be set to run on a repeating schedule.
+            - The workflow cannot be run with the Unstructured Python SDK or from the Unstructured user interface (UI), 
+              even though the workflows is visible in the UI. However, you can 
+              run the workflow with REST API clients such as Postman (or `curl`). [Learn how](/api-reference/workflow/overview#run-a-workflow).
+        </Note>
 
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:

--- a/api-reference/workflow/workflows.mdx
+++ b/api-reference/workflow/workflows.mdx
@@ -30,7 +30,7 @@ the request body (for `curl` or Postman),
 specify the settings for the workflow, as follows:
 
 <AccordionGroup>
-    <Accordion title="Python SDK">
+    <Accordion title="Python SDK (remote source and remote destination)">
         ```python
         import os
 
@@ -109,7 +109,158 @@ specify the settings for the workflow, as follows:
             print(f"            {crontab_entry.cron_expression}")
         ```
     </Accordion>
-    <Accordion title="Python SDK (async)">
+    <Accordion title="Python SDK (local source and local destination)">
+        To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        ```python
+        import os
+
+        from unstructured_client import UnstructuredClient
+        from unstructured_client.models.shared import (
+            WorkflowNode,
+            CreateWorkflow,
+            WorkflowType
+        )
+        from unstructured_client.models.operations import CreateWorkflowRequest
+
+        workflow_node = WorkflowNode(
+            name="<node-name>",
+            type="<node-type>",
+            subtype="<node-subtype>",
+            settings={
+                "...": "..."
+            }
+        )
+
+        another_workflow_node = WorkflowNode(
+            name="<node-name>",
+            type="<node-type>",
+            subtype="<node-subtype>",
+            settings={
+                "...": "..."
+            }
+        )
+
+        # And so on for any additional nodes.
+
+        workflow=CreateWorkflow(
+            name="<name>",
+            workflow_type=WorkflowType.CUSTOM,
+            workflow_nodes=[
+                workflow_node,
+                another_workflow_node
+                # And so on for any additional nodes.
+            ]
+        )
+
+        with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
+            response = client.workflows.create_workflow(
+                request=CreateWorkflowRequest(
+                    create_workflow=workflow
+                )
+            )
+
+            info = response.workflow_information
+
+            print(f"name: {info.name}")
+            print(f"id: {info.id}")
+            print(f"status: {info.status}")
+            print(f"type: {info.workflow_type}")
+            print("source(s):")
+
+            for source in info.sources:
+                print(f"    {source}")
+
+            print("destination(s):")
+
+            for destination in info.destinations:
+                print(f"    {destination}")
+
+            print("schedule(s):")
+
+            for crontab_entry in info.schedule.crontab_entries:
+                print(f"    {crontab_entry.cron_expression}")
+        ```
+    </Accordion>
+    <Accordion title="Python SDK (local source and remote destination)">
+        To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        ```python
+        import os
+
+        from unstructured_client import UnstructuredClient
+        from unstructured_client.models.shared import (
+            WorkflowNode,
+            CreateWorkflow,
+            WorkflowType
+        )
+        from unstructured_client.models.operations import CreateWorkflowRequest
+
+        workflow_node = WorkflowNode(
+            name="<node-name>",
+            type="<node-type>",
+            subtype="<node-subtype>",
+            settings={
+                "...": "..."
+            }
+        )
+
+        another_workflow_node = WorkflowNode(
+            name="<node-name>",
+            type="<node-type>",
+            subtype="<node-subtype>",
+            settings={
+                "...": "..."
+            }
+        )
+
+        # And so on for any additional nodes.
+
+        workflow=CreateWorkflow(
+            name="<name>",
+            destination_id="<destination-connector-id>",
+            workflow_type=WorkflowType.CUSTOM,
+            workflow_nodes=[
+                workflow_node,
+                another_workflow_node
+                # And so on for any additional nodes.
+            ]
+        )
+
+        with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
+            response = client.workflows.create_workflow(
+                request=CreateWorkflowRequest(
+                    create_workflow=workflow
+                )
+            )
+
+            info = response.workflow_information
+
+            print(f"name: {info.name}")
+            print(f"id: {info.id}")
+            print(f"status: {info.status}")
+            print(f"type: {info.workflow_type}")
+            print("source(s):")
+
+            for source in info.sources:
+                print(f"    {source}")
+
+            print("destination(s):")
+
+            for destination in info.destinations:
+                print(f"    {destination}")
+
+            print("schedule(s):")
+
+            for crontab_entry in info.schedule.crontab_entries:
+                print(f"    {crontab_entry.cron_expression}")
+        ```
+    </Accordion>
+    <Accordion title="Python SDK (async) (remote source and remote destination)">
         ```python
         import os
         import asyncio
@@ -191,6 +342,165 @@ specify the settings for the workflow, as follows:
         asyncio.run(create_workflow())
         ```
     </Accordion>
+    <Accordion title="Python SDK (async) (local source and local destination)">
+        To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        ```python
+        import os
+        import asyncio
+
+        from unstructured_client import UnstructuredClient
+        from unstructured_client.models.shared import (
+            WorkflowNode,
+            CreateWorkflow,
+            WorkflowType
+        )
+        from unstructured_client.models.operations import CreateWorkflowRequest
+
+        async def create_workflow():
+            workflow_node = WorkflowNode(
+                name="<node-name>",
+                type="<node-type>",
+                subtype="<node-subtype>",
+                settings={
+                    "...": "..."
+                }
+            )
+
+            another_workflow_node = WorkflowNode(
+                name="<node-name>",
+                type="<node-type>",
+                subtype="<node-subtype>",
+                settings={
+                    "...": "..."
+                }
+            )
+
+            # And so on for any additional nodes.
+
+            workflow = CreateWorkflow(
+                name="<name>",
+                workflow_type=WorkflowType.CUSTOM,
+                workflow_nodes=[
+                    workflow_node,
+                    another_workflow_node
+                    # And so on for any additional nodes.
+                ]
+            )
+
+            with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
+                response = await client.workflows.create_workflow_async(
+                    request=CreateWorkflowRequest(
+                        create_workflow=workflow
+                    )
+                )
+
+                info = response.workflow_information
+
+                print(f"name: {info.name}")
+                print(f"id: {info.id}")
+                print(f"status: {info.status}")
+                print(f"type: {info.workflow_type}")
+                print("source(s):")
+
+                for source in info.sources:
+                    print(f"    {source}")
+
+                print("destination(s):")
+
+                for destination in info.destinations:
+                    print(f"    {destination}")
+
+                print("schedule(s):")
+
+                for crontab_entry in info.schedule.crontab_entries:
+                    print(f"    {crontab_entry.cron_expression}")
+
+        asyncio.run(create_workflow())
+        ```
+    </Accordion>
+    <Accordion title="Python SDK (async) (local source and remote destination)">
+        To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `CUSTOM`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        ```python
+        import os
+        import asyncio
+
+        from unstructured_client import UnstructuredClient
+        from unstructured_client.models.shared import (
+            WorkflowNode,
+            CreateWorkflow,
+            WorkflowType
+        )
+        from unstructured_client.models.operations import CreateWorkflowRequest
+
+        async def create_workflow():
+            workflow_node = WorkflowNode(
+                name="<node-name>",
+                type="<node-type>",
+                subtype="<node-subtype>",
+                settings={
+                    "...": "..."
+                }
+            )
+
+            another_workflow_node = WorkflowNode(
+                name="<node-name>",
+                type="<node-type>",
+                subtype="<node-subtype>",
+                settings={
+                    "...": "..."
+                }
+            )
+
+            # And so on for any additional nodes.
+
+            workflow = CreateWorkflow(
+                name="<name>",
+                destination_id="<destination-connector-id>",
+                workflow_type=WorkflowType.CUSTOM,
+                workflow_nodes=[
+                    workflow_node,
+                    another_workflow_node
+                    # And so on for any additional nodes.
+                ]
+            )
+
+            with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
+                response = await client.workflows.create_workflow_async(
+                    request=CreateWorkflowRequest(
+                        create_workflow=workflow
+                    )
+                )
+
+                info = response.workflow_information
+
+                print(f"name: {info.name}")
+                print(f"id: {info.id}")
+                print(f"status: {info.status}")
+                print(f"type: {info.workflow_type}")
+                print("source(s):")
+
+                for source in info.sources:
+                    print(f"    {source}")
+
+                print("destination(s):")
+
+                for destination in info.destinations:
+                    print(f"    {destination}")
+
+                print("schedule(s):")
+
+                for crontab_entry in info.schedule.crontab_entries:
+                    print(f"    {crontab_entry.cron_expression}")
+
+        asyncio.run(create_workflow())
+        ```
+    </Accordion>
     <Accordion title="curl (remote source and remote destination)">
         ```bash
         curl --request 'POST' --location \
@@ -223,11 +533,7 @@ specify the settings for the workflow, as follows:
     <Accordion title="curl (local source and local destination)">
         To use a local source and a local destination, do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        The source and destination must both be local. You cannot specify a local source and a remote destination, nor can you specify a remote source 
-        and a local destination.
-
-        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support creating a workflow with a local source 
-        and a local destination.
+        Workflows with a local source cannot be set to run on a repeating schedule.
 
         ```bash
         curl --request 'POST' --location \
@@ -237,6 +543,37 @@ specify the settings for the workflow, as follows:
         --data \
         '{
             "name": "<name>",
+            "workflow_type": "custom",
+            "workflow_nodes": [
+                {
+                    "name": "<node-name>",
+                    "type": "<node-type>",
+                    "subtype": "<node-subtype>",
+                    "settings": {
+                        "...": "..."
+                    }
+                },
+                {
+                    "...": "..." 
+                } 
+            ]
+        }'
+        ```
+    </Accordion>
+    <Accordion title="curl (local source and remote destination)">
+        To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `custom`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        ```bash
+        curl --request 'POST' --location \
+        "$UNSTRUCTURED_API_URL/workflows" \
+        --header "unstructured-api-key: $UNSTRUCTURED_API_KEY" \
+        --header 'accept: application/json' \
+        --data \
+        '{
+            "name": "<name>",
+            "destination_id": "<destination-connector-id>",
             "workflow_type": "custom",
             "workflow_nodes": [
                 {
@@ -297,11 +634,7 @@ specify the settings for the workflow, as follows:
     <Accordion title="Postman (local source and local destination)">
         To use a local source and a local destination do not specify a `source_id` or `destination_id` value. Also, the `workflow_type` must be set to `custom`.
 
-        The source and destination must both be local. You cannot specify a local source and a remote destination, nor can you specify a remote source 
-        and a local destination.
-
-        The Unstructured user interface (UI) and the Unstructured Python SDK currently do not support creating a workflow with a local source 
-        and a local destination.
+        Workflows with a local source cannot be set to run on a repeating schedule.
 
         1. In the method drop-down list, select **POST**.
         2. In the address box, enter the following URL:
@@ -324,6 +657,48 @@ specify the settings for the workflow, as follows:
                "workflow_nodes": [
                    {
                        "name": "<node-name>",
+                       "type": "<node-type>",
+                       "subtype": "<node-subtype>",
+                       "settings": {
+                           "...": "..."
+                       }
+                   },
+                   {
+                       "...": "..." 
+                   } 
+               ]
+           }
+           ```
+
+        5. Click **Send**.
+    </Accordion>
+    <Accordion title="Postman (local source and remote destination)">
+        To use a local source and a remote destination, specify a `destination_id` value, and do not specify a `source_id` value. Also, the `workflow_type` must be set to `custom`.
+
+        Workflows with a local source cannot be set to run on a repeating schedule.
+
+        1. In the method drop-down list, select **POST**.
+        2. In the address box, enter the following URL:
+
+            ```text
+            {{UNSTRUCTURED_API_URL}}/workflows
+            ```
+
+        3. On the **Headers** tab, enter the following headers:
+
+            - **Key**: `unstructured-api-key`, **Value**: `{{UNSTRUCTURED_API_KEY}}`
+            - **Key**: `accept`, **Value**: `application/json`
+
+        4. On the **Body** tab, select **raw** and **JSON**, and specify the settings for the workflow:
+
+           ```json
+           {
+               "name": "<name>",
+               "workflow_type": "custom",
+               "workflow_nodes": [
+                   {
+                       "name": "<node-name>",
+                       "destination_id": "<destination-connector-id>",
                        "type": "<node-type>",
                        "subtype": "<node-subtype>",
                        "settings": {
@@ -376,6 +751,8 @@ Replace the preceding placeholders as follows:
   - `monthly`: At the first minute of the first day of every month (cron expression: `0 0 1 * *`).
     
   If `schedule` is not specified, the workflow does not automatically run on a repeating schedule.
+
+  Workflows with a local source cannot be set to run on a repeating schedule.
 
 ## Update a workflow
 

--- a/ui/workflows.mdx
+++ b/ui/workflows.mdx
@@ -24,7 +24,9 @@ Unstructured provides two types of workflow builders:
 <Warning>
     You must first have an existing source connector and destination connector to add to the workflow.
 
-    If you do not have an existing connector for either your target source (input) or destination (output) location, [create the source connector](/ui/sources/overview), [create the destination connector](/ui/destinations/overview), and then return here.
+    You cannot create an automatic workflow that uses a local source connector.
+
+    If you do not have an existing remote connector for either your target source (input) or destination (output) location, [create the source connector](/ui/sources/overview), [create the destination connector](/ui/destinations/overview), and then return here.
 
     To see your existing connectors, on the sidebar, click **Connectors**, and then click **Sources** or **Destinations**.
 </Warning>
@@ -123,6 +125,8 @@ If you did not previously set the workflow to run on a schedule, you can [run th
 <Warning>
     You must first have an existing source connector and destination connector to add to the workflow.
 
+    You can create a custom workflow that uses a local source connector, but you cannot save the workflow.
+
     If you do not have an existing connector for either your target source (input) or destination (output) location, [create the source connector](/ui/sources/overview), [create the destination connector](/ui/destinations/overview), and then return here.
 
     To see your existing connectors, on the sidebar, click **Connectors**, and then click **Sources** or **Destinations**.
@@ -177,6 +181,19 @@ If you did not previously set the workflow to run on a schedule, you can [run th
 9. In the pipeline designer, click the **Source** node. In the **Source** pane, select the source location. Then click **Save**.
 
    ![Workflow designer](/img/ui/Workflow-Designer.png)
+
+   <Note>
+       To use a local source location, do not choose a source connector. 
+
+       If the workflow uses a local source location, in the **Source** node, drag or click to specify a local file, and then click **Test**. The workflow's 
+       results are displayed on-screen.
+
+       A workflow that uses a local source location has the following limitations:
+       
+       - You cannot save the workflow.
+       - You cannot send the results to a remote destination location, even if you have attached a destination connector to 
+         the workflow. However, you can save the results to a local JSON-formatted file.
+   </Note>
 
 10. Click the **Destination** node. In the **Destination** pane, select the destination location. Then click **Save**.
 11. As needed, add more nodes by clicking the plus icon (recommended) or **Add Node** button:


### PR DESCRIPTION
You can now use the Python SDK to create local-to-local and local-to-remote workflows programmatically. 

You can also now use REST to create local-to-remote workflows. This is an addition to the already-existing ability to create local-to-local workflows. 

The following limitations of workflows with local connectors (regardless of whether the destination is local or remote) are noted throughout, specifically:

- You can't set these workflows to run on a repeating schedule.
- You can run these workflows only with REST clients such as `curl` or Postman. You can't run them with the Unstructured Python SDK or the Unstructured UI (even though they are visible in the UI).

Also noted, for completeness:

- If you create a workflow in the UI with a local connector, you can't save it from there. 
- If you create a workflow in the UI with a local connector AND a remote connector, you can "run" it in the workflow designer, but the results are only displayed on screen--they don't go to the remote location (even though the remote connector is attached). 

See:

- https://unstructured-53-local-to-non-local-workflows-api-2025-04-23.mintlify.app/api-reference/workflow/workflows#create-a-workflow
- https://unstructured-53-local-to-non-local-workflows-api-2025-04-23.mintlify.app/api-reference/workflow/overview#run-a-workflow