### PR TITLE
SharePoint source connector: add username/password auth, clarify ingest path format

### DIFF
--- a/snippets/general-shared-text/sharepoint-api-placeholders.mdx
+++ b/snippets/general-shared-text/sharepoint-api-placeholders.mdx
@@ -1,9 +1,10 @@
 - `<name>` (_required_) - A unique name for this connector.
-- `<client-id>` (_required_) - The client ID provided by SharePoint for the app registration.
 - `<site>` (_required_) - The base URL of the SharePoint site to connect to.
-- `<tenant>` (_required) - The **Directory (tenant) ID** for the Microsoft Entra ID app registration with the correct set of Microsoft Graph access permissions.
-- `<authority-url>` - The authentication token provider URL for the Entra ID app registration. The default is https://login.microsoftonline.com.
-- `<user-pname>` (_required_) - The UPN for the OneDrive account in the Entra ID tenant.
-- `<client-cred>` (_required_) - The **Client secret** for the Entra ID app registration.
-- `<path>` - The path from which to start parsing files. The default is `Shared Documents` if not otherwise specified.
+- `<path>` - The path from which to start parsing files. The default is **Documents** (in the UI) or `Shared Documents/` (in the URL). To start parsing from somewhere else, specify the correct path format as described previously in this article.
 - For `recursive`, set to `true` to recursively process data from subfolders within the specified path. The default is `false` if not otherwise specified.
+- `<client-id>` (_required_) - The client ID provided by SharePoint for the app registration.
+- `<tenant>` (_required_) - The **Directory (tenant) ID** for the Microsoft Entra ID app registration with the correct set of Microsoft Graph access permissions.
+- `<authority-url>` - The authentication token provider URL for the Entra ID app registration. The default is https://login.microsoftonline.com.
+- `<client-cred>` (_required_) - The **Client secret** for the Entra ID app registration.
+- `<user-pname>` (_required_ for username and password authentication) - For username and password authentication, the UPN for the OneDrive account in the Entra ID tenant.
+- `<password>` (_required_ for username and password authentication) - For username and password authentication, the password for the target UPN.

--- a/snippets/general-shared-text/sharepoint-cli-api.mdx
+++ b/snippets/general-shared-text/sharepoint-cli-api.mdx
@@ -10,10 +10,11 @@ import AdditionalIngestDependencies from '/snippets/general-shared-text/ingest-d
 
 The following environment variables:
 
-- `ENTRA_ID_USER_PRINCIPAL_NAME` - The User Principal Name (UPN) for the target OneDrive account in the Microsoft Entra ID tenant.
 - `SHAREPOINT_SITE_URL` - The SharePoint site URL, represented by `--site` (CLI) or `site` (Python).
-- `SHAREPOINT_SITE_PATH` - The path in the SharePoint site from which to start parsing files, represented by `--path` (CLI) or `path` (Python).
+- `SHAREPOINT_SITE_PATH` - The path in the SharePoint site from which to start parsing files, represented by `--path` (CLI) or `path` (Python). The default is **Documents** (in the UI) or `Shared Documents/` (in the URL). To start parsing from somewhere else, specify the correct path format as described previously in this article.
 - `ENTRA_ID_APP_CLIENT_ID` - The **Application (client) ID** value for the Microsoft Entra ID app registration, represented by `--client-id` (CLI) or `client_id` (Python).
 - `ENTRA_ID_APP_TENANT_ID` - The **Directory (tenant) ID** value for the Entra ID app registration, represented by `--client-id` (CLI) or `client_id` (Python).
+- `ENTRA_ID_TOKEN_AUTHORITY_URL` - The token authority URL for the Entra ID app registration, represented by `--authority-url` (CLI) or `authority_url` (Python). The default is `https://login.microsoftonline.com`.
 - `ENTRA_ID_APP_CLIENT_SECRET` - The **Client secret** value for the Entra ID app registration, represented by `--client-cred` (CLI) or `client_cred` (Python).
-- `ENTRA_ID_TOKEN_AUTHORITY_URL` - The token authority URL for the Entra ID app registration (which is typically `https://login.microsoftonline.com`), represented by `--authority-url` (CLI) or `authority_url` (Python).
+- `ENTRA_ID_USER_PRINCIPAL_NAME` - For username and password authentication, the User Principal Name (UPN) for the target OneDrive account in the Microsoft Entra ID tenant.
+- `ENTRA_ID_USER_PASSWORD` - For username and password authentication, the password for the target UPN.

--- a/snippets/general-shared-text/sharepoint-platform.mdx
+++ b/snippets/general-shared-text/sharepoint-platform.mdx
@@ -2,10 +2,11 @@ Fill in the following fields:
 
 - **Name** (_required_): A unique name for this connector.
 - **Site URL** (_required_): The base URL of the SharePoint site to connect to.
