### PR TITLE
Jira source connector: restore 'is cloud' setting

### DIFF
--- a/snippets/general-shared-text/jira-api-placeholders.mdx
+++ b/snippets/general-shared-text/jira-api-placeholders.mdx
@@ -6,9 +6,4 @@
 - `<project-id>`: The ID of a target project in Jira to access.
 - `<board-id>`: The ID of a target board in Jira to access.
 - `<issue-id>`: The ID of a target issue in Jira to access.
-
-<Warning>
-    Setting `cloud` to `true` is reserved for future use. 
-    
-    Do not set `cloud` to `true`. Doing so could lead to unexpected results or failures.
-</Warning>
+- Set `cloud` to `true` to specify using Jira Cloud or `false` to specify using Jira Data Center. The default is to use Jira Data Center.

--- a/snippets/general-shared-text/jira-cli-api.mdx
+++ b/snippets/general-shared-text/jira-cli-api.mdx
@@ -32,9 +32,5 @@ Also, to process specific projects, boards, or issues, use:
 - `--projects` with a comma-delimited list of target project IDs (CLI) or `project` with an array of target project IDs (Python).
 - `--boards` with a comma-delmited list of target board IDs (CLI) or `boards` with an array of target board IDs (Python).
 - `--issues` with a comma-delimited list of target issue IDs (CLI) or `issues` with an array of target issue IDs (Python).
-
-<Warning>
-    Specifying `--cloud` (CLI) and setting `cloud` to `True` (Python) are reserved for future use. 
-    
-    Do not specify `--cloud` (CLI) or set `cloud` to `True` (Python). Doing so could lead to unexpected results or failures.
-</Warning>
+- `--cloud` (CLI) or `cloud=True` (Python) to specify using Jira Cloud. The default is to use Jira Data Center.
+- `--no-cloud` (CLI) or `cloud=False` (Python) to specify using Jira Data Center. This is the default behavior.

--- a/snippets/general-shared-text/jira-platform.mdx
+++ b/snippets/general-shared-text/jira-platform.mdx
@@ -6,10 +6,7 @@ Fill in the following fields:
 - **Password** (_required_ for password authentication): The password of the Jira user.
 - **API Token** (_required_ for API token authentication): The API token of the Jira user.
 - **Personal Access Token** (_required_ for personal access token authentication): The personal access token of the Jira user.
+- **Cloud**: Check this box if you are using Jira Cloud. The default is unchecked to use Jira Data Center.
 - **Projects**: A comma-separated list of IDs of the target projects in Jira to access.
 - **Boards**: A comma-separated list of IDs of the target boards in Jira to access.
 - **Issues**: A comma-separated list of IDs of the target issues in Jira to access.
-
-<Warning>
-    The **Cloud** check box is reserved for future use. This box must always remain unchecked. Checking this box could lead to unexpected results or failures.
-</Warning>

--- a/snippets/source_connectors/jira.sh.mdx
+++ b/snippets/source_connectors/jira.sh.mdx
@@ -9,6 +9,8 @@ unstructured-ingest \
     --username $JIRA_USERNAME \
     --password $JIRA_PASSWORD_OR_API_TOKEN \ # Password or API token authentication.
     --token $JIRA_PERSONAL_ACCESS_TOKEN \ # Personal access token authentication only.
+    --cloud \ # For Jira Cloud.
+    --no-cloud \ # For Jira Data Center (default).
     --output-dir $LOCAL_FILE_OUTPUT_DIR \
     --chunking-strategy by_title \
     --embedding-provider huggingface \

--- a/snippets/source_connectors/jira.v2.py.mdx
+++ b/snippets/source_connectors/jira.v2.py.mdx
@@ -40,7 +40,8 @@ if __name__ == "__main__":
                 # token=os.getenv("JIRA_PERSONAL_ACCES_TOKEN") # Personal access token authentication only.
             ),
             url=os.getenv("JIRA_URL"),
-            username=os.getenv("JIRA_USERNAME") # For password or API token authentication.
+            username=os.getenv("JIRA_USERNAME"), # For password or API token authentication.
+            cloud=True # True for Jira Cloud, False (default) for Jira Data Center.
         ),
         partitioner_config=PartitionerConfig(
             partition_by_api=True,

--- a/snippets/source_connectors/jira_rest_create.mdx
+++ b/snippets/source_connectors/jira_rest_create.mdx
@@ -29,7 +29,8 @@ curl --request 'POST' --location \
         "issues": [ 
             "<issue-id>",
             "<issue-id>"
-        ]
+        ],
+        "cloud": <true|false>
     }
 }'
 ```

--- a/snippets/source_connectors/jira_sdk.mdx
+++ b/snippets/source_connectors/jira_sdk.mdx
@@ -36,7 +36,8 @@ with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as clien
                     issues=[ 
                         "<issue-id>",
                         "<issue-id>"
-                    ]
+                    ],
+                    cloud=<True|False>
                 )
             )
         )


### PR DESCRIPTION
See for example the **Cloud** setting at the very end/bottom of https://unstructured-53-docs-260-jira.mintlify.app/ui/sources/jira