### PR TITLE
Image/table enrichments work only with High Res partitioning

### DIFF
--- a/api-reference/workflow/workflows.mdx
+++ b/api-reference/workflow/workflows.mdx
@@ -977,6 +977,8 @@ In the request body, specify the settings for the workflow. For the specific set
 
 ## Custom workflow DAG nodes
 
+import EnrichmentImagesTablesHiResOnly from '/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx';
+
 If `WorkflowType` is set to `CUSTOM` (for the Python SDK), or if `workflow_type` is set to `custom` (for `curl` or Postman), you must also specify the settings for the workflow's 
 directed acyclic graph (DAG) nodes. These nodes' settings are specified in the `workflow_nodes` array.
 
@@ -986,6 +988,9 @@ directed acyclic graph (DAG) nodes. These nodes' settings are specified in the `
   `workflow_nodes` array.
 - You can specify [Partitioner](#partitioner-node), [Chunker](#chunker-node), 
   [Enrichment](#enrichment-node), and [Embedder](#embedder-node) nodes.
+
+  <EnrichmentImagesTablesHiResOnly />
+
 - The order of the nodes in the `workflow_nodes` array will be the same order that these nodes appear in the DAG, 
   with the first node in the array added directly after the **Source** node. The **Destination** node 
   follows the last node in the array. 
@@ -1421,7 +1426,13 @@ An **Enrichment** node has a `type` of `prompter`.
 
 [Learn about the available enrichments](/ui/enriching/overview).
 
+<EnrichmentImagesTablesHiResOnly />
+
 #### Image Description task
+
+import EnrichmentImageSummaryHiResOnly from '/snippets/general-shared-text/enrichment-image-summary-hi-res-only.mdx';
+
+<EnrichmentImageSummaryHiResOnly />
 
 <AccordionGroup>
     <Accordion title="Python SDK">
@@ -1455,6 +1466,10 @@ Allowed values for `<subtype>` include:
 
 #### Table Description task
 
+import EnrichmentTableSummaryHiResOnly from '/snippets/general-shared-text/enrichment-table-summary-hi-res-only.mdx';
+
+<EnrichmentTableSummaryHiResOnly />
+
 <AccordionGroup>
     <Accordion title="Python SDK">
         ```python
@@ -1486,6 +1501,10 @@ Allowed values for `<subtype>` include:
 - `vertexai_table_description`
 
 #### Table to HTML task
+
+import EnrichmentTableToHTMLHiResOnly from '/snippets/general-shared-text/enrichment-table-to-html-hi-res-only.mdx';
+
+<EnrichmentTableToHTMLHiResOnly />
 
 <AccordionGroup>
     <Accordion title="Python SDK">

--- a/snippets/general-shared-text/enrichment-image-summary-hi-res-only.mdx
+++ b/snippets/general-shared-text/enrichment-image-summary-hi-res-only.mdx
@@ -1,0 +1,7 @@
+<Warning>
+    Image summary descriptions are generated only when the **Partitioner** node in a workflow is set to use the **High Res** [partitioning strategy](/ui/partitioning) and 
+    the workflow also contains an image description enrichment node.
+
+    Setting the **Partitioner** node to use **Auto**, **VLM**, or **Fast** in a workflow that also contains an image description enrichment node 
+    will not produce any image summary descriptions, and it could also cause the workflow to stop running or produce unexpected results.
+</Warning>

--- a/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx
+++ b/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx
@@ -1,0 +1,7 @@
+<Warning>
+    Image summary descriptions, table summary descriptions, and table-to-HTML output is generated only when the **Partitioner** node in a workflow is set to use the **High Res** [partitioning strategy](/ui/partitioning) and 
+    the workflow also contains an image description, table description, or table-to-HTML enrichment node.
+
+    Setting the **Partitioner** node to use **Auto**, **VLM**, or **Fast** in a workflow that also contains an image description, table description, or table-to-HTML enrichment node 
+    will not generate any image summary descriptions, table summary descriptions, or table-to-HTML output, and it could also cause the workflow to stop running or produce unexpected results.
+</Warning>

--- a/snippets/general-shared-text/enrichment-table-summary-hi-res-only.mdx
+++ b/snippets/general-shared-text/enrichment-table-summary-hi-res-only.mdx
@@ -1,0 +1,7 @@
+<Warning>
+    Table summary descriptions are generated only when the **Partitioner** node in a workflow is set to use the **High Res** [partitioning strategy](/ui/partitioning) and 
+    the workflow also contains a table description enrichment node.
+
+    Setting the **Partitioner** node to use **Auto**, **VLM**, or **Fast** in a workflow that also contains a table description enrichment node 
+    will not produce any table summary descriptions, and it could also cause the workflow to stop running or produce unexpected results.
+</Warning>

--- a/snippets/general-shared-text/enrichment-table-to-html-hi-res-only.mdx
+++ b/snippets/general-shared-text/enrichment-table-to-html-hi-res-only.mdx
@@ -1,0 +1,7 @@
+<Warning>
+    Table-to-HTML generation happens only when the **Partitioner** node in a workflow is set to use the **High Res** [partitioning strategy](/ui/partitioning) and 
+    the workflow also contains a table-to-HTML enrichment node.
+
+    Setting the **Partitioner** node to use **Auto**, **VLM**, or **Fast** in a workflow that also contains a table-to-HTML enrichment node 
+    will not generate any table-to-HTML output, and it could also cause the workflow to stop running or produce unexpected results.
+</Warning>

--- a/snippets/quickstarts/single-file-ui.mdx
+++ b/snippets/quickstarts/single-file-ui.mdx
@@ -59,6 +59,7 @@ allowfullscreen
 ></iframe>
 
 import GetStartedSimpleUIOnly from '/snippets/general-shared-text/get-started-simple-ui-only.mdx';
+import EnrichmentImagesTablesHiResOnly from '/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx';
 
 <Steps>
     <Step title="Sign up and sign in">
@@ -137,6 +138,9 @@ import GetStartedSimpleUIOnly from '/snippets/general-shared-text/get-started-si
            - Add an **Enrichment** node after the **Chunker** node, to apply enrichments to the chunked data such as image summaries, table summaries, table-to-HTML transforms, and 
              named entity recognition (NER). To do this, click the add (**+**) button to the right of the **Chunker** node, and then click **Enrich > Enrichment**. 
              Click the new **Enrichment** node and specify its settings. For help, click the **FAQ** button in the **Enrichment** node's pane. [Learn more about enrichments and enrichment settings](/ui/enriching/overview).
+
+             <EnrichmentImagesTablesHiResOnly />
+
            - Add an **Embedder** node after the **Enrichment** node, to generate vector embeddings for performing vector-based searches. To do this, click the add (**+**) button to the 
              right of the **Enrichment** node, and then click **Transform > Embedder**. Click the new **Embedder** node and specify its settings. For help, click the **FAQ** button 
              in the **Embedder** node's pane. [Learn more about embedding and embedding settings](/ui/embedding).

--- a/ui/enriching/image-descriptions.mdx
+++ b/ui/enriching/image-descriptions.mdx
@@ -43,13 +43,16 @@ Any embeddings that are produced after these summaries are generated will be bas
 
 ## Generate image descriptions
 
+import EnrichmentImageSummaryHiResOnly from '/snippets/general-shared-text/enrichment-image-summary-hi-res-only.mdx';
+
 To generate image descriptions, in an **Enrichment** node in a workflow, specify the following:
 
 <Note>
     You can change a workflow's image description settings only through [Custom](/ui/workflows#create-a-custom-workflow) workflow settings.
     
-    Image summaries are generated only when the **Partitioner** node in a workflow is also set to use the **High Res** partitioning strategy. [Learn more](/ui/partitioning).
 </Note>
+
+<EnrichmentImageSummaryHiResOnly />
 
 Select **Image**, and then choose one of the following provider (and model) combinations to use:
 

--- a/ui/enriching/overview.mdx
+++ b/ui/enriching/overview.mdx
@@ -2,6 +2,8 @@
 title: Overview
 ---
 
+import EnrichmentImagesTablesHiResOnly from '/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx';
+
 _Enriching_ adds enhancments to the processed data that Unstructured produces. These enrichments include:
 
 - Providing a summarized description of the contents of a detected image. [Learn more](/ui/enriching/image-descriptions).
@@ -13,9 +15,9 @@ To add an enrichment, in an **Enrichment** node in a workflow, select one of the
 
 <Note>
     You can change enrichment settings only through [Custom](/ui/workflows#create-a-custom-workflow) workflow settings.
-
-    Enrichments work only when the **Partitioner** node in a workflow is also set to use the **High Res** partitioning strategy. [Learn more](/ui/partitioning).
 </Note>
+
+<EnrichmentImagesTablesHiResOnly />
 
 - **Image** to provide a summarized description of the contents of each detected image. [Learn more](/ui/enriching/image-descriptions).
 - **Table** to provide a summarized description of the contents of each detected table. [Learn more](/ui/enriching/table-descriptions).

--- a/ui/enriching/table-descriptions.mdx
+++ b/ui/enriching/table-descriptions.mdx
@@ -50,13 +50,16 @@ Any embeddings that are produced after these summaries are generated will be bas
 
 ## Generate table descriptions
 
+import EnrichmentTableSummaryHiResOnly from '/snippets/general-shared-text/enrichment-table-summary-hi-res-only.mdx';
+
 To generate table descriptions, in an **Enrichment** node in a workflow, specify the following:
 
 <Note>
     You can change a workflow's table description settings only through [Custom](/ui/workflows#create-a-custom-workflow) workflow settings.
     
-    Table summaries are generated only when the **Partitioner** node in a workflow is also set to use the **High Res** partitioning strategy. [Learn more](/ui/partitioning).
 </Note>
+
+<EnrichmentTableSummaryHiResOnly />
 
 Select **Table**, and then choose one of the following provider (and model) combinations to use:
 

--- a/ui/enriching/table-to-html.mdx
+++ b/ui/enriching/table-to-html.mdx
@@ -62,6 +62,8 @@ Line breaks have been inserted here for readability. The output will not contain
 
 ## Generate table-to-HTML output
 
+import EnrichmentTableToHTMLHiResOnly from '/snippets/general-shared-text/enrichment-table-to-html-hi-res-only.mdx';
+
 To generate table-to-HTML output, in an **Enrichment** node in a workflow, for **Model**, select **OpenAI (GPT-4o)**.
 
 Make sure after you choose this provider and model, that **Table to HTML** is also selected.
@@ -69,5 +71,6 @@ Make sure after you choose this provider and model, that **Table to HTML** is al
 <Note>
     You can change a workflow's table description settings only through [Custom](/ui/workflows#create-a-custom-workflow) workflow settings.
     
-    Table-to-HTML output is generated only when the **Partitioner** node in a workflow is set to use the **High Res** partitioning strategy. [Learn more](/ui/partitioning).
 </Note>
+
+<EnrichmentTableToHTMLHiResOnly />

--- a/ui/summarizing.mdx
+++ b/ui/summarizing.mdx
@@ -73,9 +73,13 @@ Line breaks have been inserted here for readability. The output will not contain
 
 ## Summarize images or tables
 
+import EnrichmentImagesTablesHiResOnly from '/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx';
+
 To summarize images or tables, in the **Task** drop-down list of an **Enrichment** node in a workflow, specify the following:
 
 <Note>You can change a workflow's summarization settings only through [Custom](/ui/workflows#create-a-custom-workflow) workflow settings.</Note>
+
+<EnrichmentImagesTablesHiResOnly />
 
 For image summarization, select **Image Description**, and then choose one of the following provider (and model) combinations to use:
 

--- a/ui/workflows.mdx
+++ b/ui/workflows.mdx
@@ -21,6 +21,8 @@ Unstructured provides two types of workflow builders:
 
 ### Create an automatic workflow
 
+import EnrichmentImagesTablesHiResOnly from '/snippets/general-shared-text/enrichment-images-tables-hi-res-only.mdx';
+
 <Warning>
     You must first have an existing source connector and destination connector to add to the workflow.
 
@@ -99,6 +101,8 @@ By default, this workflow partitions, chunks, and generates embeddings as follow
 After this workflow is created, you can change any or all of its settings if you want to. This includes the workflow's 
 source connector, destination connector, partitioning, chunking, and embedding settings. You can also add enrichments 
 to the workflow if you want to. 
+
+<EnrichmentImagesTablesHiResOnly />
 
 To change the workflow's default settings or to add enrichments:
 
@@ -202,6 +206,9 @@ If you did not previously set the workflow to run on a schedule, you can [run th
 
     - Click **Connect** to add another **Source** or **Destination** node. You can add multiple source and destination locations. Files will be ingested from all of the source locations, and the processed data will be delivered to all of the destination locations. [Learn more](#custom-workflow-node-types).
     - Click **Enrich** to add a **Chunker** or **Enrichment** node. [Learn more](#custom-workflow-node-types).
+
+      <EnrichmentImagesTablesHiResOnly />
+
     - Click **Transform** to add a **Partitioner** or **Embedder** node. [Learn more](#custom-workflow-node-types).
 
     <Tip>
@@ -306,6 +313,8 @@ import PlatformPartitioningStrategies from '/snippets/general-shared-text/platfo
     </Accordion>
     <Accordion title="Enrichment node">
         Choose one of the following:
+
+        <EnrichmentImagesTablesHiResOnly />
 
         - **Image** to summarize images. Also select one of the following provider (and model) combinations to use:
 


### PR DESCRIPTION
More external customers (and now internal users) are encountering this, resulting in hung workflows and no-ops, so making this guidance clearer throughout the docs. 

See for example the yellow warning box in https://unstructured-53-hi-res-enrichments-2025-05-22.mintlify.app/ui/enriching/overview