-- **Path** (_required_): The path from which to start parsing files, for example `Shared Documents`.
+- **Path**: The path from which to start parsing files. The default is **Documents** (in the UI) or `Shared Documents/` (in the URL). To start parsing from somewhere else, specify the correct path format as described previously in this article.
 - **Recursive**: Check this box to recursively process data from subfolders within the specified path.
 - **Client ID** (_required_): The **Application (client) ID** for the Microsoft Entra ID app registration with the correct set of Microsoft Graph access permissions.
 - **Tenant ID** (_required_): The **Directory (tenant) ID** for the Entra ID app registration.
-- **User Principal Name (UPN)** (_required_): The UPN for the OneDrive account in the Entra ID tenant.
-- **Client Credentials** (_required_): The **Client secret** for the Entra ID app registration.
 - **Authority URL** (_required_): The authentication token provider URL for the Entra ID app registration. The default is `https://login.microsoftonline.com`.
+- **Client Credentials** (_required_): The **Client secret** for the Entra ID app registration.
+- **User Principal Name (UPN)** (_required_ for username and password authentication): For username and password authentication, the UPN for the OneDrive account in the Entra ID tenant.
+- **Password** (_required_ for username and password authentication): For username and password authentication, the password for the UPN.

--- a/snippets/general-shared-text/sharepoint.mdx
+++ b/snippets/general-shared-text/sharepoint.mdx
@@ -30,26 +30,6 @@
   OneDrive personal accounts, and Microsoft 365 Free, Basic, Personal, and Family plans are not supported.
 - The SharePoint Online and OneDrive plans must share the same Microsoft Entra ID tenant. 
   [Learn more](https://learn.microsoft.com/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide). 
-- The User Principal Name (UPN) for the OneDrive account in the Microsoft Entra ID tenant. This is typically the OneDrive account user's email address. To find a UPN:
-
-  1. Depending on your plan, sign in to your Microsoft 365 admin center (typically [https://admin.microsoft.com](https://admin.microsoft.com)) using your administrator credentials, 
-     or sign in to your Office 365 portal (typically [https://portal.office.com](https://portal.office.com)) using your credentials.
-  2. In the **Users** section, click **Active users**.
-  3. Locate the user account in the list of active users.
-  4. The UPN is displayed in the **Username** column.
-
-  The following video shows how to get a UPN:
-
-  <iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/H0yYfhfyCE0"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-  ></iframe>
-
 - The SharePoint Online site URL.
 
   - Site collection-level URLs typically have the format `https://<tenant>.sharepoint.com/sites/<site-collection-name>`.
@@ -58,7 +38,12 @@
 
   [Learn more](https://learn.microsoft.com/microsoft-365/community/query-string-url-tricks-sharepoint-m365).
 
-- The path in the SharePoint Online site from which to start parsing files, for example `"Shared Documents"`. If the SharePoint connector is to process all sites within the tenant, this filter will be applied to all site document libraries.
+- The path in the SharePoint Online site from which to start parsing files. By default, parsing starts from the site's **Documents** folder (if viewed from the site's UI) or the 
+  `Shared Documents` folder (if viewed from the site's URL). 
+
+  To start parsing from a path than **Documents** (in the UI) or `Shared Documents/` (in the URL), specify only the part of the path that 
+  comes after that. For example, to start parsing from **Documents > my-folder > my-subfolder** (in the UI) or 
+  `Shared Documents/my-folder/my-subfolder` (in the URL), specify `my-folder/my-subfolder`.
 
   The following video shows how to get the site URL and a path within the site:
 
@@ -72,8 +57,10 @@
   allowfullscreen
   ></iframe>
 
-- The **Application (client) ID**, **Directory (tenant) ID**, and **Client secret** for the Microsoft Entra ID app registration with 
-  the correct set of Microsoft Graph access permissions. These permissions include:
+- Two types of authentication are supported: client credentials and a username and password. Both authentication types require a 
+  Microsoft Entra ID app registration. You will need to provide 
+  the **Application (client) ID**, **Directory (tenant) ID**, and **Client secret** for the Entra ID app registration, and the 
+  app registration must have the correct set of Microsoft Graph access permissions. These permissions include:
 
   - `Sites.ReadWrite.All` (if both reading and writing are needed)
   - `User.Read.All`
@@ -107,3 +94,22 @@
   ></iframe>
 
 - The token authority URL for your Microsoft Entra ID app registration. This is typically `https://login.microsoftonline.com`
+- For username and password authentication, you must also provide the User Principal Name (UPN) and its password for the OneDrive account in the Microsoft Entra ID tenant. This UPN is typically the OneDrive account user's email address. To find a UPN:
+
+  1. Depending on your plan, sign in to your Microsoft 365 admin center (typically [https://admin.microsoft.com](https://admin.microsoft.com)) using your administrator credentials, 
+     or sign in to your Office 365 portal (typically [https://portal.office.com](https://portal.office.com)) using your credentials.
+  2. In the **Users** section, click **Active users**.
+  3. Locate the user account in the list of active users.
+  4. The UPN is displayed in the **Username** column.
+
+  The following video shows how to get a UPN:
+
+  <iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/H0yYfhfyCE0"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  ></iframe>

--- a/snippets/source_connectors/sharepoint.sh.mdx
+++ b/snippets/source_connectors/sharepoint.sh.mdx
@@ -3,15 +3,16 @@
 
 unstructured-ingest \
   sharepoint \
-    --client-cred $ENTRA_ID_APP_CLIENT_SECRET \
-    --client-id $ENTRA_ID_APP_CLIENT_ID \
-    --user-pname $ENTRA_ID_USER_PRINCIPAL_NAME \
-    --tenant $ENTRA_ID_APP_TENANT_ID \
-    --authority-url $ENTRA_ID_TOKEN_AUTHORITY_URL \
     --site $SHAREPOINT_SITE_URL \
     --path $SHAREPOINT_SITE_PATH \
     --recursive \
-    --download-dir $LOCAL_FILE_DOWNLOAD_DIR\
+    --client-id $ENTRA_ID_APP_CLIENT_ID \
+    --tenant $ENTRA_ID_APP_TENANT_ID \
+    --authority-url $ENTRA_ID_TOKEN_AUTHORITY_URL \
+    --client-cred $ENTRA_ID_APP_CLIENT_SECRET \
+    --user-pname $ENTRA_ID_USER_PRINCIPAL_NAME \
+    --password $ENTRA_ID_USER_PASSWORD \
+    --download-dir $LOCAL_FILE_DOWNLOAD_DIR \
     --partition-by-api \
     --api-key $UNSTRUCTURED_API_KEY \
     --partition-endpoint $UNSTRUCTURED_API_URL \

--- a/snippets/source_connectors/sharepoint.v2.py.mdx
+++ b/snippets/source_connectors/sharepoint.v2.py.mdx
@@ -31,13 +31,14 @@ if __name__ == "__main__":
         downloader_config=SharepointDownloaderConfig(download_dir=os.getenv("LOCAL_FILE_DOWNLOAD_DIR")),
         source_connection_config=SharepointConnectionConfig(
             access_config=SharepointAccessConfig(
-                client_cred=os.getenv("ENTRA_ID_APP_CLIENT_SECRET")
+                client_cred=os.getenv("ENTRA_ID_APP_CLIENT_SECRET"),
+                password=os.getenv("ENTRA_ID_USER_PASSWORD"), # For username and password authentication.
             ),
+            site=os.getenv("SHAREPOINT_SITE_URL"),
             client_id=os.getenv("ENTRA_ID_APP_CLIENT_ID"),
-            user_pname=os.getenv("ENTRA_ID_USER_PRINCIPAL_NAME"),
             tenant=os.getenv("ENTRA_ID_APP_TENANT_ID"),
             authority_url=os.getenv("ENTRA_ID_TOKEN_AUTHORITY_URL"),
-            site=os.getenv("SHAREPOINT_SITE_URL")
+            user_pname=os.getenv("ENTRA_ID_USER_PRINCIPAL_NAME") # For username and password authentication.            
         ),
         partitioner_config=PartitionerConfig(
             partition_by_api=True,

--- a/snippets/source_connectors/sharepoint_rest_create.mdx
+++ b/snippets/source_connectors/sharepoint_rest_create.mdx
@@ -9,14 +9,15 @@ curl --request 'POST' --location \
     "name": "<name>",
     "type": "sharepoint",
     "config": {
-        "client_id": "<client-id>",
         "site": "<site>",
+        "path": "<path>",
+        "recursive": <true|false>,
+        "client_id": "<client-id>",
         "tenant": "<tenant>",
         "authority_url": "<authority-url>",
-        "user_pname": "<user-pname>",
         "client_cred": "<client-cred>",
-        "path": "<path>",
-        "recursive": <true|false>
+        "user_pname": "<user-pname>", # For username and password authentication.
+        "password": "<password>" # For username and password authentication.
     }
 }'
 ```

--- a/snippets/source_connectors/sharepoint_sdk.mdx
+++ b/snippets/source_connectors/sharepoint_sdk.mdx
@@ -16,14 +16,15 @@ with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as clien
                 name="<name>",
                 type=SourceConnectorType.SHAREPOINT,
                 config=SharePointSourceConnectorConfigInput(
-                    client_id="<client_id>",
                     site="<site>",
+                    path="<path>",
+                    recursive=<True|False>,
+                    client_id="<client_id>",
                     tenant="<tenant>",
                     authority_url="<authority_url>",
-                    user_pname="<user_pname>",
                     client_cred="<client_cred>",
-                    path="<path>",
-                    recursive=<True|False>
+                    user_pname="<user_pname>", # For username and password authentication.
+                    password="<password>" # For username and password authentication.   
                 )
             )
         )


### PR DESCRIPTION
- Username/password authentication is now also supported. 
- Rearranged requirements and parameter listings to better match the UI and the (now) two supported authentication flows.
- Clarified the format for specifying a non-default site path to begin ingesting files from.

See:

- UI: https://unstructured-53-docs-268-sharepoint.mintlify.app/ui/sources/sharepoint
- API: https://unstructured-53-docs-268-sharepoint.mintlify.app/api-reference/workflow/sources/sharepoint
- Ingest: https://unstructured-53-docs-268-sharepoint.mintlify.app/ingestion/source-connectors/sharepoint