### PR TITLE
Remove 'recently updated' banner from all pages

### DIFF
--- a/open-source/ingestion/destination-connectors/astradb.mdx
+++ b/open-source/ingestion/destination-connectors/astradb.mdx
@@ -2,9 +2,7 @@
 title: Astra DB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
 
-<NewDocument />
 
 import SharedAstraDB from '/snippets/dc-shared-text/astradb-cli-api.mdx';
 

--- a/open-source/ingestion/destination-connectors/azure-ai-search.mdx
+++ b/open-source/ingestion/destination-connectors/azure-ai-search.mdx
@@ -2,10 +2,6 @@
 title: Azure AI Search
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedAzureAIS from '/snippets/dc-shared-text/azure-ai-search-cli-api.mdx';
 
 <SharedAzureAIS />

--- a/open-source/ingestion/destination-connectors/azure.mdx
+++ b/open-source/ingestion/destination-connectors/azure.mdx
@@ -2,10 +2,6 @@
 title: Azure
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedAzure from '/snippets/dc-shared-text/azure-cli-api.mdx';
 
 <SharedAzure />

--- a/open-source/ingestion/destination-connectors/box.mdx
+++ b/open-source/ingestion/destination-connectors/box.mdx
@@ -2,10 +2,6 @@
 title: Box
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedBox from '/snippets/dc-shared-text/box-cli-api.mdx';
 
 <SharedBox />

--- a/open-source/ingestion/destination-connectors/chroma.mdx
+++ b/open-source/ingestion/destination-connectors/chroma.mdx
@@ -2,10 +2,6 @@
 title: Chroma
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedChroma from '/snippets/dc-shared-text/chroma-cli-api.mdx';
 
 <SharedChroma />

--- a/open-source/ingestion/destination-connectors/couchbase.mdx
+++ b/open-source/ingestion/destination-connectors/couchbase.mdx
@@ -2,10 +2,6 @@
 title: Couchbase
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedCouchbase from '/snippets/dc-shared-text/couchbase-cli-api.mdx';
 
 <SharedCouchbase />

--- a/open-source/ingestion/destination-connectors/databricks-delta-table.mdx
+++ b/open-source/ingestion/destination-connectors/databricks-delta-table.mdx
@@ -12,10 +12,6 @@ title: Delta Tables in Databricks
     [Databricks Volumes](/open-source/ingestion/destination-connectors/databricks-volumes).
 </Note>
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedDatabricksDeltaTable from '/snippets/dc-shared-text/databricks-delta-table-cli-api.mdx';
 
 <SharedDatabricksDeltaTable />

--- a/open-source/ingestion/destination-connectors/dropbox.mdx
+++ b/open-source/ingestion/destination-connectors/dropbox.mdx
@@ -2,10 +2,6 @@
 title: Dropbox
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedDropbox from '/snippets/dc-shared-text/dropbox-cli-api.mdx';
 
 <SharedDropbox />

--- a/open-source/ingestion/destination-connectors/duckdb.mdx
+++ b/open-source/ingestion/destination-connectors/duckdb.mdx
@@ -2,10 +2,6 @@
 title: DuckDB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedDuckDB from '/snippets/dc-shared-text/duckdb-cli-api.mdx';
 
 <SharedDuckDB />

--- a/open-source/ingestion/destination-connectors/elasticsearch.mdx
+++ b/open-source/ingestion/destination-connectors/elasticsearch.mdx
@@ -2,10 +2,6 @@
 title: Elasticsearch
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedElasticsearch from '/snippets/dc-shared-text/elasticsearch-cli-api.mdx';
 
 <SharedElasticsearch />

--- a/open-source/ingestion/destination-connectors/google-cloud-service.mdx
+++ b/open-source/ingestion/destination-connectors/google-cloud-service.mdx
@@ -2,10 +2,6 @@
 title: Google Cloud Storage
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedGoogleCloudStorage from '/snippets/dc-shared-text/gcs-cli-api.mdx';
 
 <SharedGoogleCloudStorage />

--- a/open-source/ingestion/destination-connectors/ibm-watsonxdata.mdx
+++ b/open-source/ingestion/destination-connectors/ibm-watsonxdata.mdx
@@ -2,10 +2,6 @@
 title: IBM watsonx.data
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedIBMWatsonxdata from '/snippets/dc-shared-text/ibm-watsonxdata-cli-api.mdx';
 
 <SharedIBMWatsonxdata />

