### PR TITLE
RBAC: Expand Operator role permissions

### DIFF
--- a/ui/account/organizations.mdx
+++ b/ui/account/organizations.mdx
@@ -157,7 +157,7 @@ sales representative, or email Unstructured Sales at [sales@unstructured.io](mai
 ## Add a member to an organizational account
 
 <Info>
-    Your user must have the **Super Admin** [role](/ui/account/roles) in the organizational account to add members to that organizational account.
+    Your user must have the **Super Administrator** [role](/ui/account/roles) in the organizational account to add members to that organizational account.
 </Info>
 
 To add a user to an organizational account as a member:
@@ -175,7 +175,7 @@ To add a user to an organizational account as a member:
 ## Change an organizational account role for a member
 
 <Info>
-    Your user must have the **Super Admin** role in the organizational account to change its members' organizational account roles.
+    Your user must have the **Super Administrator** role in the organizational account to change its members' organizational account roles.
 </Info>
 
 1. Sign in to your Unstructured account.
@@ -201,7 +201,7 @@ To add a user to an organizational account as a member:
 </Warning>
 
 <Info>
-    Your user must have the **Super Admin** [role](/ui/account/roles) in the organizational account to remove members from that organizational account.
+    Your user must have the **Super Administrator** [role](/ui/account/roles) in the organizational account to remove members from that organizational account.
 </Info>
 
 1. Sign in to your Unstructured account.

--- a/ui/account/roles.mdx
+++ b/ui/account/roles.mdx
@@ -13,25 +13,25 @@ sidebarTitle: Roles
 _Roles_ in Unstructured are part of the _role-based access control_ (RBAC) system that manages permissions for members of 
 organizational accounts and their workspaces. (Roles are not used in personal accounts.)
 
-Any member with the **Super Admin** role in an organizational account can manage the roles of that organizational account's members and the roles of the 
+Any member with the **Super Administrator** role in an organizational account can manage the roles of that organizational account's members and the roles of the 
 members of the organizational account's workspaces. 
 
-Any member with the **Super Admin** role in an organizational account or the **Workspace Admin** role in a workspace within an 
+Any member with the **Super Administrator** role in an organizational account or the **Workspace Admin** role in a workspace within an 
 organizational account can mange the roles of that workspace's members.
 
-A **Super Admin** member assigns an organizational account member's initial role when they are [added to the organizational account](/ui/account/organizations#add-a-member-to-an-organizational-account). This member's 
+A **Super Administrator** member assigns an organizational account member's initial role when they are [added to the organizational account](/ui/account/organizations#add-a-member-to-an-organizational-account). This member's 
 initial role can be [changed](/ui/account/organizations#change-an-organizational-account-role-for-a-member) later.
 
-A **Super Admin** or **Workspace Admin** member assigns a workspace member's initial role when they are [added to the workspace](/ui/account/workspaces#add-a-member-to-a-workspace). This 
+A **Super Administrator** or **Workspace Admin** member assigns a workspace member's initial role when they are [added to the workspace](/ui/account/workspaces#add-a-member-to-a-workspace). This 
 member's initial role can be [changed](/ui/account/workspaces#change-a-workspace-role-for-a-member) later.
 
 ## Organizational account roles 
 
 Organizational account roles include:
 
-- Super Administrator
-- Account Member
-- Billing Administrator
+- **Super Administrator**: Has access to all permissions, and has access to all resources created in an organization.
+- **Account Member**: Able to be added to workspaces with a workspace role.
+- **Billing Administrator**: Only able to view billing information and usage. Is able to allocate budget across multiple workspaces.
 
 These roles include the following permissions:
 
@@ -59,21 +59,25 @@ These roles include the following permissions:
 
 Workspace roles include:
 
-- Viewer
-- Developer
-- Operator
-- Workspace administrators
+- **Viewer**: Ability to view all connectors and workflows that exist in the workspace in a read-only capacity.
+- **Operator**: Ability to create, run, schedule, and delete any workflows that exist in the workspace. 
+  Can view connectors but cannot create or edit them.
+- **Developer**: Ability to create and edit all connectors and workflows that exist in the workspace.
+- **Workspace Administrator**: Ability to manage users on the workspace (invite, remove or change roles) as well as edit the workspace.
 
 These roles include the following permissions:
 
 | Resource | Action | Viewer | Operator | Developer | Workspace Administrator |
 |---|---|---|---|---|---|
 | Workflows | Read | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
-| | Create | <span class="no-label">No</span> | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
-| | Edit | <span class="no-label">No</span> | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
-| | Delete | <span class="no-label">No</span> | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | 
+| | Create | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
+| | Edit | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
+| | Delete | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | 
 | | Run | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | 
 | | Schedule | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | 
+| | Save | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
+| | Duplicate | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
+| | Activate and deactivate | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
 | Connectors | Read | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
 | | Create | <span class="no-label">No</span> | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |
 | | Edit | <span class="no-label">No</span> | <span class="no-label">No</span> | <span class="yes-label">Yes</span> | <span class="yes-label">Yes</span> |

--- a/ui/account/workspaces.mdx
+++ b/ui/account/workspaces.mdx
@@ -104,7 +104,7 @@ contact your Unstructured
 sales representative, or email Unstructured Sales at [sales@unstructured.io](mailto:sales@unstructured.io).
 
 <Info>
-    Your user must have the **Super Admin** [role](/ui/account/roles) in the intended workspace's parent organizational account to create workspaces in that organizational account.
+    Your user must have the **Super Administrator** [role](/ui/account/roles) in the intended workspace's parent organizational account to create workspaces in that organizational account.
 
     (A user always has one and only one personal workspace within their personal account. You cannot create additional workspaces in personal accounts.)
 </Info>
@@ -137,7 +137,7 @@ sales representative, or email Unstructured Sales at [sales@unstructured.io](mai
 ## Add a member to a workspace
 
 <Info>
-    Your user must have either the **Super Admin** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** role in the 
+    Your user must have either the **Super Administrator** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** role in the 
     workspace to add members to that workspace.
 
     The user to be added must also have the **Developer** role in the workspace's parent organizational account.
@@ -163,7 +163,7 @@ To add a user to a workspace as a member:
 ## Change a workspace role for a member
 
 <Info>
-    Your user must have either the **Super Admin** role in the workspace's parent organizational account or the **Workspace Admin** role in the 
+    Your user must have either the **Super Administrator** role in the workspace's parent organizational account or the **Workspace Admin** role in the 
     workspace to change the roles for that workspace's members.
 </Info>
 
@@ -189,7 +189,7 @@ To add a user to a workspace as a member:
 </Warning>
 
 <Info>
-    Your user must have either the **Super Admin** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** role in the 
+    Your user must have either the **Super Administrator** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** role in the 
     workspace to remove members from that workspace.
 
     (A user cannot be removed from their personal workspace within their personal account.)
@@ -208,7 +208,7 @@ To add a user to a workspace as a member:
 ## Create an API key for a workspace
 
 <Info>
-    Your user must have either the **Super Admin** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** or **Developer** role in the 
+    Your user must have either the **Super Administrator** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** or **Developer** role in the 
     workspace to create API keys for that workspace.
 </Info>
 
@@ -238,7 +238,7 @@ An API key is valid only for the workspace for which it was created.
 </Warning>
 
 <Info>
-    Your user must have either the **Super Admin** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** or **Developer** role in the 
+    Your user must have either the **Super Administrator** [role](/ui/account/roles) in the workspace's parent organizational account or the **Workspace Admin** or **Developer** role in the 
     workspace to delete API keys from that workspace.
 </Info>
 


### PR DESCRIPTION
- For the **Operator** role, changed **No** to **Yes** for Worfkows -> Create, Edit, and Delete.
- Added a new permission set Workflow -> Save; setting to **Viewer** = **No** , **Operator** = **Yes**, **Developer** = **Yes**, and **Workspace Administrator** =  **Yes**
- Added a new permission set Workflow -> Duplicate; setting to **Viewer** = **No** , **Operator** = **Yes**, **Developer** = **Yes**, and **Workspace Administrator** =  **Yes**
- Added a new permission set Workflow -> Activate and deactivate; setting to **Viewer** = **No** , **Operator** = **Yes**, **Developer** = **Yes**, and **Workspace Administrator** =  **Yes**

Also:

- Copied the role descriptions out of the UI into the docs where those roles and listed.
- Updated **Super Admin** to **Super Administrator** throughout as appropriate to match the UI.

See 