### PR TITLE
File type updates for open source

### DIFF
--- a/open-source/introduction/supported-file-types.mdx
+++ b/open-source/introduction/supported-file-types.mdx
@@ -2,7 +2,7 @@
 title: Supported file types
 ---
 
-import SupportedFileTypes from '/snippets/general-shared-text/supported-file-types.mdx';
+import SupportedFileTypes from '/snippets/general-shared-text/supported-file-types-open-source.mdx';
 
 <SupportedFileTypes />
 

--- a/snippets/general-shared-text/supported-file-types-open-source.mdx
+++ b/snippets/general-shared-text/supported-file-types-open-source.mdx
@@ -1,4 +1,4 @@
-Unstructured supports processing of the following file types:
+The Unstructured open source library supports processing of the following file types:
 
 By file extension:
 


### PR DESCRIPTION
Clarifying on the page listing the supported file types for open source that this list indeed applies only to open source. 

Also renaming the file containing the list that this page references, to clearly differentiate the open source list from the non-open source one. 😓 

See https://unstructured-53-open-source-file-types-2025-05-20.mintlify.app/open-source/introduction/supported-file-types