--- a/open-source/ingestion/destination-connectors/kafka.mdx
+++ b/open-source/ingestion/destination-connectors/kafka.mdx
@@ -2,10 +2,6 @@
 title: Kafka
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedKafka from '/snippets/dc-shared-text/kafka-cli-api.mdx';
 
 <SharedKafka />

--- a/open-source/ingestion/destination-connectors/kdbai.mdx
+++ b/open-source/ingestion/destination-connectors/kdbai.mdx
@@ -2,10 +2,6 @@
 title: KDB.AI
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedKDBAI from '/snippets/dc-shared-text/kdbai-cli-api.mdx';
 
 <SharedKDBAI />

--- a/open-source/ingestion/destination-connectors/lancedb.mdx
+++ b/open-source/ingestion/destination-connectors/lancedb.mdx
@@ -2,10 +2,6 @@
 title: LanceDB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedLanceDB from '/snippets/dc-shared-text/lancedb-cli-api.mdx';
 
 <SharedLanceDB />

--- a/open-source/ingestion/destination-connectors/local.mdx
+++ b/open-source/ingestion/destination-connectors/local.mdx
@@ -2,10 +2,6 @@
 title: Local
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentLocal from '/snippets/dc-shared-text/local.mdx';
 
 <SharedContentLocal/>

--- a/open-source/ingestion/destination-connectors/milvus.mdx
+++ b/open-source/ingestion/destination-connectors/milvus.mdx
@@ -2,10 +2,6 @@
 title: Milvus
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedMilvus from '/snippets/dc-shared-text/milvus-cli-api.mdx';
 
 <SharedMilvus />

--- a/open-source/ingestion/destination-connectors/mongodb.mdx
+++ b/open-source/ingestion/destination-connectors/mongodb.mdx
@@ -2,10 +2,6 @@
 title: MongoDB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedMongoDB from '/snippets/dc-shared-text/mongodb-cli-api.mdx';
 
 <SharedMongoDB />

--- a/open-source/ingestion/destination-connectors/motherduck.mdx
+++ b/open-source/ingestion/destination-connectors/motherduck.mdx
@@ -2,10 +2,6 @@
 title: MotherDuck
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedMotherDuck from '/snippets/dc-shared-text/motherduck-cli-api.mdx';
 
 <SharedMotherDuck />

--- a/open-source/ingestion/destination-connectors/neo4j.mdx
+++ b/open-source/ingestion/destination-connectors/neo4j.mdx
@@ -2,10 +2,6 @@
 title: Neo4j
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedNeo4j from '/snippets/dc-shared-text/neo4j-cli-api.mdx';
 
 <SharedNeo4j />

--- a/open-source/ingestion/destination-connectors/onedrive.mdx
+++ b/open-source/ingestion/destination-connectors/onedrive.mdx
@@ -2,10 +2,6 @@
 title: OneDrive
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedOneDrive from '/snippets/dc-shared-text/onedrive-cli-api.mdx';
 
 <SharedOneDrive />

--- a/open-source/ingestion/destination-connectors/opensearch.mdx
+++ b/open-source/ingestion/destination-connectors/opensearch.mdx
@@ -2,10 +2,6 @@
 title: OpenSearch
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedOpenSearch from '/snippets/dc-shared-text/opensearch-cli-api.mdx';
 
 <SharedOpenSearch />

--- a/open-source/ingestion/destination-connectors/postgresql.mdx
+++ b/open-source/ingestion/destination-connectors/postgresql.mdx
@@ -2,10 +2,6 @@
 title: PostgreSQL
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedPostgreSQL from '/snippets/dc-shared-text/postgresql-cli-api.mdx';
 
 <SharedPostgreSQL/>

--- a/open-source/ingestion/destination-connectors/s3.mdx
+++ b/open-source/ingestion/destination-connectors/s3.mdx
@@ -2,10 +2,6 @@
 title: S3
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedS3 from '/snippets/dc-shared-text/s3-cli-api.mdx';
 
 <SharedS3 />

