### PR TITLE
Quickstarts: add link from single-file UI quickstart to new how-to video

### DIFF
--- a/snippets/quickstarts/single-file-ui.mdx
+++ b/snippets/quickstarts/single-file-ui.mdx
@@ -48,6 +48,16 @@ To run this quickstart, you will need a local file with a size of 10 MB or less 
 If you do not have any files available, you can use one of the sample files that Unstructured offers in the UI. Or, you can download one or more sample files 
 from the [example-docs](https://github.com/Unstructured-IO/unstructured-ingest/tree/main/example-docs) folder in the Unstructured repo on GitHub.
 
+<iframe
+width="560"
+height="315"
+src="https://www.youtube.com/embed/pICXdW_P50s"
+title="YouTube video player"
+frameborder="0"
+allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen
+></iframe>
+
 import GetStartedSimpleUIOnly from '/snippets/general-shared-text/get-started-simple-ui-only.mdx';
 
 <Steps>


### PR DESCRIPTION
To view, scroll down to the first embedded video in https://unstructured-53-playground-video-2025-05-20.mintlify.app/welcome#unstructured-ui-quickstart 