### PR TITLE
Confluence source connector: specify space keys, not space names

### DIFF
--- a/snippets/general-shared-text/confluence-api-placeholders.mdx
+++ b/snippets/general-shared-text/confluence-api-placeholders.mdx
@@ -2,7 +2,7 @@
 - `<url>` (_required_) - The URL to the target Confluence Cloud instance.
 - `<max-num-of-spaces>` - The maximum number of Confluence spaces to access within the Confluence Cloud instance. The default is `500` unless otherwise specified.
 - `<max-num-of-docs-from-each-space>` - The maximum number of documents to access within each space. The default is `150` unless otherwise specified.
-- `spaces` is an array of strings, with each `<space-name>` specifying the name of a space to access, for example: `["luke","paul"]`. By default, if no space names are specified, and the `<max-num-of-spaces>` is exceeded for the instance, be aware that you might get unexpected results.
+- `spaces` is an array of strings, with each `<space-key>` specifying the key (not display name) of a space to access, for example: `["luke","paul"]`. By default, if no space keys are specified, and the `<max-num-of-spaces>` is exceeded for the instance, be aware that you might get unexpected results.
 - `extract_images` - Set to `true` to download images and replace the HTML content with Base64-encoded images. The default is `false` if not otherwise specified.
 - `extract_files` - Set to `true` to download any embedded files in pages. The default is `false` if not otherwise specified.
 

--- a/snippets/general-shared-text/confluence-cli-api.mdx
+++ b/snippets/general-shared-text/confluence-cli-api.mdx
@@ -19,7 +19,7 @@ The following environment variables:
 
 Additional settings include:
 
-- `--spaces` (CLI) or `spaces` (Python): Optionally, the list of the names of the specific spaces to access, expressed as a comma-separated list of strings (CLI) or an array of strings (Python), with each string representing a space's name. The default is no specific spaces, if not otherwise specified.
+- `--spaces` (CLI) or `spaces` (Python): Optionally, the list of the keys (not display names) of the specific spaces to access, expressed as a comma-separated list of strings (CLI) or an array of strings (Python), with each string representing a space's key (not display name). The default is no specific spaces, if not otherwise specified.
 - `--max-num-of-spaces` (CLI) or `max_num_of_spaces` (Python): Optionally, the maximum number of spaces to access, expressed as an integer. The default value is `500` if not otherwise specified.
 - `--max-num-of-docs-from-each-space` (CLI) or `max_num_of_docs_from_each_space` (Python): Optionally, the maximum number of documents to access from each space, expressed as an integer. The default value is `100` if not otherwise specified.
 - `--cloud` or `--no-cloud` (CLI) or `cloud` (Python): Optionally, whether to use Confluence Cloud (`--cloud` for CLI or `cloud=True` for Python). The default is `--no-cloud` (CLI) or `cloud=False` (Python) if not otherwise specified.

--- a/snippets/general-shared-text/confluence-platform.mdx
+++ b/snippets/general-shared-text/confluence-platform.mdx
@@ -10,8 +10,8 @@ Fill in the following fields:
   The default is 500 unless otherwise specified.
 - **Max number of docs per space**: The maximum number of documents to access within each space. 
   The default is 150 unless otherwise specified.
-- **List of spaces**: A comma-separated string that lists the names of all of the spaces to access, for example: `luke,paul`. 
-  By default, if no space names are specified, and the **Max Number of Spaces** is reached for the instance, be aware that you might get 
+- **List of spaces**: A comma-separated string that lists the keys (not display names) of all of the spaces to access, for example: `luke,paul`. 
+  By default, if no space keys are specified, and the **Max Number of Spaces** is reached for the instance, be aware that you might get 
   unexpected results.
 - **Extract inline images**: Check this box to download images and replace the HTML content with Base64-encoded images. By default, this box is unchecked.
 - **Extract files**: Check this box to download any embedded files in pages. By default, this box is unchecked.

--- a/snippets/general-shared-text/confluence.mdx
+++ b/snippets/general-shared-text/confluence.mdx
@@ -18,7 +18,8 @@
   - For Confluence Data Center only, the target user's personal access token (PAT). 
     [Create a PAT](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html).
 
