### PR TITLE
Updates to Milvus and IBM watsonx.data connectors

### DIFF
--- a/snippets/general-shared-text/ibm-watsonxdata.mdx
+++ b/snippets/general-shared-text/ibm-watsonxdata.mdx
@@ -137,7 +137,7 @@
        a. Check the box labelled **Associate Catalog**.<br/>
        b. For **Catalog type**, select **Apache Iceberg**.<br/>
        c. Enter some **Catalog name**.<br/>
-       b. Click **Associate**.<br/>
+       d. Click **Associate**.<br/>
 
   10. On the sidebar, click **Infrastructure manager**. Make sure the catalog is associated with the appropriate engines. If it is not, rest your mouse 
       on an unassociated target engine, click the **Manage associations** icon, check the box next to the target catalog's name, and then 

--- a/snippets/general-shared-text/ibm-watsonxdata.mdx
+++ b/snippets/general-shared-text/ibm-watsonxdata.mdx
@@ -122,7 +122,7 @@
        a. Check the box labelled **Associate Catalog**.<br/>
        b. For **Catalog type**, select **Apache Iceberg**.<br/>
        c. Enter some **Catalog name**.<br/>
-       b. Click **Associate**.<br/>
+       d. Click **Associate**.<br/>
 
      If you select **Register my own**, you must provide the following settings:
 

