### PR TITLE
File type updates for UI/API on Welcome page

### DIFF
--- a/snippets/general-shared-text/supported-file-types-platform.mdx
+++ b/snippets/general-shared-text/supported-file-types-platform.mdx
@@ -8,7 +8,7 @@ By file extension:
 | `.bmp` |
 | `.csv` |
 | `.cwk` |
-| `.dif`[*](#notes) |
+| `.dif`* |
 | `.doc` |
 | `.docx` |
 | `.dot` |
@@ -61,7 +61,7 @@ By file type:
 | Image | `.bmp`, `.heic`, `.jpeg`, `.jpg`, `.png`, `.prn`, `.svg`, `.tiff` |
 | Markdown | `.md` |
 | Org Mode | `.org` |
-| Other | `.dif`[*](#notes), `.eth`, `.mw`, `.pbd`, `.sdp` |
+| Other | `.dif`*, `.eth`, `.mw`, `.pbd`, `.sdp` |
 | PDF | `.pdf` |
 | Plain text | `.txt` |
 | PowerPoint | `.pot`, `.ppt`, `.pptm`, `.pptx` |
@@ -73,7 +73,5 @@ By file type:
 | Word processing | `.abw`, `.doc`, `.docx`, `.dot`, `.hwp`, `.zabw` |
 | XML | `.xml` |
 
-## Notes
-
-* For `.dif`, `\n` characters in `.dif` files are supported, but `\r\n` characters will raise the error 
-  `UnsupportedFileFormatError: Partitioning is not supported for the FileType.UNK file type`.
+`*` For `.dif`, `\n` characters in `.dif` files are supported, but `\r\n` characters will raise the error 
+`UnsupportedFileFormatError: Partitioning is not supported for the FileType.UNK file type`.

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -93,7 +93,7 @@ Here is a screenshot of some Python code that calls the Unstructured Workflow En
 
 ## <Icon icon="files" />   Supported file types 
 
-import SupportedFileTypes from '/snippets/general-shared-text/supported-file-types.mdx';
+import SupportedFileTypes from '/snippets/general-shared-text/supported-file-types-platform.mdx';
 
 <SupportedFileTypes />
 


### PR DESCRIPTION
The Welcome page was incorrectly pointing to list of file types supported by open source and giving the impression this was the same list for the Platform UI/API. This PR now points to the correct list. 

(Also needed to remove a pesky "Notes" heading that was making for some awkward TOC presentations.)

See https://unstructured-53-file-types-2025-05-20.mintlify.app/welcome#supported-file-types