### PR TITLE
Site header and footer updates: try Unstructured for free; more social links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -598,14 +598,22 @@
   },
   "navbar": {
     "primary": {
-      "type": "github",
-      "href": "https://github.com/Unstructured-IO/unstructured"
+      "type": "button",
+      "label": "Try Unstructured for free",
+      "href": "https://unstructured.io/?modal=try-for-free"
     }
   },
   "footer": {
     "socials": {
-      "twitter": "https://twitter.com/UnstructuredIO?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor",
-      "linkedin": "https://www.linkedin.com/company/unstructuredio/"
+      "website": "https://unstructured.io/",
+      "youtube": "https://www.youtube.com/@UnstructuredIO",
+      "slack": "https://short.unstructured.io/pzw05l7",
+      "x": "https://x.com/UnstructuredIO",
+      "twitter": "https://twitter.com/UnstructuredIO",
+      "linkedin": "https://www.linkedin.com/company/unstructuredio/",
+      "reddit": "https://www.reddit.com/r/UnstructuredIO/",
+      "github": "https://github.com/Unstructured-IO/",
+      "instagram": "https://www.instagram.com/unstructuredio/"
     }
   },
   "integrations": {


### PR DESCRIPTION
Added the "Try Unstructured for free" button in the header:

<img width="233" height="47" alt="Screenshot 2025-08-29 at 4 45 25 PM" src="https://github.com/user-attachments/assets/50be485d-8886-429a-8a7e-3f0800df16ce" />

Expanded the list of clickable social links in the footer:

<img width="396" height="50" alt="Screenshot 2025-08-29 at 4 45 36 PM" src="https://github.com/user-attachments/assets/c151d8ea-53ab-43df-88d8-7d28eda089d6" />