--- a/snippets/general-shared-text/milvus.mdx
+++ b/snippets/general-shared-text/milvus.mdx
@@ -37,17 +37,22 @@ The following video shows how to fulfill the minimum set of requirements for Mil
   - The name of the [database](https://docs.zilliz.com/docs/database#create-database) in the instance.
   - The name of the [collection](https://docs.zilliz.com/docs/manage-collections-console#create-collection) in the database.
 
-    The collection must have a a defined schema before Unstructured can write to the collection. The minimum viable 
-    schema for Unstructured contains only the fields `element_id`, `embeddings`, and `record_id`, as follows:
+    The collection must have a defined schema before Unstructured can write to the collection. The minimum viable 
+    schema for Unstructured contains only the fields `element_id`, `embeddings`, `record_id`, and `text`, as follows:
 
     | Field Name | Field Type | Max Length | Dimension |
     |---|---|---|---|
     | `element_id` (primary key field) | **VARCHAR** | `200` | -- |
-    | `embeddings` (vector field) | **FLOAT_VECTOR** | -- | `3072` |
+    | `embeddings` (vector field) | **FLOAT_VECTOR** | -- | `384` |
     | `record_id` | **VARCHAR** | `200` | -- |
+    | `text` | **VARCHAR** | `65536` | -- |
 
     In the **Create Index** area for the collection, next to **Vector Fields**, click **Edit Index**. Make sure that for the 
     `embeddings` field, the **Field Type** is set to **FLOAT_VECTOR** and the **Metric Type** is set to **Cosine**.
+
+    <Warning>
+        The number of dimensions for the `embeddings` field must match the number of dimensions for the embedding model that you plan to use.
+    </Warning>
 
 - For Milvus on IBM watsonx.data, you will need:
 
@@ -69,7 +74,7 @@ The following video shows how to fulfill the minimum set of requirements for Mil
     [Get the instance's GRPC host and GRPC port](https://cloud.ibm.com/docs/watsonxdata?topic=watsonxdata-conn-to-milvus).
   - The name of the [database](https://milvus.io/docs/manage_databases.md) in the instance.
   - The name of the [collection](https://milvus.io/docs/manage-collections.md) in the database. Note the collection requirements at the end of this section.
-  - The uername and password to access the instance. 
+  - The username and password to access the instance. 
     The username for Milvus on IBM watsonx.data is always `ibmlhapikey`. 
     The password for Milvus on IBM watsonx.data is in the form of an IBM Cloud user API key. 
     [Get the user API key](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui).
@@ -84,74 +89,94 @@ The following video shows how to fulfill the minimum set of requirements for Mil
   - The [username and password, or token](https://milvus.io/docs/authenticate.md) to access the instance.
 
 All Milvus instances require the target collection to have a defined schema before Unstructured can write to the collection. The minimum viable 
-schema for Unstructured contains only the fields `element_id`, `embeddings`, and `record_id`, as follows. Adding a `text` field is optional but highly recommended.This example code demonstrates the use of the 
+schema for Unstructured contains only the fields `element_id`, `embeddings`, `record_id`, and `text`, as follows. This example code demonstrates the use of the 
 [Python SDK for Milvus](https://pypi.org/project/pymilvus/) to create a collection with this schema, 
-targeting Milvus on IBM watsonx.data. For the `connections.connect` arguments to connect to other types of Milvus deployments, see your Milvus provider's documentation:
+targeting Milvus on IBM watsonx.data. For the `MilvusClient` arguments to connect to other types of Milvus deployments, see your Milvus provider's documentation:
 
 ```python Python
 import os
+
 from pymilvus import (
-    connections,
+    MilvusClient,
     FieldSchema,
     DataType,
-    CollectionSchema,
-    Collection,
+    CollectionSchema
 )
 
-connections.connect(
-    alias="default",
-    host=os.getenv("MILVUS_GRPC_HOST"),
-    port=os.getenv("MILVUS_GRPC_PORT"),
-    user=os.getenv("MILVUS_USER"),
-    password=os.getenv("MILVUS_PASSWORD"),
-    secure=True
+DATABASE_NAME   = "default"
+COLLECTION_NAME = "my_collection"
+
+client = MilvusClient(
+    uri="https://" +
+        os.getenv("MILVUS_USER") + 
+        ":" + 
+        os.getenv("MILVUS_PASSWORD") + 
+        "@" + 
+        os.getenv("MILVUS_GRPC_HOST") + 
+        ":" + 
+        os.getenv("MILVUS_GRPC_PORT"),
+    db_name=DATABASE_NAME
 )
 
-primary_key = FieldSchema(
+primary_key_field = FieldSchema(
     name="element_id",
     dtype=DataType.VARCHAR,
     is_primary=True,
     max_length=200
 )
 
-vector = FieldSchema(
+# IMPORTANT: The number of dimensions for the "embeddings" field
+# must match the number of dimensions for the embedding model 
+# that you plan to use.
+embeddings_field = FieldSchema(
     name="embeddings",
     dtype=DataType.FLOAT_VECTOR,
-    dim=3072
+    dim=384
 )
 
-record_id = FieldSchema(
+record_id_field = FieldSchema(
     name="record_id",
     dtype=DataType.VARCHAR,
     max_length=200
 )
 
-text = FieldSchema(
+text_field = FieldSchema(
     name="text",
     dtype=DataType.VARCHAR,
-    max_length=65536
+    max_length=65535
 )
 
 schema = CollectionSchema(
-    fields=[primary_key, vector, record_id, text],
-    enable_dynamic_field=True
+    fields=[
+        primary_key_field, 
+        embeddings_field,
+        record_id_field, 
+        text_field
+    ]
 )
 
-collection = Collection(
-    name="my_collection",
+client.create_collection(
+    collection_name=COLLECTION_NAME",
     schema=schema,
-    using="default"
+    using=DATABASE_NAME
 )
 
-index_params = {
-    "metric_type": "L2",
-    "index_type": "IVF_FLAT",
-    "params": {"nlist": 1024}
-}
+index_params = client.prepare_index_params()
 
-collection.create_index(
+index_params.add_index(
     field_name="embeddings",
+    metric_type="COSINE",
+    index_type="IVF_FLAT",
+    params={"nlist": 1024}
+)
+
+client.create_index(
+    collection_name=COLLECTION_NAME,
     index_params=index_params
+)
+
+client.load_collection(
+    collection_name=COLLECTION_NAME
 )
 ```
 


### PR DESCRIPTION
- Fix lead-in lettering for sublists. 
- Change default embedding dimensions to match those offered by IBM, and add a note that dimensions need to match with your chosen model.
- Update the default schema to include the missing `text` field. 
- Update the collection creation code snippet to use `client` methods as recommended instead of `connection` methods, as well as the recommended approach to build the index separately. 