--- a/open-source/ingestion/destination-connectors/sftp.mdx
+++ b/open-source/ingestion/destination-connectors/sftp.mdx
@@ -2,10 +2,6 @@
 title: SFTP
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedSFTP from '/snippets/dc-shared-text/sftp-cli-api.mdx';
 
 <SharedSFTP />

--- a/open-source/ingestion/destination-connectors/singlestore.mdx
+++ b/open-source/ingestion/destination-connectors/singlestore.mdx
@@ -2,10 +2,6 @@
 title: SingleStore
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedSingleStore from '/snippets/dc-shared-text/singlestore-cli-api.mdx';
 import SharedSingleStoreSchema from '/snippets/general-shared-text/singlestore-schema.mdx';
 

--- a/open-source/ingestion/destination-connectors/snowflake.mdx
+++ b/open-source/ingestion/destination-connectors/snowflake.mdx
@@ -2,10 +2,6 @@
 title: Snowflake
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedSnowflake from '/snippets/dc-shared-text/snowflake-cli-api.mdx';
 
 <SharedSnowflake />

--- a/open-source/ingestion/destination-connectors/sqlite.mdx
+++ b/open-source/ingestion/destination-connectors/sqlite.mdx
@@ -2,10 +2,6 @@
 title: SQLite
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedSQLite from '/snippets/dc-shared-text/sqlite-cli-api.mdx';
 
 <SharedSQLite/>

--- a/open-source/ingestion/destination-connectors/weaviate.mdx
+++ b/open-source/ingestion/destination-connectors/weaviate.mdx
@@ -2,10 +2,6 @@
 title: Weaviate
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedWeaviate from '/snippets/dc-shared-text/weaviate-cli-api.mdx';
 
 <SharedWeaviate />

--- a/open-source/ingestion/source-connectors/airtable.mdx
+++ b/open-source/ingestion/source-connectors/airtable.mdx
@@ -2,10 +2,6 @@
 title: Airtable
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentAirtable from '/snippets/sc-shared-text/airtable-cli-api.mdx';
 
 <SharedContentAirtable/>

--- a/open-source/ingestion/source-connectors/astradb.mdx
+++ b/open-source/ingestion/source-connectors/astradb.mdx
@@ -2,10 +2,6 @@
 title: Astra DB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentAstraDB from '/snippets/sc-shared-text/astradb-cli-api.mdx';
 
 <SharedContentAstraDB/>

--- a/open-source/ingestion/source-connectors/azure.mdx
+++ b/open-source/ingestion/source-connectors/azure.mdx
@@ -2,10 +2,6 @@
 title: Azure
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentAzure from '/snippets/sc-shared-text/azure-cli-api.mdx';
 
 <SharedContentAzure/>

--- a/open-source/ingestion/source-connectors/box.mdx
+++ b/open-source/ingestion/source-connectors/box.mdx
@@ -2,10 +2,6 @@
 title: Box
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentBox from '/snippets/sc-shared-text/box-cli-api.mdx';
 
 <SharedContentBox/>

--- a/open-source/ingestion/source-connectors/confluence.mdx
+++ b/open-source/ingestion/source-connectors/confluence.mdx
@@ -2,10 +2,6 @@
 title: Confluence
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentConfluence from '/snippets/sc-shared-text/confluence-cli-api.mdx';
 
 <SharedContentConfluence/>

--- a/open-source/ingestion/source-connectors/couchbase.mdx
+++ b/open-source/ingestion/source-connectors/couchbase.mdx
@@ -2,10 +2,6 @@
 title: Couchbase
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedCouchbase from '/snippets/sc-shared-text/couchbase-cli-api.mdx';
 
 <SharedCouchbase/>

--- a/open-source/ingestion/source-connectors/databricks-volumes.mdx
+++ b/open-source/ingestion/source-connectors/databricks-volumes.mdx
@@ -2,10 +2,6 @@
 title: Databricks Volumes
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentDatabricksVolumes from '/snippets/sc-shared-text/databricks-volumes-cli-api.mdx';
 
 <SharedContentDatabricksVolumes/>

--- a/open-source/ingestion/source-connectors/discord.mdx
+++ b/open-source/ingestion/source-connectors/discord.mdx
@@ -2,10 +2,6 @@
 title: Discord
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentDiscord from '/snippets/sc-shared-text/discord-cli-api.mdx';
 
 <SharedContentDiscord/>

