### PR TITLE
Workflow Endpoint: all connectors - deprecate ConfigInput and ConnectorType across all code examples

### DIFF
--- a/api-reference/workflow/overview.mdx
+++ b/api-reference/workflow/overview.mdx
@@ -272,15 +272,14 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import ListSourcesRequest
-        from unstructured_client.models.shared import SourceConnectorType
-
+        
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
         )
 
         response = client.sources.list_sources(
             request=ListSourcesRequest(
-                source_type=SourceConnectorType.<type> # Optional, list only for this source type.
+                source_type="<type>" # Optional, list only for this source type.
             )
         )
 
@@ -301,8 +300,7 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import ListSourcesRequest
-        from unstructured_client.models.shared import SourceConnectorType
-
+        
         async def list_sources():
             client = UnstructuredClient(
                 api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
@@ -310,7 +308,7 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
             response = await client.sources.list_sources_async(
                 request=ListSourcesRequest(
-                    source_type=SourceConnectorType.<type> # Optional, list only for this source type. 
+                    source_type="<type>" # Optional, list only for this source type. 
                 )
             )
 
@@ -471,22 +469,18 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import CreateSourceRequest
-        from unstructured_client.models.shared import (
-            CreateSourceConnector,
-            SourceConnectorType,
-            <type>SourceConnectorConfigInput
-        )
+        from unstructured_client.models.shared import CreateSourceConnector
 
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
         )
 
