### PR TITLE
MongoDB connectors: update embedded how-to video

### DIFF
--- a/snippets/general-shared-text/mongodb.mdx
+++ b/snippets/general-shared-text/mongodb.mdx
@@ -1,3 +1,13 @@
+<iframe
+width="560"
+height="315"
+src="https://www.youtube.com/embed/8YBVHt5spIQ"
+title="YouTube video player"
+frameborder="0"
+allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen
+></iframe>
+
 The MongoDB requirements for a MongoDB Atlas deployment include:
 
 import AllowIPAddressRanges from '/snippets/general-shared-text/ip-address-ranges.mdx';


### PR DESCRIPTION
Re-shot the how-to video to show creating an `M10` cluster that included SCRAM-SHA-256 for authentication. (The previous version showed creating an `M0` (`Free`) cluster that only includes SCRAM-SHA-1 for authentication, which we no longer support.)

See for example the embedded video in https://unstructured-53-doc-23-mongodb-atlas.mintlify.app/ui/sources/mongodb