--- a/open-source/ingestion/source-connectors/dropbox.mdx
+++ b/open-source/ingestion/source-connectors/dropbox.mdx
@@ -2,10 +2,6 @@
 title: Dropbox
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentDropbox from '/snippets/sc-shared-text/dropbox-cli-api.mdx';
 
 <SharedContentDropbox/>

--- a/open-source/ingestion/source-connectors/elastic-search.mdx
+++ b/open-source/ingestion/source-connectors/elastic-search.mdx
@@ -2,10 +2,6 @@
 title: Elasticsearch
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentElasticsearch from '/snippets/sc-shared-text/elasticsearch-cli-api.mdx';
 
 <SharedContentElasticsearch/>

--- a/open-source/ingestion/source-connectors/github.mdx
+++ b/open-source/ingestion/source-connectors/github.mdx
@@ -2,10 +2,6 @@
 title: GitHub
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentGitHub from '/snippets/sc-shared-text/github-cli-api.mdx';
 
 <SharedContentGitHub/>

--- a/open-source/ingestion/source-connectors/gitlab.mdx
+++ b/open-source/ingestion/source-connectors/gitlab.mdx
@@ -2,10 +2,6 @@
 title: GitLab
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentGitLab from '/snippets/sc-shared-text/gitlab-cli-api.mdx';
 
 <SharedContentGitLab/>

--- a/open-source/ingestion/source-connectors/google-cloud-storage.mdx
+++ b/open-source/ingestion/source-connectors/google-cloud-storage.mdx
@@ -2,10 +2,6 @@
 title: Google Cloud Storage
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentGoogleCloudStorage from '/snippets/sc-shared-text/gcs-cli-api.mdx';
 
 <SharedContentGoogleCloudStorage/>

--- a/open-source/ingestion/source-connectors/google-drive.mdx
+++ b/open-source/ingestion/source-connectors/google-drive.mdx
@@ -2,10 +2,6 @@
 title: Google Drive
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentGoogleDrive from '/snippets/sc-shared-text/google-drive-cli-api.mdx';
 
 <SharedContentGoogleDrive/>

--- a/open-source/ingestion/source-connectors/jira.mdx
+++ b/open-source/ingestion/source-connectors/jira.mdx
@@ -2,10 +2,6 @@
 title: Jira
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentJira from '/snippets/sc-shared-text/jira-cli-api.mdx';
 
 <SharedContentJira/>

--- a/open-source/ingestion/source-connectors/kafka.mdx
+++ b/open-source/ingestion/source-connectors/kafka.mdx
@@ -2,10 +2,6 @@
 title: Kafka
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentKafka from '/snippets/sc-shared-text/kafka-cli-api.mdx';
 
 <SharedContentKafka/>

--- a/open-source/ingestion/source-connectors/local.mdx
+++ b/open-source/ingestion/source-connectors/local.mdx
@@ -2,10 +2,6 @@
 title: Local
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentLocal from '/snippets/sc-shared-text/local.mdx';
 
 <SharedContentLocal/>

--- a/open-source/ingestion/source-connectors/mongodb.mdx
+++ b/open-source/ingestion/source-connectors/mongodb.mdx
@@ -2,10 +2,6 @@
 title: MongoDB
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentMongoDB from '/snippets/sc-shared-text/mongodb-cli-api.mdx';
 
 <SharedContentMongoDB/>

--- a/open-source/ingestion/source-connectors/notion.mdx
+++ b/open-source/ingestion/source-connectors/notion.mdx
@@ -2,10 +2,6 @@
 title: Notion
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentNotion from '/snippets/sc-shared-text/notion-cli-api.mdx';
 
 <SharedContentNotion/>

--- a/open-source/ingestion/source-connectors/one-drive.mdx
+++ b/open-source/ingestion/source-connectors/one-drive.mdx
@@ -2,10 +2,6 @@
 title: OneDrive
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentOneDrive from '/snippets/sc-shared-text/onedrive-cli-api.mdx';
 
 <SharedContentOneDrive/>

--- a/open-source/ingestion/source-connectors/opensearch.mdx
+++ b/open-source/ingestion/source-connectors/opensearch.mdx
@@ -2,10 +2,6 @@
 title: OpenSearch
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentOpenSearch from '/snippets/sc-shared-text/opensearch-cli-api.mdx';
 
 <SharedContentOpenSearch/>