-        destination_connector = CreateSourceConnector(
+        source_connector = CreateSourceConnector(
             name="<name>",
-            type=SourceConnectorType.<type>,
-            config=<type>SourceConnectorConfigInput(
+            type="<type>",
+            config={
                 # Specify the settings for the connector here.
-            )
+            }
         )
 
         response = client.sources.create_source(
@@ -512,11 +506,7 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import CreateSourceRequest
-        from unstructured_client.models.shared import (
-            CreateSourceConnector,
-            SourceConnectorType,
-            <type>SourceConnectorConfigInput
-        )
+        from unstructured_client.models.shared import CreateSourceConnector
 
         async def create_source():
             client = UnstructuredClient(
@@ -525,10 +515,10 @@ To get this ID, see [Sources](/api-reference/workflow/sources/overview).
 
             source_connector = CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.<type>,
-                config=<type>SourceConnectorConfigInput(
+                type="<type>",
+                config={
                     # Specify the settings for the connector here.
-                )
+                }
             )
 
             response = await client.sources.create_source_async(
@@ -604,19 +594,16 @@ You can change any of the connector's settings except for its `name` and `type`.
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import UpdateSourceRequest
-        from unstructured_client.models.shared import (
-            UpdateSourceConnector,
-            <type>SourceConnectorConfigInput
-        )
+        from unstructured_client.models.shared import UpdateSourceConnector
 
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
         )
 
         source_connector = UpdateSourceConnector(
-            config=<type>SourceConnectorConfigInput(
+            config={
                 # Specify the settings for the connector here.
-            )
+            }
         )
 
         response = client.sources.update_source(
@@ -643,20 +630,17 @@ You can change any of the connector's settings except for its `name` and `type`.
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import UpdateSourceRequest
-        from unstructured_client.models.shared import (
-            UpdateSourceConnector,
-            <type>SourceConnectorConfigInput
-        )
-
+        from unstructured_client.models.shared import UpdateSourceConnector
+        
         async def update_source():
             client = UnstructuredClient(
                 api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
             )
 
             source_connector = UpdateSourceConnector(
-                config=<type>SourceConnectorConfigInput(
+                config={
                     # Specify the settings for the connector here.
-                )
+                }
             )
 
             response = await client.sources.update_source_async(
@@ -867,15 +851,14 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import ListDestinationsRequest
-        from unstructured_client.models.shared import DestinationConnectorType
-
+        
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
         )
 
         response = client.destinations.list_destinations(
             request=ListDestinationsRequest(
-                destination_type=DestinationConnectorType.<type> # Optional, list only for this destination type.
+                destination_type="<type>" # Optional, list only for this destination type.
             )
         )
 
@@ -896,8 +879,7 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import ListDestinationsRequest
-        from unstructured_client.models.shared import DestinationConnectorType
-
+        
         async def list_destinations():
             client = UnstructuredClient(
                 api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
@@ -905,7 +887,7 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
             response = await client.destinations.list_destinations_async(
                 request=ListDestinationsRequest(
-                    destination_type=DestinationConnectorType.<type>  # Optional, list only for this destination type.
+                    destination_type="<type>" # Optional, list only for this destination type.
                 )
             )
 
@@ -1065,11 +1047,7 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import CreateDestinationRequest
-        from unstructured_client.models.shared import (
-            CreateDestinationConnector,
-            DestinationConnectorType,
-            <type>DestinationConnectorConfigInput
-        )
+        from unstructured_client.models.shared import CreateDestinationConnector
 
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
@@ -1077,10 +1055,10 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
         destination_connector = CreateDestinationConnector(
             name="<name>",
-            type=DestinationConnectorType.<type>,
-            config=<type>DestinationConnectorConfigInput(
+            type="<type>",
+            config={
                 # Specify the settings for the connector here.
-            )
+            }
         )
 
         response = client.destinations.create_destination(
@@ -1105,11 +1083,7 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import CreateDestinationRequest
-        from unstructured_client.models.shared import (
-            CreateDestinationConnector,
-            DestinationConnectorType,
-            <type>DestinationConnectorConfigInput
-        )
+        from unstructured_client.models.shared import CreateDestinationConnector
 
         async def create_destination():
             client = UnstructuredClient(
@@ -1117,11 +1091,11 @@ To get this ID, see [Destinations](/api-reference/workflow/destinations/overview
             )
 
             destination_connector = CreateDestinationConnector(
-                name="my-s3-connector",
-                type=DestinationConnectorType.<type>,
-                config=<type>DestinationConnectorConfigInput(
+                name="<name>",
+                type="<type>",
+                config={
                     # Specify the settings for the connector here.
-                )
+                }
             )
 
             response = await client.destinations.create_destination_async(
@@ -1194,19 +1168,16 @@ You can change any of the connector's settings except for its `name` and `type`.
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import UpdateDestinationRequest
-        from unstructured_client.models.shared import (
-            UpdateDestinationConnector,
-            <type>DestinationConnectorConfigInput
-        )
+        from unstructured_client.models.shared import UpdateDestinationConnector
 
         client = UnstructuredClient(
             api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")
         )
 
         destination_connector = UpdateDestinationConnector(
-            config=<type>DestinationConnectorConfigInput(
+            config={
                 # Specify the settings for the connector here.
-            )
+            }
         )
 
         response = client.destinations.update_destination(
@@ -1232,10 +1203,7 @@ You can change any of the connector's settings except for its `name` and `type`.
 
         from unstructured_client import UnstructuredClient
         from unstructured_client.models.operations import UpdateDestinationRequest
-        from unstructured_client.models.shared import (
-            UpdateDestinationConnector,
-            <type>DestinationConnectorConfigInput
-        )
+        from unstructured_client.models.shared import UpdateDestinationConnector
 
         async def update_destination():
             client = UnstructuredClient(
@@ -1243,9 +1211,9 @@ You can change any of the connector's settings except for its `name` and `type`.
             )
 
             destination_connector = UpdateDestinationConnector(
-                config=<type>DestinationConnectorConfigInput(
+                config={
                     # Specify the settings for the connector here.
-                )
+                }
             )
 
             response = await client.destinations.update_destination_async(

--- a/examplecode/tools/mcp.mdx
+++ b/examplecode/tools/mcp.mdx
@@ -140,8 +140,7 @@ You are now ready to start coding.
             ListSourcesRequest,
             GetSourceRequest
         )
-        from unstructured_client.models.shared import SourceConnectorType
-
+        
         def load_environment_variables() -> None:
             """
             Loads environment variables from a .env file and checks for required variables. 
@@ -209,7 +208,7 @@ You are now ready to start coding.
 
             if source_type:
                 try:
-                    request.source_type = SourceConnectorType[source_type]
+                    request.source_type = [source_type]
                 except KeyError:
                     return f"Invalid source type: {source_type}"
 

--- a/snippets/destination_connectors/astradb_sdk.mdx
+++ b/snippets/destination_connectors/astradb_sdk.mdx
@@ -3,26 +3,22 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    AstraDBConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.ASTRADB,
-                config=AstraDBConnectorConfigInput(
-                    token="<token>",
-                    api_endpoint="<api-endpoint>",
-                    collection_name="<collection-name>",
-                    keyspace="<keyspace>",
-                    batch_size=<batch-size>,
-                    flatten_metadata=<True|False>
-                )
+                type="astradb",
+                config={
+                    "token": "<token>",
+                    "api_endpoint": "<api-endpoint>",
+                    "collection_name": "<collection-name>",
+                    "keyspace=": "<keyspace>",
+                    "batch_size": <batch-size>,
+                    "flatten_metadata": <True|False>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/azure_ai_search_sdk.mdx
+++ b/snippets/destination_connectors/azure_ai_search_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    AzureAISearchConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.AZURE_AI_SEARCH,
-                config=AzureAISearchConnectorConfigInput(
-                    endpoint="<endpoint>",
-                    index="<index>",
-                    key="<azure-ai-search-key>"
-                )
+                type="azure_ai_search",
+                config={
+                    "endpoint": "<endpoint>",
+                    "index": "<index>",
+                    "key": "<azure-ai-search-key>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/couchbase_sdk.mdx
+++ b/snippets/destination_connectors/couchbase_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    CouchbaseDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=estinationConnectorType.COUCHBASE,
-                config=CouchbaseDestinationConnectorConfigInput(
-                    username="<username>",
-                    bucket="<bucket>",
-                    connection_string="<connection-string>",
-                    scope="<scope>",
-                    collection="<collection>",
-                    password="<password>",
-                    batch_size=<batch-size>
-                )
+                type="couchbase",
+                config={
+                    "username": "<username>",
+                    "bucket": "<bucket>",
+                    "connection_string": "<connection-string>",
+                    "scope": "<scope>",
+                    "collection": "<collection>",
+                    "password": "<password>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/databricks_delta_table_sdk.mdx
+++ b/snippets/destination_connectors/databricks_delta_table_sdk.mdx
@@ -3,31 +3,27 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    DatabricksVDTDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.DATABRICKS_VOLUME_DELTA_TABLES,
-                config=DatabricksVDTDestinationConnectorConfigInput(
-                    server_hostname="<server-hostname>",
-                    http_path="<http-path>",
-                    token="<token>",
-                    client_id="<client-id>",
-                    client_secret="<client-secret>",
-                    volume="<volume>",
-                    catalog="<catalog>",
-                    volume_path="<volume_path>",
-                    schema="<schema>",
-                    database="<database>",
-                    table_name="<table_name>"
-                )
+                type="databricks_volume_delta_tables",
+                config={
+                    "server_hostname": "<server-hostname>",
+                    "http_path": "<http-path>",
+                    "token": "<token>",
+                    "client_id": "<client-id>",
+                    "client_secret": "<client-secret>",
+                    "volume": "<volume>",
+                    "catalog": "<catalog>",
+                    "volume_path": "<volume_path>",
+                    "schema": "<schema>",
+                    "database": "<database>",
+                    "table_name": "<table_name>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/databricks_volumes_sdk.mdx
+++ b/snippets/destination_connectors/databricks_volumes_sdk.mdx
@@ -3,32 +3,28 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    DatabricksVolumesConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.DATABRICKS_VOLUMES,
-                config=DatabricksVolumesConnectorConfigInput(
-                    host="<host>",
-                    catalog="<catalog>",
-                    schema="<schema>",
-                    volume="<volume>",
-                    volume_path="<volume_path>",
+                type="databricks_volumes",
+                config={
+                    "host": "<host>",
+                    "catalog": "<catalog>",
+                    "schema": "<schema>",
+                    "volume": "<volume>",
+                    "volume_path": "<volume_path>",
 
                     # For Databricks OAuth machine-to-machine (M2M) authentication:
-                    client_secret="<client-secret>",
-                    client_id="<client-id>"
+                    "client_secret": "<client-secret>",
+                    "client_id": "<client-id>"
 
                     # For Databricks personal access token authentication:
-                    token="<token>"
-                )
+                    "token": "<token>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/delta_table_sdk.mdx
+++ b/snippets/destination_connectors/delta_table_sdk.mdx
@@ -3,24 +3,20 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    DeltaTableConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.DELTA_TABLE,
-                config=DeltaTableConnectorConfigInput(
-                    aws_region="<aws-region>",
-                    table_uri="<table-uri>",
-                    aws_access_key_id="<aws-access-key-id>",
-                    aws_secret_access_key="<aws-secret-access-key>"
-                )
+                type="delta_table",
+                config={
+                    "aws_region": "<aws-region>",
+                    "table_uri": "<table-uri>",
+                    "aws_access_key_id": "<aws-access-key-id>",
+                    "aws_secret_access_key": "<aws-secret-access-key>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/elasticsearch_sdk.mdx
+++ b/snippets/destination_connectors/elasticsearch_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    ElasticsearchConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.ELASTICSEARCH,
-                config=ElasticsearchConnectorConfigInput(
-                    hosts=["<host-url>"],
-                    es_api_key="<es-api-key>",
-                    index_name="<index-name>"
-                )
+                type="elasticsearch",
+                config={
+                    "hosts": ["<host-url>"],
+                    "es_api_key": "<es-api-key>",
+                    "index_name": "<index-name>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/gcs_sdk.mdx
+++ b/snippets/destination_connectors/gcs_sdk.mdx
@@ -3,22 +3,18 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    GCSDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.GCS,
-                config=GCSDestinationConnectorConfigInput(
-                    remote_url="<remote-url>",
-                    service_account_key="<service-account-key>"
-                )
+                type="gcs",
+                config={
+                    "remote_url": "<remote-url>",
+                    "service_account_key": "<service-account-key>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/ibm_watsonxdata_sdk.mdx
+++ b/snippets/destination_connectors/ibm_watsonxdata_sdk.mdx
@@ -3,32 +3,28 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    IBMWatsonxS3DestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.IBM_WATSONX_S3,
-                config=IBMWatsonxS3DestinationConnectorConfigInput(
-                    iceberg_endpoint="<iceberg-endpoint>",
-                    object_storage_endpoint="<object-storage-endpoint>",
-                    object_storage_region="<object-storage-region>",
-                    iam_api_key="<iam-api-key>",
-                    access_key_id="<access-key-id>",
-                    secret_access_key="<secret-access-key>",
-                    catalog="<catalog>",
-                    namespace="<namespace>",
-                    table="<table>",
-                    max_retries=<max-retries>,
-                    max_retries_connection=<max-retries-connection>,
-                    record_id_key="<record-id-key>"
-                )
+                type="ibm_watsonx_s3",
+                config={
+                    "iceberg_endpoint": "<iceberg-endpoint>",
+                    "object_storage_endpoint": "<object-storage-endpoint>",
+                    "object_storage_region": "<object-storage-region>",
+                    "iam_api_key": "<iam-api-key>",
+                    "access_key_id": "<access-key-id>",
+                    "secret_access_key": "<secret-access-key>",
+                    "catalog": "<catalog>",
+                    "namespace": "<namespace>",
+                    "table": "<table>",
+                    "max_retries": <max-retries>,
+                    "max_retries_connection": <max-retries-connection>,
+                    "record_id_key": "<record-id-key>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/kafka_sdk.mdx
+++ b/snippets/destination_connectors/kafka_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    KafkaCloudDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.KAFKA_CLOUD,
-                config=KafkaCloudDestinationConnectorConfigInput(
-                    bootstrap_servers="<bootstrap-server>",
-                    port=<port>,
-                    group_id="<group-id>",
-                    kafka_api_key="<kafka-api-key>",
-                    secret="<secret>",
-                    topic="<topic>",
-                    batch_size=<batch-size>
-                )
+                type="kafka-cloud",
+                config={
+                    "bootstrap_servers": "<bootstrap-server>",
+                    "port": <port>,
+                    "group_id": "<group-id>",
+                    "kafka_api_key": "<kafka-api-key>",
+                    "secret": "<secret>",
+                    "topic": "<topic>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/milvus_sdk.mdx
+++ b/snippets/destination_connectors/milvus_sdk.mdx
@@ -3,25 +3,21 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    MilvusDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.MILVUS,
-                config=MilvusDestinationConnectorConfigInput(
-                    user="<user>",
-                    uri="<uri>",
-                    db_name="<db-name>",
-                    password="<password>",
-                    collection_name="<collection-name>"
-                )
+                type="milvus",
+                config={
+                    "user": "<user>",
+                    "uri": "<uri>",
+                    "db_name": "<db-name>",
+                    "password": "<password>",
+                    "collection_name": "<collection-name>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/mongodb_sdk.mdx
+++ b/snippets/destination_connectors/mongodb_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    MongoDBConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.MONGODB,
-                config=MongoDBConnectorConfigInput(
-                    database="<database>",
-                    collection="<collection>",
-                    uri="<uri>"
-                )
+                type="mongodb",
+                config={
+                    "database": "<database>",
+                    "collection": "<collection>",
+                    "uri": "<uri>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/motherduck_sdk.mdx
+++ b/snippets/destination_connectors/motherduck_sdk.mdx
@@ -3,24 +3,20 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    MotherDuckDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.MOTHERDUCK,
-                config=MotherDuckDestinationConnectorConfigInput(
-                    database="<database>",
-                    db_schema="<db-schema>",
-                    table="<table>",
-                    md_token="<md-token>"
-                )
+                type="motherduck",
+                config={
+                    "database": "<database>",
+                    "db_schema": "<db-schema>",
+                    "table": "<table>",
+                    "md_token": "<md-token>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/neo4j_sdk.mdx
+++ b/snippets/destination_connectors/neo4j_sdk.mdx
@@ -3,25 +3,21 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    Neo4jDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.NEO4J,
-                config=Neo4jDestinationConnectorConfigInput(
-                    uri="<uri>",
-                    database="<database>",
-                    username="<username>",
-                    password="<password>",
-                    batch_size=<batch-size>
-                )
+                type="neo4j",
+                config={
+                    "uri": "<uri>",
+                    "database": "<database>",
+                    "username": "<username>",
+                    "password": "<password>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/onedrive_sdk.mdx
+++ b/snippets/destination_connectors/onedrive_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    OneDriveDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.ONEDRIVE,
-                config=OneDriveDestinationConnectorConfigInput(
-                    client_id="<client-id>", 
-                    user_pname="<user-pname>",
-                    password="<password>", # For username and password authentication.
-                    tenant="<tenant>", 
-                    authority_url="<authority-url>",
-                    client_cred="<client-cred>",
-                    remote_url="<remote-url>" 
-                )
+                type="onedrive",
+                config={
+                    "client_id": "<client-id>",
+                    "user_pname": "<user-pname>",
+                    "password": "<password>",  # For username and password authentication
+                    "tenant": "<tenant>",
+                    "authority_url": "<authority-url>",
+                    "client_cred": "<client-cred>",
+                    "remote_url": "<remote-url>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/pinecone_sdk.mdx
+++ b/snippets/destination_connectors/pinecone_sdk.mdx
@@ -3,24 +3,20 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    PineconeDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.PINECONE,
-                config=PineconeDestinationConnectorConfigInput(
-                    index_name="<index-name>", 
-                    namespace="<namespace-name>",
-                    api_key="<api-key>",
-                    batch_size=<batch-size>
-                )
+                type="pinecone",
+                config={
+                    "index_name": "<index-name>",
+                    "namespace": "<namespace-name>",
+                    "api_key": "<api-key>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/postgresql_sdk.mdx
+++ b/snippets/destination_connectors/postgresql_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    PostgresDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.POSTGRES,
-                config=PostgresDestinationConnectorConfigInput(
-                    host="<host>",
-                    database="<database>",
-                    port="<port>",
-                    username="<username>",
-                    password="<password>",
-                    table_name="<table_name>",
-                    batch_size=<batch-size>
-                )
+                type="postgres",
+                config={
+                    "host": "<host>",
+                    "database": "<database>",
+                    "port": <port>
+                    "username": "<username>",
+                    "password": "<password>",
+                    "table_name": "<table_name>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/qdrant_sdk.mdx
+++ b/snippets/destination_connectors/qdrant_sdk.mdx
@@ -3,24 +3,20 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    QdrantCloudDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.QDRANT_CLOUD,
-                config=QdrantCloudDestinationConnectorConfigInput(
-                    url="<url>",
-                    collection_name="<collection-name>",
-                    batch_size=<batch-size>,
-                    api_key="<api-key>"
-                )
+                type="qdrant-cloud",
+                config={
+                    "url": "<url>",
+                    "collection_name": "<collection-name>",
+                    "batch_size": <batch-size>,
+                    "api_key": "<api-key>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/redis_sdk.mdx
+++ b/snippets/destination_connectors/redis_sdk.mdx
@@ -3,33 +3,29 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    RedisDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.REDIS,
-                config=RedisDestinationConnectorConfigInput(
-                    database="<database>",
-                    ssl=<True|False>,
-                    batch_size=<batch-size>,
-                    key_prefix="<key-prefix>",
+                type="redis",
+                config={
+                    "database": "<database>",
+                    "ssl": <True|False>,
+                    "batch_size": <batch-size>,
+                    "key_prefix": "<key-prefix>",
 
-                    # For URI authentication:
-                    uri="<uri>"
-                
-                    # For password authentication:
-                    host="<host>",
-                    port=<port>,
-                    username="<username>",
-                    password="<password>"   
-                )
+                    # For URI authentication, include only "uri" key:
+                    # "uri": "<uri>",
+
+                    # For password authentication, include these keys instead:
+                    # "host": "<host>",
+                    # "port": <port>,
+                    # "username": "<username>",
+                    # "password": "<password>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/s3_sdk.mdx
+++ b/snippets/destination_connectors/s3_sdk.mdx
@@ -3,31 +3,25 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    S3DestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.S3,
-                config=S3DestinationConnectorConfigInput(
-                    # For AWS access key ID with AWS secret access key authentication:
-                    key="<key>", 
-                    secret="<secret>", 
+                type="s3",
+                config={
+                    # For AWS Access Key ID with AWS Secret Access Key authentication:
+                    "key": "<key>",
+                    "secret": "<secret>",
 
-                    # For AWS STS token authentication:
-                    key="<key>", 
-                    secret="<secret>",
-                    token="<token>", 
+                    # For AWS STS token authentication (use instead of or in addition to above):
+                    # "token": "<token>",
 
-                    remote_url="<remote_url>",
-                    endpoint_url="<endpoint-url>"
-                )
+                    "remote_url": "<remote_url>",
+                    "endpoint_url": "<endpoint-url>"
+                }
             )
         )
     )

--- a/snippets/destination_connectors/snowflake_sdk.mdx
+++ b/snippets/destination_connectors/snowflake_sdk.mdx
@@ -3,31 +3,27 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    SnowflakeDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.SNOWFLAKE,
-                config=SnowflakeDestinationConnectorConfigInput(
-                    account="<account>",
-                    user="<user>",
-                    host="<host>",
-                    port=<port>,
-                    database="<database>",
-                    schema="<schema>",
-                    role="<role>",
-                    password="<password>",
-                    record_id_key="<record-id-key>",
-                    table_name="<table_name>",
-                    batch_size=<batch-size>
-                )
+                type="snowflake",
+                config={
+                    "account": "<account>",
+                    "user": "<user>",
+                    "host": "<host>",
+                    "port": <port>,
+                    "database": "<database>",
+                    "schema": "<schema>",
+                    "role": "<role>",
+                    "password": "<password>",
+                    "record_id_key": "<record-id-key>",
+                    "table_name": "<table_name>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )

--- a/snippets/destination_connectors/weaviate_sdk.mdx
+++ b/snippets/destination_connectors/weaviate_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateDestinationRequest
-from unstructured_client.models.shared import (
-    CreateDestinationConnector,
-    DestinationConnectorType,
-    WeaviateDestinationConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateDestinationConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.destinations.create_destination(
         request=CreateDestinationRequest(
             create_destination_connector=CreateDestinationConnector(
                 name="<name>",
-                type=DestinationConnectorType.WEAVIATE_CLOUD,
-                config=WeaviateDestinationConnectorConfigInput(
-                    cluster_url="<host-url>",
-                    collection="<class-name>",
-                    api_key="<api-key>"
-                )
+                type="weaviate-cloud",
+                config={
+                    "cluster_url": "<host-url>",
+                    "collection": "<class-name>",
+                    "api_key": "<api-key>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/azure_sdk.mdx
+++ b/snippets/source_connectors/azure_sdk.mdx
@@ -3,36 +3,31 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    AzureSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.AZURE,
-                config=AzureSourceConnectorConfigInput(
-                    remote_url="az://<container-name>/<path/to/file/or/folder>",
-                    recursive=<True|False>,
-                
-                    # For anonymous authentication, do not set any of the 
-                    # following fields.
+                type="azure",
+                config={
+                    "remote_url": "az://<container-name>/<path/to/file/or/folder>",
+                    "recursive": <True|False>,
 
+                    # For anonymous authentication, omit the following auth keys.
+                    
                     # For SAS token authentication:
-                    account_name="<account-name>",
-                    sas_token="<sas-token>"
+                    # "account_name": "<account-name>",
+                    # "sas_token": "<sas-token>",
 
                     # For account key authentication:
-                    account_name="<account-name>",
-                    account_key="<account-key>"
+                    # "account_name": "<account-name>",
+                    # "account_key": "<account-key>",
 
                     # For connection string authentication:
-                    connection_string="<connection-string>"
-                )
+                    # "connection_string": "<connection-string>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/box_sdk.mdx
+++ b/snippets/source_connectors/box_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    BoxSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.BOX,
-                config=BoxSourceConnectorConfigInput(
-                    remote_url="<remote-url>",
-                    recursive=<True|False>,
-                    box_app_config="<box-app-config>"
-                )
+                type="box",
+                config={
+                    "remote_url": "<remote-url>",
+                    "recursive": <True|False>,
+                    "box_app_config": "<box-app-config>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/confluence_sdk.mdx
+++ b/snippets/source_connectors/confluence_sdk.mdx
@@ -3,43 +3,36 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    ConfuenceSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.CONFLUENCE,
-                config=ConfluenceSourceConnectorConfigInput(
-                    url="<url>",
-                    max_num_of_spaces=<max-num-of-spaces>,
-                    max_num_of_docs_from_each_space=<max-num-of-docs-from-each-space>,
-                    spaces=["<space-name>", "<space-name>"],
-                    extract_images=<True|False>,
-                    extract_files=<True|False>,
+                type="confluence",
+                config={
+                    "url": "<url>",
+                    "max_num_of_spaces": <max-num-of-spaces>,
+                    "max_num_of_docs_from_each_space": <max-num-of-docs-from-each-space>,
+                    "spaces": ["<space-name>", "<space-name>"],
+                    "extract_images": <True|False>,
+                    "extract_files": <True|False>,
 
                     # For API token authentication:
-
-                    username="<username>",
-                    token="<api-token>",
-                    cloud=<True|False>
+                    # "username": "<username>",
+                    # "token": "<api-token>",
+                    # "cloud": <True|False>,
 
                     # For personal access token (PAT) authentication:
-
-                    token="<personal-access-token>",
-                    cloud=False
+                    # "token": "<personal-access-token>",
+                    # "cloud": False,
 
                     # For password authentication:
-
-                    username="<username>",
-                    password="<password>",
-                    cloud=<True|False>     
-                )
+                    # "username": "<username>",
+                    # "password": "<password>",
+                    # "cloud": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/couchbase_sdk.mdx
+++ b/snippets/source_connectors/couchbase_sdk.mdx
@@ -3,28 +3,24 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    CouchbaseSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.COUCHBASE,
-                config=CouchbaseSourceConnectorConfigInput(
-                    username="<username>",
-                    bucket="<bucket>",
-                    connection_string="<connection-string>",
-                    scope="<scope>",
-                    collection="<collection>",
-                    password="<password>",
-                    batch_size=<batch-size>,
-                    collection_id="<collection-id>" 
-                )
+                type="couchbase",
+                config={
+                    "username": "<username>",
+                    "bucket": "<bucket>",
+                    "connection_string": "<connection-string>",
+                    "scope": "<scope>",
+                    "collection": "<collection>",
+                    "password": "<password>",
+                    "batch_size": <batch-size>,
+                    "collection_id": "<collection-id>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/databricks_volumes_sdk.mdx
+++ b/snippets/source_connectors/databricks_volumes_sdk.mdx
@@ -3,32 +3,28 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    DatabricksVolumesConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.DATABRICKS_VOLUMES,
-                config=DatabricksVolumesConnectorConfigInput(
-                    catalog="<catalog>",
-                    host="<host>",
-                    schema_="<schema>",
-                    volume="<volume>",
-                    volume_path="<volume_path>",
+                type="databricks_volumes",
+                config={
+                    "catalog": "<catalog>",
+                    "host": "<host>",
+                    "schema_": "<schema>",
+                    "volume": "<volume>",
+                    "volume_path": "<volume_path>",
 
                     # For Databricks OAuth machine-to-machine (M2M) authentication:
-                    client_id="<client_id>",
-                    client_secret="<client_secret>"
+                    # "client_id": "<client_id>",
+                    # "client_secret": "<client_secret>",
 
                     # For Databricks personal access token authentication:
-                    token="<token>"
-                )
+                    # "token": "<token>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/dropbox_sdk.mdx
+++ b/snippets/source_connectors/dropbox_sdk.mdx
@@ -3,25 +3,21 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    DropboxSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.DROPBOX,
-                config=DropboxSourceConnectorConfigInput(
-                    remote_url="<remote-url>",
-                    recursive=<True|False>,
-                    refresh_token="<refresh-token>",
-                    app_key="<app-key>",
-                    app_secret="<app-secret>"
-                )
+                type="dropbox",
+                config={
+                    "remote_url": "<remote-url>",
+                    "recursive": <True|False>,
+                    "refresh_token": "<refresh-token>",
+                    "app_key": "<app-key>",
+                    "app_secret": "<app-secret>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/elasticsearch_sdk.mdx
+++ b/snippets/source_connectors/elasticsearch_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    ElasticsearchConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.ELASTICSEARCH,
-                config=ElasticsearchConnectorConfigInput(
-                    hosts=["<host-url>"],
-                    es_api_key="<es-api-key>",
-                    index_name="<index-name>"
-                )
+                type="elasticsearch",
+                config={
+                    "hosts": ["<host-url>"],
+                    "es_api_key": "<es-api-key>",
+                    "index_name": "<index-name>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/gcs_sdk.mdx
+++ b/snippets/source_connectors/gcs_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    GCSSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.GCS,
-                config=GCSSourceConnectorConfigInput(
-                    service_account_key="<service-account-key>",
-                    remote_url="<remote-url>",
-                    recursive=<True|False>
-                )
+                type="gcs",
+                config={
+                    "service_account_key": "<service-account-key>",
+                    "remote_url": "<remote-url>",
+                    "recursive": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/google_drive_sdk.mdx
+++ b/snippets/source_connectors/google_drive_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    GoogleDriveSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.GOOGLE_DRIVE,
-                config=GoogleDriveSourceConnectorConfigInput(
-                    drive_id="<drive-id>",
-                    service_account_key="<service-account-key>",
-                    extensions=[
+                type="google_drive",
+                config={
+                    "drive_id": "<drive-id>",
+                    "service_account_key": "<service-account-key>",
+                    "extensions": [
                         "<extension>",
                         "<extension>"
                     ],
-                    recursive=<True|False>
-                )
+                    "recursive": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/jira_sdk.mdx
+++ b/snippets/source_connectors/jira_sdk.mdx
@@ -3,47 +3,43 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    JiraSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.JIRA,
-                config=JiraSourceConnectorConfigInput(
-                    url="<url>",
+                type="jira",
+                config={
+                    "url": "<url>",
 
                     # For password or API token authentication:
-                    username="<username>",
-                    password="<password">,
+                    # "username": "<username>",
+                    # "password": "<password>",
 
                     # For personal access token authentication:
-                    token="<token>",
-        
-                    projects=[ 
+                    # "token": "<token>",
+
+                    "projects": [
                         "<project-id>",
                         "<project-id>"
                     ],
-                    boards=[ 
+                    "boards": [
                         "<board-id>",
                         "<board-id>"
                     ],
-                    issues=[ 
+                    "issues": [
                         "<issue-id>",
                         "<issue-id>"
                     ],
-                    status_filters=[
+                    "status_filters": [
                         "<status>",
                         "<status>"
                     ],
-                    download_attachments=<True|False>,
-                    cloud=<True|False>
-                )
+                    "download_attachments": <True|False>,
+                    "cloud": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/kafka_sdk.mdx
+++ b/snippets/source_connectors/kafka_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    KafkaCloudSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.KAFKA_CLOUD,
-                config=KafkaCloudSourceConnectorConfigInput(
-                    bootstrap_servers="<bootstrap-server>",
-                    port=<port>,
-                    group_id="<group-id>",
-                    kafka_api_key="<kafka-api-key>",
-                    secret="<secret>",
-                    topic="<topic>",
-                    num_message_to_consume=<num-message-to-consume>,
-                )
+                type="kafka-cloud",
+                config={
+                    "bootstrap_servers": "<bootstrap-server>",
+                    "port": <port>,
+                    "group_id": "<group-id>",
+                    "kafka_api_key": "<kafka-api-key>",
+                    "secret": "<secret>",
+                    "topic": "<topic>",
+                    "num_message_to_consume": <num-message-to-consume>
+                }
             )
         )
     )

--- a/snippets/source_connectors/mongodb_sdk.mdx
+++ b/snippets/source_connectors/mongodb_sdk.mdx
@@ -3,23 +3,19 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    MongoDBConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.MONGODB,
-                config=MongoDBConnectorConfigInput(
-                    uri="<uri>",
-                    database="<database>",
-                    collection="<collection>"
-                )
+                type="mongodb",
+                config={
+                    "uri": "<uri>",
+                    "database": "<database>",
+                    "collection": "<collection>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/onedrive_sdk.mdx
+++ b/snippets/source_connectors/onedrive_sdk.mdx
@@ -3,28 +3,24 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    OneDriveSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.ONEDRIVE,
-                config=OneDriveSourceConnectorConfigInput(
-                    client_id="<client-id>", 
-                    user_pname="<user-pname>",
-                    password="<password>", # For username and password authentication.
-                    tenant="<tenant>", 
-                    authority_url="<authority-url>",
-                    client_cred="<client-cred>",
-                    path="<path>",
-                    recursive=<True|False>
-                )
+                type="onedrive",
+                config={
+                    "client_id": "<client-id>",
+                    "user_pname": "<user-pname>",
+                    "password": "<password>", # For username and password authentication.
+                    "tenant": "<tenant>",
+                    "authority_url": "<authority-url>",
+                    "client_cred": "<client-cred>",
+                    "path": "<path>",
+                    "recursive": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/outlook_sdk.mdx
+++ b/snippets/source_connectors/outlook_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    OutlookSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.OUTLOOK,
-                config=OutlookSourceConnectorConfigInput(
-                    client_id="<client-id>",
-                    authority_url="<authority-url>",
-                    tenant="<tenant>",
-                    client_cred="<client-cred>",
-                    user_email="<user-email>",
-                    outlook_folders=["<folder-name>","<folder-name>"],
-                    recursive=<True|False>
-                )
+                type="outlook",
+                config={
+                    "client_id": "<client-id>",
+                    "authority_url": "<authority-url>",
+                    "tenant": "<tenant>",
+                    "client_cred": "<client-cred>",
+                    "user_email": "<user-email>",
+                    "outlook_folders": ["<folder-name>", "<folder-name>"],
+                    "recursive": <True|False>
+                }
             )
         )
     )

--- a/snippets/source_connectors/postgresql_sdk.mdx
+++ b/snippets/source_connectors/postgresql_sdk.mdx
@@ -3,32 +3,28 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    PostgresSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.POSTGRES,
-                config=PostgresSourceConnectorConfigInput(
-                    host="<host>",
-                    database="<database>",
-                    port="<port>",
-                    username="<username>",
-                    password="<password>",
-                    table_name="<table_name>",
-                    batch_size=<batch-size>,
-                    id_column="<id-column>",
-                    fields=[
+                type="postgres",
+                config={
+                    "host": "<host>",
+                    "database": "<database>",
+                    "port": <port>,
+                    "username": "<username>",
+                    "password": "<password>",
+                    "table_name": "<table_name>",
+                    "batch_size": <batch-size>,
+                    "id_column": "<id-column>",
+                    "fields": [
                         "<field>",
                         "<field>"
                     ]
-                )
+                }
             )
         )
     )

--- a/snippets/source_connectors/s3_sdk.mdx
+++ b/snippets/source_connectors/s3_sdk.mdx
@@ -3,35 +3,31 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    S3SourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.S3,
-                config=S3SourceConnectorConfigInput(
+                type="s3",
+                config={
                     # For anonymous authentication:
-                    anonymous=True,
+                    # "anonymous": True,
 
                     # For AWS access key ID with AWS secret access key authentication:
-                    key="<key>", 
-                    secret="<secret>", 
+                    # "key": "<key>",
+                    # "secret": "<secret>",
 
                     # For AWS STS token authentication:
-                    token="<token>", 
-                    key="<key>", 
-                    secret="<secret>", 
+                    # "token": "<token>",
+                    # "key": "<key>",
+                    # "secret": "<secret>",
 
-                    remote_url="<remote_url>",
-                    endpoint_url="<endpoint-url>", 
-                    recursive=<True|False>
-                )
+                    "remote_url": "<remote_url>",
+                    "endpoint_url": "<endpoint-url>",
+                    "recursive": <True|False>  # Boolean: True or False, no quotes
+                }
             )
         )
     )

--- a/snippets/source_connectors/salesforce_sdk.mdx
+++ b/snippets/source_connectors/salesforce_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    SalesforceSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.SALESFORCE,
-                config=SalesforceSourceConnectorConfigInput( 
-                    username="<user-name>",
-                    consumer_key="<consumer-key>",
-                    private_key="<private-key>",
-                    categories=[
+                type="salesforce",
+                config={
+                    "username": "<user-name>",
+                    "consumer_key": "<consumer-key>",
+                    "private_key": "<private-key>",
+                    "categories": [
                         "<category>",
                         "<category>"
                     ]
-                )
+                }
             )
         )
     )

--- a/snippets/source_connectors/sharepoint_sdk.mdx
+++ b/snippets/source_connectors/sharepoint_sdk.mdx
@@ -3,30 +3,26 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    SharePointSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.SHAREPOINT,
-                config=SharePointSourceConnectorConfigInput(
-                    site="<site>",
-                    library="<library>",
-                    path="<path>",
-                    recursive=<True|False>,
-                    client_id="<client_id>",
-                    tenant="<tenant>",
-                    authority_url="<authority_url>",
-                    client_cred="<client_cred>",
-                    user_pname="<user_pname>", # For username and password authentication.
-                    password="<password>" # For username and password authentication.   
-                )
+                type="sharepoint",
+                config={
+                    "site": "<site>",
+                    "library": "<library>",
+                    "path": "<path>",
+                    "recursive": <True|False>,
+                    "client_id": "<client_id>",
+                    "tenant": "<tenant>",
+                    "authority_url": "<authority_url>",
+                    "client_cred": "<client_cred>",
+                    "user_pname": "<user_pname>", # For username and password authentication.
+                    "password": "<password>" # For username and password authentication.
+                }
             )
         )
     )

--- a/snippets/source_connectors/slack_sdk.mdx
+++ b/snippets/source_connectors/slack_sdk.mdx
@@ -3,27 +3,23 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    SlackSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.SLACK,
-                config=SlackSourceConnectorConfigInput(
-                    channels=[
+                type="slack",
+                config={
+                    "channels": [
                         "<channel>",
                         "<channel>"
                     ],
-                    start_date="<start-date>",
-                    end_date="<end-date>",
-                    token="<token>"
-                )
+                    "start_date": "<start-date>",
+                    "end_date": "<end-date>",
+                    "token": "<token>"
+                }
             )
         )
     )

--- a/snippets/source_connectors/snowflake_sdk.mdx
+++ b/snippets/source_connectors/snowflake_sdk.mdx
@@ -3,35 +3,31 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    SnowflakeSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.SNOWFLAKE,
-                config=SnowflakeSourceConnectorConfigInput(
-                    account="<account>",
-                    role="<role>",
-                    user="<user>",
-                    password="<password>",
-                    host="<host",
-                    port=<port>
-                    database="<database>",
-                    schema_="<schema>",
-                    table_name="<table_name>",
-                    id_column="<id-column>",
-                    fields=[
-                        "<field>", 
+                type="snowflake",
+                config={
+                    "account": "<account>",
+                    "role": "<role>",
+                    "user": "<user>",
+                    "password": "<password>",
+                    "host": "<host>",
+                    "port": <port>,
+                    "database": "<database>",
+                    "schema_": "<schema>",
+                    "table_name": "<table_name>",
+                    "id_column": "<id-column>",
+                    "fields": [
+                        "<field>",
                         "<field>"
                     ],
-                    batch_size=<batch-size> 
-                )
+                    "batch_size": <batch-size> 
+                }
             )
         )
     )

--- a/snippets/source_connectors/zendesk_sdk.mdx
+++ b/snippets/source_connectors/zendesk_sdk.mdx
@@ -3,28 +3,25 @@ import os
 
 from unstructured_client import UnstructuredClient
 from unstructured_client.models.operations import CreateSourceRequest
-from unstructured_client.models.shared import (
-    CreateSourceConnector,
-    SourceConnectorType,
-    ZendeskSourceConnectorConfigInput
-)
+from unstructured_client.models.shared import CreateSourceConnector
 
 with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as client:
     response = client.sources.create_source(
         request=CreateSourceRequest(
             create_source_connector=CreateSourceConnector(
                 name="<name>",
-                type=SourceConnectorType.ZENDESK,
-                config=ZendeskSourceConnectorConfigInput(
-                    subdomain="<subdomain>",
-                    email="<email>",
-                    api_token="<api-token>",
-                    item_type="<item-type>",
-                    batch_size=<batch-size> 
-                )
+                type="zendesk",
+                config={
+                    "subdomain": "<subdomain>",
+                    "email": "<email>",
+                    "api_token": "<api-token>",
+                    "item_type": "<item-type>",
+                    "batch_size": <batch-size>
+                }
             )
         )
     )
 
     print(response.source_connector_information)
+
 ```


### PR DESCRIPTION
See "Files changed" tab for all code changes.