### PR TITLE
Embedding models: together.ai 2K and 8K models are no longer available

### DIFF
--- a/api-reference/workflow/workflows.mdx
+++ b/api-reference/workflow/workflows.mdx
@@ -1788,8 +1788,6 @@ Allowed values for `subtype` and `model_name` include:
 
 - `"subtype": "togetherai"`
 
-  - `"model_name": "togethercomputer/m2-bert-80M-2k-retrieval"`
-  - `"model_name": "togethercomputer/m2-bert-80M-8k-retrieval"`
   - `"model_name": "togethercomputer/m2-bert-80M-32k-retrieval"`
 
 - `"subtype": "voyageai"`

--- a/open-source/how-to/embedding.mdx
+++ b/open-source/how-to/embedding.mdx
@@ -70,7 +70,7 @@ To use the Ingest CLI or Ingest Python library to generate embeddings, do the fo
    - `mixedbread-ai`. [Choose a model](https://www.mixedbread.ai/docs/embeddings/models), or use the default model [mixedbread-ai/mxbai-embed-large-v1](https://www.mixedbread.ai/docs/embeddings/mxbai-embed-large-v1).
    - `octoai`. [Choose a model](https://octo.ai/blog/supercharge-rag-performance-using-octoai-and-unstructured-embeddings/), or use the default model `thenlper/gte-large`.
    - `openai`. [Choose a model](https://platform.openai.com/docs/guides/embeddings/embedding-models), or use the default model `text-embedding-ada-002`.
-   - `togetherai`. [Choose a model](https://docs.together.ai/docs/embedding-models), or use the default model `togethercomputer/m2-bert-80M-8k-retrieval`.
+   - `togetherai`. [Choose a model](https://docs.together.ai/docs/embedding-models), or use the default model `togethercomputer/m2-bert-80M-32k-retrieval`.
    - `vertexai`. [Choose a model](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api), or use the default model `text-embedding-05`.
    - `voyageai`.  [Choose a model](https://docs.voyageai.com/docs/embeddings). No default model is provided.
 

--- a/snippets/ingest-configuration-shared/embedding-configuration.mdx
+++ b/snippets/ingest-configuration-shared/embedding-configuration.mdx
@@ -28,7 +28,7 @@ The default `embedding_model_name` values unless otherwise specified are:
 
 * `openai`: `text-embedding-ada-002`, with 1536 dimensions
 
-* `togetherai`: `togethercomputer/m2-bert-80M-8k-retrieval`, with 768 dimensions
+* `togetherai`: `togethercomputer/m2-bert-80M-32k-retrieval`, with 768 dimensions
 
 * `vertexai`: `text-embedding-05`, with 768 dimensions
 

--- a/ui/embedding.mdx
+++ b/ui/embedding.mdx
@@ -81,8 +81,6 @@ To generate embeddings, choose one of the following embedding providers and mode
 
 - **TogetherAI**: Use [TogetherAI](https://www.together.ai/) to generate embeddings with one of the following models:
 
-  - **M2-BERT-80M-2K-Retrieval**, with 768 dimensions.
-  - **M2-BERT-80M-8K-Retrieval**, with 768 dimensions.
   - **M2-BERT-80M-32K-Retrieval**, with 768 dimensions.
   
   [Learn more](https://docs.together.ai/docs/serverless-models#embedding-models).

--- a/ui/workflows.mdx
+++ b/ui/workflows.mdx
@@ -376,8 +376,6 @@ import PlatformPartitioningStrategies from '/snippets/general-shared-text/platfo
 
         - **TogetherAI**: Use TogetherAI to generate embeddings with one of the following models:
 
-          - **M2-BERT-80M-2K-Retrieval**, with 768 dimensions.
-          - **M2-BERT-80M-8K-Retrieval**, with 768 dimensions.
           - **M2-BERT-80M-32K-Retrieval**, with 768 dimensions.
           
           [Learn more](https://docs.together.ai/docs/serverless-models#embedding-models).


### PR DESCRIPTION
The 32K model is currently the only one offered and is now the default for together.ai.