--- a/open-source/ingestion/source-connectors/outlook.mdx
+++ b/open-source/ingestion/source-connectors/outlook.mdx
@@ -2,10 +2,6 @@
 title: Outlook
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentOutlook from '/snippets/sc-shared-text/outlook-cli-api.mdx';
 
 <SharedContentOutlook/>

--- a/open-source/ingestion/source-connectors/postgresql.mdx
+++ b/open-source/ingestion/source-connectors/postgresql.mdx
@@ -2,10 +2,6 @@
 title: PostgreSQL
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentPostgreSQL from '/snippets/sc-shared-text/postgresql-cli-api.mdx';
 
 <SharedContentPostgreSQL/>

--- a/open-source/ingestion/source-connectors/s3.mdx
+++ b/open-source/ingestion/source-connectors/s3.mdx
@@ -2,10 +2,6 @@
 title: S3
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentS3 from '/snippets/sc-shared-text/s3-cli-api.mdx';
 
 <SharedContentS3/>

--- a/open-source/ingestion/source-connectors/salesforce.mdx
+++ b/open-source/ingestion/source-connectors/salesforce.mdx
@@ -2,10 +2,6 @@
 title: Salesforce
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSalesforce from '/snippets/sc-shared-text/salesforce-cli-api.mdx';
 
 <SharedContentSalesforce/>

--- a/open-source/ingestion/source-connectors/sftp.mdx
+++ b/open-source/ingestion/source-connectors/sftp.mdx
@@ -2,10 +2,6 @@
 title: SFTP
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSFTP from '/snippets/sc-shared-text/sftp-cli-api.mdx';
 
 <SharedContentSFTP/>

--- a/open-source/ingestion/source-connectors/sharepoint.mdx
+++ b/open-source/ingestion/source-connectors/sharepoint.mdx
@@ -2,10 +2,6 @@
 title: SharePoint
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSharePoint from '/snippets/sc-shared-text/sharepoint-cli-api.mdx';
 
 <SharedContentSharePoint/>

--- a/open-source/ingestion/source-connectors/singlestore.mdx
+++ b/open-source/ingestion/source-connectors/singlestore.mdx
@@ -2,10 +2,6 @@
 title: SingleStore
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSingleStore from '/snippets/sc-shared-text/singlestore-cli-api.mdx';
 
 <SharedContentSingleStore/>

--- a/open-source/ingestion/source-connectors/slack.mdx
+++ b/open-source/ingestion/source-connectors/slack.mdx
@@ -2,10 +2,6 @@
 title: Slack
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSlack from '/snippets/sc-shared-text/slack-cli-api.mdx';
 
 <SharedContentSlack/>

--- a/open-source/ingestion/source-connectors/snowflake.mdx
+++ b/open-source/ingestion/source-connectors/snowflake.mdx
@@ -2,10 +2,6 @@
 title: Snowflake
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSnowflake from '/snippets/sc-shared-text/snowflake-cli-api.mdx';
 
 <SharedContentSnowflake/>

--- a/open-source/ingestion/source-connectors/sqlite.mdx
+++ b/open-source/ingestion/source-connectors/sqlite.mdx
@@ -2,10 +2,6 @@
 title: SQLite
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentSQLite from '/snippets/sc-shared-text/sqlite-cli-api.mdx';
 
 <SharedContentSQLite/>

--- a/open-source/ingestion/source-connectors/zendesk.mdx
+++ b/open-source/ingestion/source-connectors/zendesk.mdx
@@ -2,10 +2,6 @@
 title: Zendesk
 ---
 
-import NewDocument from '/snippets/general-shared-text/new-document.mdx';
-
-<NewDocument />
-
 import SharedContentZendesk from '/snippets/sc-shared-text/zendesk-cli-api.mdx';
 
 <SharedContentZendesk/>


### PR DESCRIPTION
Removing the banner "this page was recently updated; tell us what you think about it" for the following reasons:

- We already have feedback mechanisms on these pages.
- Most of these pages were updated a really long time ago, but the banner was never removed since then.
- These banners can be a bit visually distracting.
- These banners are of relatively low value, as they don't list what content was actually updated on the page--nor to what it was updated.