-- Optionally, the names of the specific [spaces](https://support.atlassian.com/confluence-cloud/docs/navigate-spaces/) in the Confluence instance to access.
+- Optionally, the keys (not display names) of the specific [spaces](https://support.atlassian.com/confluence-cloud/docs/navigate-spaces/) in the Confluence instance to access. To get a space's key, 
+  which is different from a space's display name, open the space in your web browser and look at the URL. The space's key is the part of the URL after `spaces/` but before the next `/` after that.
 
 The following video provides related setup information for Confluence Cloud:
 

--- a/snippets/general-shared-text/confluence.mdx
+++ b/snippets/general-shared-text/confluence.mdx
@@ -26,7 +26,7 @@ The following video provides related setup information for Confluence Cloud:
 <iframe
 width="560"
 height="315"
-src="https://www.youtube.com/embed/tXu6S6Pd7Dc"
+src="https://www.youtube.com/embed/3PsFJkcIotI"
 title="YouTube video player"
 frameborder="0"
 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/snippets/source_connectors/confluence.sh.mdx
+++ b/snippets/source_connectors/confluence.sh.mdx
@@ -8,7 +8,7 @@ unstructured-ingest \
     --url $CONFLUENCE_URL \
     --username $CONFLUENCE_USERNAME \
     --cloud \
-    --spaces luke,paul \
+    --spaces <space-key>,<space-key> \
     --max-num-of-spaces 500 \
     --max-num-of-docs-from-each-space 150 \
     --extract-images \
@@ -26,7 +26,7 @@ unstructured-ingest \
   confluence \
     --token $CONFLUENCE_PERSONAL_ACCESS_TOKEN \
     --url $CONFLUENCE_URL \
-    --spaces luke,paul \
+    --spaces <space-key>,<space-key> \
     --max-num-of-spaces 500 \
     --max-num-of-docs-from-each-space 150 \
     --extract-images \

--- a/snippets/source_connectors/confluence.v2.py.mdx
+++ b/snippets/source_connectors/confluence.v2.py.mdx
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     Pipeline.from_configs(
         context=ProcessorConfig(),
         indexer_config=ConfluenceIndexerConfig(
-            spaces=["luke", "paul"],
+            spaces=["<space-key>", "<space-key>"],
             max_num_of_spaces=500,
             max_num_of_docs_from_each_space=150
         ),

--- a/snippets/source_connectors/confluence_rest_create.mdx
+++ b/snippets/source_connectors/confluence_rest_create.mdx
@@ -12,7 +12,7 @@ curl --request 'POST' --location \
         "url": "<url>",
         "max_num_of_spaces": <max-num-of-spaces>,
         "max_num_of_docs_from_each_space": <max-num-of-docs-from-each-space>,
-        "spaces": ["<space-name>", "<space-name>"],
+        "spaces": ["<space-key>", "<space-key>"],
         "extract_images": "<true|false>",
         "extract_files": "<true|false>",
 

--- a/snippets/source_connectors/confluence_sdk.mdx
+++ b/snippets/source_connectors/confluence_sdk.mdx
@@ -15,7 +15,7 @@ with UnstructuredClient(api_key_auth=os.getenv("UNSTRUCTURED_API_KEY")) as clien
                     "url": "<url>",
                     "max_num_of_spaces": <max-num-of-spaces>,
                     "max_num_of_docs_from_each_space": <max-num-of-docs-from-each-space>,
-                    "spaces": ["<space-name>", "<space-name>"],
+                    "spaces": ["<space-key>", "<space-key>"],
                     "extract_images": <True|False>,
                     "extract_files": <True|False>,
 


### PR DESCRIPTION
The connector uses space keys, not space names. Space keys must be unique across a Confluence instance. Space names should also be unique--but this is not strictly required. 

See coverage of space keys in:

- https://unstructured-53-confluence-2025-08-21.mintlify.app/ui/sources/confluence
- https://unstructured-53-confluence-2025-08-21.mintlify.app/ui/sources/confluence
- https://unstructured-53-confluence-2025-08-21.mintlify.app/open-source/ingestion/source-connectors/confluence 

