### PR TITLE
SharePoint source connector: Power Automate flow example - use key vault value instead of hard-coded API key

### DIFF
--- a/examplecode/tools/sharepoint-events.mdx
+++ b/examplecode/tools/sharepoint-events.mdx
@@ -142,7 +142,8 @@ In this step, you store your Unstructured API key in an Azure key vault for your
     - For **Headers**, enter the following:
 
       - `accept`, set to `application/json`
-      - `unstructured-api-key`, set to your Unstructured API key value.
+      - `unstructured-api-key`, set to your key vault value. To do this, type `/` and select **Insert dynamic content**. 
+        Under **Get secret**, select **body/value**.
 
 16. In the top navigation bar, click the disk (**Save**) button.
 17. Click **Back** to go to the flow's home page.


### PR DESCRIPTION
See https://unstructured-53-sharepoint-events-2025-07-11.mintlify.app/examplecode/tools/sharepoint-events#step-3%3A-create-a-power-automate-flow > item 15, `unstructured-api-key` setting